### PR TITLE
fix: correct authentication and attribution in register_identity_hash

### DIFF
--- a/contracts/identity_registry/README.md
+++ b/contracts/identity_registry/README.md
@@ -18,8 +18,10 @@ The Identity Registry Contract provides a decentralized trust system for healthc
 
 - **`initialize(owner)`**: Initialize the contract with an owner who becomes the first verifier
 - **`register_identity_hash(hash, subject, meta)`**: Register a 32-byte identity hash with metadata
-- **`attest(subject, claim_hash)`**: Create an attestation for a subject (verifiers only)
-- **`revoke_attestation(subject, claim_hash)`**: Revoke an existing attestation (verifiers only)
+  - **Authorization**: Requires `subject.require_auth()` - only the subject can register their own identity
+  - The `registered_by` field is set to the subject (the authenticated caller)
+- **`attest(verifier, subject, claim_hash)`**: Create an attestation for a subject (verifiers only)
+- **`revoke_attestation(verifier, subject, claim_hash)`**: Revoke an existing attestation (verifiers only)
 
 ### Verifier Management
 
@@ -71,9 +73,11 @@ pub struct Attestation {
 - Consider using salted hashes for additional security
 
 ### Access Control
-- Only the owner can add/remove verifiers
-- Only verifiers can create/revoke attestations
-- Owner cannot be removed as a verifier
+- **Identity Registration**: Only the subject can register their own identity hash (requires `subject.require_auth()`)
+- **Registrar Attribution**: The `registered_by` field correctly reflects the subject (actual caller), not the contract address
+- **Verifier Management**: Only the owner can add/remove verifiers
+- **Attestations**: Only authorized verifiers can create/revoke attestations
+- **Owner Protection**: Owner cannot be removed as a verifier
 
 ### Gas Optimization
 - Efficient storage patterns using Soroban's native types

--- a/contracts/identity_registry/src/lib.rs
+++ b/contracts/identity_registry/src/lib.rs
@@ -317,6 +317,27 @@ mod tests {
     }
 
     #[test]
+    fn test_register_identity_hash_with_correct_registrar() {
+        let (env, client, _owner) = create_contract();
+        let subject = Address::generate(&env);
+
+        let hash = BytesN::from_array(&env, &[1; 32]);
+        let meta = String::from_str(&env, "Healthcare Provider License #12345");
+
+        // Register identity hash
+        client.mock_all_auths().register_identity_hash(&hash, &subject, &meta);
+
+        // Verify that registered_by is set to the subject (not the contract)
+        let record_key = DataKey::IdentityHash(subject.clone());
+        let record: IdentityRecord = env.storage().instance().get(&record_key).unwrap();
+
+        // The registered_by field should be the subject, not the contract address
+        assert_eq!(record.registered_by, subject);
+        assert_eq!(record.hash, hash);
+        assert_eq!(record.meta, meta);
+    }
+
+    #[test]
     fn test_add_and_remove_verifier() {
         let (env, client, _owner) = create_contract();
         let new_verifier = Address::generate(&env);

--- a/contracts/identity_registry/src/lib.rs
+++ b/contracts/identity_registry/src/lib.rs
@@ -47,13 +47,15 @@ impl IdentityRegistryContract {
     }
 
     /// Register an identity hash with metadata
+    /// Only the subject can register their own identity hash
     pub fn register_identity_hash(env: Env, hash: BytesN<32>, subject: Address, meta: String) {
-        let caller = env.current_contract_address();
+        // Require authorization from the subject
+        subject.require_auth();
 
         let identity_record = IdentityRecord {
             hash: hash.clone(),
             meta: meta.clone(),
-            registered_by: caller,
+            registered_by: subject.clone(),
         };
 
         env.storage()
@@ -302,8 +304,8 @@ mod tests {
         let hash = BytesN::from_array(&env, &[1; 32]);
         let meta = String::from_str(&env, "Healthcare Provider License #12345");
 
-        // Register identity hash
-        client.register_identity_hash(&hash, &subject, &meta);
+        // Register identity hash - subject must authorize
+        client.mock_all_auths().register_identity_hash(&hash, &subject, &meta);
 
         // Verify storage
         assert_eq!(client.get_identity_hash(&subject), Some(hash));
@@ -488,8 +490,8 @@ mod tests {
         let meta2 = String::from_str(&env, "Clinic Registration");
 
         // Register multiple identities
-        client.register_identity_hash(&hash1, &subject1, &meta1);
-        client.register_identity_hash(&hash2, &subject2, &meta2);
+        client.mock_all_auths().register_identity_hash(&hash1, &subject1, &meta1);
+        client.mock_all_auths().register_identity_hash(&hash2, &subject2, &meta2);
 
         // Verify both are stored correctly
         assert_eq!(client.get_identity_hash(&subject1), Some(hash1));


### PR DESCRIPTION


- Added subject.require_auth() to ensure only subjects can register their own identity
- Set registered_by to subject (actual caller) instead of contract address
- Added test to verify correct registrar attribution
- Updated README with authorization requirements

Fixed authorization bypass vulnerability where anyone could register identities for others.