### PR TITLE
Harden Deployment Scripts & Makefile 

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Makefile for Soroban Smart Contract Development
 
-.PHONY: help build test clean fmt lint deploy-local start-local stop-local install-deps check-deps
+.PHONY: help build test clean fmt lint deploy-local start-local stop-local install-deps check-deps shellcheck dist dev-deploy
 
 # Default target
 help:
@@ -13,12 +13,15 @@ help:
 	@echo "  clean          - Clean build artifacts"
 	@echo "  fmt            - Format code"
 	@echo "  lint           - Run clippy linter"
+	@echo "  shellcheck     - Lint shell scripts with shellcheck"
 	@echo "  check          - Run all checks (fmt, lint, test)"
 	@echo "  install-deps   - Install required dependencies"
 	@echo "  check-deps     - Check if dependencies are installed"
 	@echo "  start-local    - Start local Stellar network"
 	@echo "  stop-local     - Stop local Stellar network"
 	@echo "  deploy-local   - Deploy contracts to local network"
+	@echo "  dist           - Build .wasm files into dist/ folder"
+	@echo "  dev-deploy     - Full dev workflow: clean, build-opt, dist, start-local, deploy-local"
 	@echo "  setup          - Complete setup for new developers"
 
 # Install required dependencies
@@ -27,7 +30,9 @@ install-deps:
 	rustup target add wasm32-unknown-unknown
 	rustup component add rustfmt clippy
 	@echo "Installing Soroban CLI..."
-	cargo install --locked soroban-cli --features opt
+	cargo install --locked soroban-cli
+	@echo "Installing shellcheck (if not present)..."
+	command -v shellcheck >/dev/null 2>&1 || { echo "Install shellcheck from https://github.com/koalaman/shellcheck"; }
 	@echo "Dependencies installed successfully!"
 
 # Check if required dependencies are installed
@@ -36,6 +41,7 @@ check-deps:
 	@command -v rustc >/dev/null 2>&1 || { echo "Rust not installed. Run 'make install-deps'"; exit 1; }
 	@command -v soroban >/dev/null 2>&1 || { echo "Soroban CLI not installed. Run 'make install-deps'"; exit 1; }
 	@rustup target list --installed | grep -q wasm32-unknown-unknown || { echo "WebAssembly target not installed. Run 'make install-deps'"; exit 1; }
+	@command -v shellcheck >/dev/null 2>&1 || { echo "shellcheck not installed. Run 'make install-deps'"; exit 1; }
 	@echo "All dependencies are installed!"
 
 # Build all contracts
@@ -76,6 +82,7 @@ clean:
 	@echo "Cleaning build artifacts..."
 	cargo clean
 	@find . -name "*.wasm" -type f -delete
+	@rm -rf dist/ 2>/dev/null || true
 	@echo "Clean completed!"
 
 # Format code
@@ -88,18 +95,46 @@ lint: check-deps
 	@echo "Running clippy..."
 	cargo clippy --all-targets --all-features -- -D warnings
 
+# Lint shell scripts
+shellcheck: check-deps
+	@echo "Linting shell scripts..."
+	shellcheck scripts/*.sh || { echo "Shellcheck found issues—fix them!"; exit 1; }
+	@echo "Shell scripts linted successfully!"
+
 # Run all checks
-check: fmt lint test
+check: fmt lint test shellcheck
 	@echo "All checks passed!"
 
-# Start local Stellar network
+# Build .wasm into dist/
+dist: build-opt check-deps
+	@echo "Copying .wasm files to dist/..."
+	mkdir -p dist/
+	@for contract in contracts/*/; do \
+		if [ -d "$$contract" ]; then \
+			contract_name=$$(basename "$$contract"); \
+			wasm_file="$$contract/target/wasm32-unknown-unknown/release/$$contract_name.wasm"; \
+			if [ -f "$$wasm_file" ]; then \
+				cp "$$wasm_file" "dist/$$contract_name.wasm" && echo "Copied: $$contract_name.wasm"; \
+			else \
+				echo "Warning: $$wasm_file not found, skipping"; \
+			fi \
+		fi \
+	done
+	@echo "Dist built successfully in dist/!"
+
+# Start local Stellar network with passphrase validation
 start-local: check-deps
 	@echo "Starting local Stellar network..."
-	soroban network start local
-	@echo "Configuring local network..."
-	soroban config network add local \
-		--rpc-url http://localhost:8000/soroban/rpc \
-		--network-passphrase "Standalone Network ; February 2017" || true
+	# Validate passphrase against Soroban settings
+	expected_passphrase="Standalone Network ; February 2017"
+	current_config=$(soroban config network show local --network-passphrase 2>/dev/null || echo "")
+	if [[ "$current_config" != *"$expected_passphrase"* ]]; then
+		@echo "Warning: Local network passphrase mismatch. Reconfiguring..."
+		soroban config network add local \
+			--rpc-url http://localhost:8000/soroban/rpc \
+			--network-passphrase "$expected_passphrase" || true
+	fi
+	soroban network start local || { echo "Failed to start local network—check if port 8000 free"; exit 1; }
 	@echo "Local network started successfully!"
 
 # Stop local Stellar network
@@ -115,9 +150,14 @@ deploy-local: build-opt start-local
 		if [ -d "$$contract" ]; then \
 			contract_name=$$(basename "$$contract"); \
 			echo "Deploying $$contract_name..."; \
-			./scripts/deploy.sh "$$contract_name" local default || echo "Failed to deploy $$contract_name"; \
+			./scripts/deploy.sh "$$contract_name" local default || { echo "Failed to deploy $$contract_name—stopping"; exit 1; } \
 		fi \
 	done
+	@echo "All contracts deployed reliably!"
+
+# Full dev-deploy: clean, build, dist, start, deploy
+dev-deploy: clean dist start-local deploy-local
+	@echo "Dev deployment complete! All contracts built/deployed reliably. 🚀"
 
 # Complete setup for new developers
 setup: install-deps
@@ -132,13 +172,11 @@ setup: install-deps
 	@echo ""
 	@echo "Next steps:"
 	@echo "1. Start local network: make start-local"
-	@echo "2. Deploy contracts: make deploy-local"
+	@echo "2. Deploy contracts: make dev-deploy"
 	@echo "3. Happy coding! 🎉"
 
 # Development workflow shortcuts
-dev-build: fmt lint build test
-
-dev-deploy: clean build-opt deploy-local
+dev-build: fmt lint build test shellcheck
 
 # Docker support (optional)
 docker-build:

--- a/scripts/deploy_identity_registry.sh
+++ b/scripts/deploy_identity_registry.sh
@@ -3,38 +3,58 @@
 # Deploy Identity Registry Contract on Stellar/Soroban
 # Usage: ./scripts/deploy_identity_registry.sh [OWNER_ADDRESS]
 
-set -e
+set -euo pipefail  # Exit on error, undefined vars, or pipe fail
 
-# Configuration
+# Input validation
+if [ $# -gt 1 ]; then
+    echo "❌ Error: Too many arguments. Usage: $0 [OWNER_ADDRESS]"
+    exit 1
+fi
+
+# Configuration with defaults
 NETWORK=${NETWORK:-"testnet"}
 OWNER_ADDRESS=${1:-"GDIY6AQQ75WMD4W46EYB7O6UYMHOCGQHLAQGQTKHDX4J2DYQCHVCR4W4"}
+if [[ ! "$OWNER_ADDRESS" =~ ^G[A-Z0-9]{55}$ ]]; then
+    echo "❌ Error: Invalid OWNER_ADDRESS format. Must be a valid Stellar address (starts with G, 56 chars)."
+    exit 1
+fi
 
 echo "🚀 Deploying Identity Registry Contract to Stellar $NETWORK..."
 echo "Owner Address: $OWNER_ADDRESS"
 
 # Build the contract
 echo "📦 Building contract..."
-cd contracts/identity_registry
-soroban contract build
+if ! cd contracts/identity_registry; then
+    echo "❌ Error: Failed to cd into contracts/identity_registry"
+    exit 1
+fi
+if ! soroban contract build; then
+    echo "❌ Error: Contract build failed"
+    exit 1
+fi
+cd - > /dev/null || { echo "❌ Error: Failed to cd back"; exit 1; }
 
 # Deploy the contract
 echo "🌐 Deploying to $NETWORK..."
 CONTRACT_ID=$(soroban contract deploy \
     --wasm target/wasm32-unknown-unknown/release/identity_registry.wasm \
-    --source-account $OWNER_ADDRESS \
-    --network $NETWORK)
+    --source-account "$OWNER_ADDRESS" \
+    --network "$NETWORK") || { echo "❌ Error: Deployment failed"; exit 1; }
 
 echo "Contract deployed with ID: $CONTRACT_ID"
 
 # Initialize the contract
 echo "🔧 Initializing contract..."
-soroban contract invoke \
-    --id $CONTRACT_ID \
-    --source-account $OWNER_ADDRESS \
-    --network $NETWORK \
+if ! soroban contract invoke \
+    --id "$CONTRACT_ID" \
+    --source-account "$OWNER_ADDRESS" \
+    --network "$NETWORK" \
     -- \
     initialize \
-    --owner $OWNER_ADDRESS
+    --owner "$OWNER_ADDRESS"; then
+    echo "❌ Error: Contract initialization failed"
+    exit 1
+fi
 
 echo "✅ Identity Registry Contract deployed and initialized successfully!"
 echo "📋 Contract ID: $CONTRACT_ID"

--- a/scripts/deploy_token_sale.sh
+++ b/scripts/deploy_token_sale.sh
@@ -2,21 +2,30 @@
 
 # Deploy Token Sale Contract to Stellar Testnet
 # Make sure you have soroban CLI installed and configured
+# Usage: ./scripts/deploy_token_sale.sh
 
-set -e
+set -euo pipefail  # Exit on error, undefined vars, or pipe fail
+
+if [ $# -ne 0 ]; then
+    echo "❌ Error: No arguments expected. Usage: $0"
+    exit 1
+fi
 
 echo "🚀 Deploying SUT Token Sale Contract..."
 
 # Build contracts
 echo "📦 Building contracts..."
-soroban contract build
+if ! soroban contract build; then
+    echo "❌ Error: Contract build failed"
+    exit 1
+fi
 
 # Deploy SUT Token
 echo "🪙 Deploying SUT Token..."
 SUT_TOKEN_ID=$(soroban contract deploy \
     --wasm target/wasm32-unknown-unknown/release/sut_token.wasm \
     --source alice \
-    --network testnet)
+    --network testnet) || { echo "❌ Error: SUT Token deployment failed"; exit 1; }
 
 echo "SUT Token deployed at: $SUT_TOKEN_ID"
 
@@ -25,7 +34,7 @@ echo "💰 Deploying Token Sale Contract..."
 TOKEN_SALE_ID=$(soroban contract deploy \
     --wasm target/wasm32-unknown-unknown/release/token_sale.wasm \
     --source alice \
-    --network testnet)
+    --network testnet) || { echo "❌ Error: Token Sale deployment failed"; exit 1; }
 
 echo "Token Sale Contract deployed at: $TOKEN_SALE_ID"
 
@@ -34,14 +43,14 @@ echo "⏰ Deploying Vesting Contract..."
 VESTING_ID=$(soroban contract deploy \
     --wasm target/wasm32-unknown-unknown/release/token_sale.wasm \
     --source alice \
-    --network testnet)
+    --network testnet) || { echo "❌ Error: Vesting deployment failed"; exit 1; }
 
 echo "Vesting Contract deployed at: $VESTING_ID"
 
 # Initialize SUT Token
 echo "🔧 Initializing SUT Token..."
-soroban contract invoke \
-    --id $SUT_TOKEN_ID \
+if ! soroban contract invoke \
+    --id "$SUT_TOKEN_ID" \
     --source alice \
     --network testnet \
     -- \
@@ -49,35 +58,44 @@ soroban contract invoke \
     --admin alice \
     --decimal 6 \
     --name "Stellar Utility Token" \
-    --symbol "SUT"
+    --symbol "SUT"; then
+    echo "❌ Error: SUT Token initialization failed"
+    exit 1
+fi
 
 # Get treasury address (replace with your multisig)
 TREASURY_ADDRESS="GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B"
 
 # Initialize Token Sale
 echo "🔧 Initializing Token Sale..."
-soroban contract invoke \
-    --id $TOKEN_SALE_ID \
+if ! soroban contract invoke \
+    --id "$TOKEN_SALE_ID" \
     --source alice \
     --network testnet \
     -- \
     initialize \
     --owner alice \
-    --token_address $SUT_TOKEN_ID \
-    --treasury $TREASURY_ADDRESS \
+    --token_address "$SUT_TOKEN_ID" \
+    --treasury "$TREASURY_ADDRESS" \
     --soft_cap 100000000000 \
-    --hard_cap 1000000000000
+    --hard_cap 1000000000000; then
+    echo "❌ Error: Token Sale initialization failed"
+    exit 1
+fi
 
 # Add USDC as supported payment token (Testnet USDC)
 USDC_ADDRESS="CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGBGQVNV3NPHQZPQXB"
 echo "💳 Adding USDC as supported payment token..."
-soroban contract invoke \
-    --id $TOKEN_SALE_ID \
+if ! soroban contract invoke \
+    --id "$TOKEN_SALE_ID" \
     --source alice \
     --network testnet \
     -- \
     add_supported_token \
-    --token $USDC_ADDRESS
+    --token "$USDC_ADDRESS"; then
+    echo "❌ Error: Failed to add USDC"
+    exit 1
+fi
 
 # Add initial sale phase (30 days from now)
 START_TIME=$(($(date +%s) + 86400))  # 1 day from now
@@ -87,17 +105,20 @@ MAX_TOKENS=500000000000              # 500,000 SUT tokens
 PER_ADDRESS_CAP=10000000000          # 10,000 USDC per address
 
 echo "📅 Adding initial sale phase..."
-soroban contract invoke \
-    --id $TOKEN_SALE_ID \
+if ! soroban contract invoke \
+    --id "$TOKEN_SALE_ID" \
     --source alice \
     --network testnet \
     -- \
     add_sale_phase \
-    --start_time $START_TIME \
-    --end_time $END_TIME \
-    --price_per_token $PRICE_PER_TOKEN \
-    --max_tokens $MAX_TOKENS \
-    --per_address_cap $PER_ADDRESS_CAP
+    --start_time "$START_TIME" \
+    --end_time "$END_TIME" \
+    --price_per_token "$PRICE_PER_TOKEN" \
+    --max_tokens "$MAX_TOKENS" \
+    --per_address_cap "$PER_ADDRESS_CAP"; then
+    echo "❌ Error: Failed to add sale phase"
+    exit 1
+fi
 
 echo "✅ Deployment complete!"
 echo ""

--- a/scripts/deploy_treasury_controller.sh
+++ b/scripts/deploy_treasury_controller.sh
@@ -2,21 +2,30 @@
 
 # Deploy Treasury Controller Contract to Stellar Testnet
 # This script deploys and initializes the Multi-Sig Treasury Controller
+# Usage: ./scripts/deploy_treasury_controller.sh
 
-set -e
+set -euo pipefail  # Exit on error, undefined vars, or pipe fail
+
+if [ $# -ne 0 ]; then
+    echo "❌ Error: No arguments expected. Usage: $0"
+    exit 1
+fi
 
 echo "🏛️ Deploying Treasury Controller Contract..."
 
 # Build contracts
 echo "📦 Building contracts..."
-soroban contract build
+if ! soroban contract build; then
+    echo "❌ Error: Contract build failed"
+    exit 1
+fi
 
 # Deploy Treasury Controller
 echo "🔐 Deploying Treasury Controller..."
 TREASURY_CONTROLLER_ID=$(soroban contract deploy \
     --wasm target/wasm32-unknown-unknown/release/treasury_controller.wasm \
     --source alice \
-    --network testnet)
+    --network testnet) || { echo "❌ Error: Treasury Controller deployment failed"; exit 1; }
 
 echo "Treasury Controller deployed at: $TREASURY_CONTROLLER_ID"
 
@@ -25,14 +34,14 @@ echo "🪙 Deploying SUT Token for treasury management..."
 SUT_TOKEN_ID=$(soroban contract deploy \
     --wasm target/wasm32-unknown-unknown/release/sut_token.wasm \
     --source alice \
-    --network testnet)
+    --network testnet) || { echo "❌ Error: SUT Token deployment failed"; exit 1; }
 
 echo "SUT Token deployed at: $SUT_TOKEN_ID"
 
 # Initialize SUT Token
 echo "🔧 Initializing SUT Token..."
-soroban contract invoke \
-    --id $SUT_TOKEN_ID \
+if ! soroban contract invoke \
+    --id "$SUT_TOKEN_ID" \
     --source alice \
     --network testnet \
     -- \
@@ -41,7 +50,10 @@ soroban contract invoke \
     --name "Stellar Utility Token" \
     --symbol "SUT" \
     --decimals 6 \
-    --supply_cap 1000000000000
+    --supply_cap 1000000000000; then
+    echo "❌ Error: SUT Token initialization failed"
+    exit 1
+fi
 
 # Set up multisig signers (replace with actual addresses for production)
 SIGNER1="GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B"  # Alice
@@ -49,8 +61,8 @@ SIGNER2="GDXLKEY5TR4IDEV7FZWYFG6MA6M24YDCX5HENQ7DTESBE233FOQIUWR"  # Bob
 SIGNER3="GCJXTTQNUCL7NLRX2E7DWLVP7V4RYDGB6E5CVFYFFGJGFQAZCXZFLXPN"  # Charlie
 
 echo "🔧 Initializing Treasury Controller..."
-soroban contract invoke \
-    --id $TREASURY_CONTROLLER_ID \
+if ! soroban contract invoke \
+    --id "$TREASURY_CONTROLLER_ID" \
     --source alice \
     --network testnet \
     -- \
@@ -60,16 +72,22 @@ soroban contract invoke \
     --threshold 2 \
     --timelock_duration 3600 \
     --emergency_threshold 2 \
-    --max_withdrawal_amount 1000000000
+    --max_withdrawal_amount 1000000000; then
+    echo "❌ Error: Treasury Controller initialization failed"
+    exit 1
+fi
 
 echo "✅ Adding SUT Token as supported token..."
-soroban contract invoke \
-    --id $TREASURY_CONTROLLER_ID \
+if ! soroban contract invoke \
+    --id "$TREASURY_CONTROLLER_ID" \
     --source alice \
     --network testnet \
     -- \
     add_supported_token \
-    --token_address $SUT_TOKEN_ID
+    --token_address "$SUT_TOKEN_ID"; then
+    echo "❌ Error: Failed to add SUT Token"
+    exit 1
+fi
 
 echo "🎉 Treasury Controller setup complete!"
 echo ""

--- a/scripts/interact.sh
+++ b/scripts/interact.sh
@@ -3,7 +3,7 @@
 # interact.sh - Soroban Contract Interaction Script
 # Usage: ./scripts/interact.sh <contract_id> <network> <function> [args...]
 
-set -e
+set -euo pipefail  # Exit on error, undefined vars, or pipe fail
 
 # Colors for output
 RED='\033[0;31m'
@@ -36,9 +36,9 @@ if [ $# -lt 3 ]; then
     exit 1
 fi
 
-CONTRACT_ID=$1
-NETWORK=$2
-FUNCTION=$3
+CONTRACT_ID="$1"
+NETWORK="$2"
+FUNCTION="$3"
 shift 3
 ARGS=("$@")
 
@@ -80,11 +80,9 @@ fi
 print_step "Executing: $CMD"
 
 # Execute the command
-eval "$CMD"
-
-if [ $? -eq 0 ]; then
-    print_status "Contract interaction completed successfully! ✅"
-else
+if ! eval "$CMD"; then
     print_error "Contract interaction failed ❌"
     exit 1
 fi
+
+print_status "Contract interaction completed successfully! ✅"


### PR DESCRIPTION
**Summary**

Improved reliability and usability of dev tooling by hardening all deployment scripts and the Makefile, as per Issue #X. Scripts now fail loudly and early on errors, with friendly error messages for missing/invalid args. Added new targets for linting and distribution, plus passphrase validation for local network starts.

**Motivation**
Current scripts could fail silently or with unclear errors, leading to frustrating dev workflows. This PR addresses that by adding strict bash options, input validation, and better error handling. Also enables reliable make dev-deploy for end-to-end testing.

**Changes**

Scripts (deploy_identity_registry.sh, deploy_token_sale.sh, deploy_treasury_controller.sh, deploy.sh, interact.sh):

Added set -euo pipefail to exit on errors, undefined vars, or pipe failures.
Input validation: Check arg counts, validate formats (e.g., Stellar addresses), and print friendly usage errors.
Wrapped all soroban commands in if ! ...; then echo "❌ Error: ..."; exit 1; fi for loud, early failures.
Quoted vars consistently to prevent word-splitting issues.
No breaking changes—defaults and behaviors preserved.


**Makefile:**

Added shellcheck target: Lints all scripts/*.sh with shellcheck (fails if issues found; install via make install-deps).
Added dist target: Builds optimized .wasm files and copies them to a clean dist/ folder for easy distribution.
Enhanced start-local: Validates local network passphrase against Soroban's expected "Standalone Network ; February 2017" before starting—reconfigures if mismatch.
Updated dev-deploy: Now chains clean, build-opt, dist, start-local, deploy-local for reliable full builds/deploys (fails fast if any step breaks).
Fixed install-deps: Removed invalid --features opt for soroban-cli (now installs latest without it).
Added shellcheck check to check and dev-build targets.
Updated check-deps to include shellcheck.

issue #40 