### PR TITLE
Add consent-based access control for confidential medical records

### DIFF
--- a/contracts/medical_records/Cargo.toml
+++ b/contracts/medical_records/Cargo.toml
@@ -17,7 +17,7 @@ stellar-xdr.workspace = true
 
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, default-features = false }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
 
 [features]


### PR DESCRIPTION
- Updated initialize() to accept consent_contract address parameter
- Added has_consent() helper function for cross-contract consent verification
- Enhanced get_record() access control to require patient consent for confidential records
- Added comprehensive tests for consent grant/revoke flows and unauthorized access
- Updated Cargo.toml to enable testutils feature for development
- Maintains backward compatibility for non-confidential records and existing access patterns

Implements requirement: Doctors need explicit patient consent via medical_consent_nft for accessing confidential records, not just authorship.