### PR TITLE
Feat/Add Consent-Based Access Control (via medical_consent_nft)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-[patch.crates-io]
-stellar-xdr = { version = "20.0.0", default-features = false, features = [] }
 [workspace]
 resolver = "2"
 members = [
@@ -13,15 +11,10 @@ authors = ["Your Name <your.email@example.com>"]
 license = "MIT"
 repository = "https://github.com/yourusername/soroban-project"
 
-
-
-
 [workspace.dependencies]
 stellar-xdr = { version = "20.0.0", default-features = false, features = [] }
 soroban-sdk = { version = "20.0.0", default-features = false }
 soroban-cli = "20.0.0"
-
-
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
**Summary**
Enforce access to confidential medical records using explicit patient consent NFTs. Doctors now require a valid, non-revoked consent token for the specific patient and consent type (e.g., "treatment") to view records via get_record(). This adds patient-centric control: consents can be minted by authorized issuers, transferred to doctors for granting access, and revoked by patients at any time (even after transfer).
Motivation

Current system relies only on authorship; this ensures explicit consent for privacy compliance (e.g., HIPAA-like).
Cross-contract integration: Records contract calls has_consent() on this NFT contract.

**Proposed Changes**

New DataKey: PatientConsents(Address) to track all consents per patient for easy revocation.
Updated ConsentMetadata: Added patient: Address field for ownership tracking.
mint_consent():

Renamed param to → patient for clarity.
Added issuer: Address param with require_auth() and issuer check (fixes unauthorized mints).
Mints to patient initially; adds to both OwnerTokens and PatientConsents.


revoke_consent():

Uses metadata.patient.require_auth() so patients control revocation regardless of current owner.
Added proper error handling with ok_or(ContractError::TokenNotFound).


New Function: has_consent(patient: Address, doctor: Address, consent_type: String) -> bool

Checks doctor's tokens for matching valid (non-revoked, non-expired) consent for the patient/type.
For cross-contract use in records contract.


**Minor Fixes:**

Removed non-existent env.invoker() (use passed addresses + auth).
Updated events and history for consistency.
No changes to transfer/update (they remain owner-authorized).

Closes #35 