### PR TITLE
refactor: implement granular error handling and validation

### DIFF
--- a/contracts/medical_records/src/errors.rs
+++ b/contracts/medical_records/src/errors.rs
@@ -1,0 +1,79 @@
+use soroban_sdk::{contracterror, symbol_short, Symbol};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    // --- System & State Errors (1-9) ---
+    ContractPaused = 1,
+    ProposalAlreadyExecuted = 6,
+    TimelockNotElasped = 7,
+    NotEnoughApproval = 8,
+    Overflow = 47,
+
+    // --- Access & Auth Errors (10-19) ---
+    NotAuthorized = 2,
+    CrossChainAccessDenied = 15,
+    EmergencyAccessExpired = 24,
+    EmergencyAccessNotFound = 25,
+    NotAICoordinator = 28,
+
+    // --- Identity & DID Errors (20-29) ---
+    DIDNotFound = 18,
+    DIDNotActive = 19,
+    InvalidCredential = 20,
+    CredentialExpired = 21,
+    CredentialRevoked = 22,
+    MissingRequiredCredential = 23,
+    IdentityRegistryNotSet = 26,
+
+    // --- Validation: Content Errors (30-39) ---
+    InvalidCategory = 3,
+    EmptyTreatment = 4,
+    EmptyDiagnosis = 30,
+    EmptyTag = 5,
+    EmptyDataRef = 9,
+    InvalidInput = 45,
+
+    // --- Validation: Length & Format Errors (40-49) ---
+    InvalidDataRefLength = 10,
+    InvalidDataRefCharset = 11,
+    InvalidDiagnosisLength = 31,
+    InvalidTreatmentLength = 32,
+    InvalidPurposeLength = 33,
+    InvalidTagLength = 34,
+    InvalidModelVersionLength = 38,
+    InvalidExplanationLength = 39,
+    InvalidTreatmentTypeLength = 42,
+
+    // --- AI & Logic Errors (50-59) ---
+    AIConfigNotSet = 27,
+    InvalidAIScore = 29,
+    InvalidScore = 35,
+    InvalidDPEpsilon = 36,
+    InvalidParticipantCount = 37,
+
+    // --- General/Cross-Chain Errors (60+) ---
+    RecordNotFound = 14,
+    RecordAlreadySynced = 16,
+    InvalidChain = 17,
+    CrossChainNotEnabled = 12,
+    CrossChainContractsNotSet = 13,
+    InvalidAddress = 40,
+    SameAddress = 41,
+    BatchTooLarge = 43,
+    InvalidBatch = 44,
+    NumberOutOfBounds = 46,
+}
+
+/// AC: Recovery suggestions to help users fix issues
+pub fn get_suggestion(error: Error) -> Symbol {
+    match error {
+        Error::ContractPaused => symbol_short!("RE_TRY_L"),
+        Error::NotAuthorized => symbol_short!("CHK_AUTH"),
+        Error::EmptyDiagnosis | Error::EmptyTreatment => symbol_short!("FILL_FLD"),
+        Error::EmergencyAccessExpired => symbol_short!("NEW_EMER"),
+        Error::InvalidCategory => symbol_short!("FIX_CAT"),
+        _ => symbol_short!("CONTACT"),
+    }
+}

--- a/contracts/medical_records/src/test.rs
+++ b/contracts/medical_records/src/test.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 use super::*;
+use crate::errors::Error;
 use soroban_sdk::testutils::{Address as _, Events};
 use soroban_sdk::{vec, Address, Env, String, TryFromVal, Vec};
 
@@ -13,139 +14,6 @@ fn create_contract(env: &Env) -> (MedicalRecordsContractClient<'_>, Address) {
     client.initialize(&admin);
     (client, admin)
 }
-
-#[test]
-fn test_add_records_batch_and_get_batch() {
-    let env = Env::default();
-    env.mock_all_auths();
-
-    let (_client, _admin) = create_contract(&env);
-    let _doctor = Address::generate(&env);
-    let _patient1 = Address::generate(&env);
-    //     let patient2 = Address::generate(&env);
-    //
-    //     client.manage_user(&admin, &doctor, &Role::Doctor);
-    //     client.manage_user(&admin, &patient1, &Role::Patient);
-    //     client.manage_user(&admin, &patient2, &Role::Patient);
-    //
-    //     let records_input = vec![
-    //         &env,
-    //         (
-    //             patient1.clone(),
-    //             String::from_str(&env, "Flu"),
-    //             String::from_str(&env, "Antiviral"),
-    //             false,
-    //             vec![&env, String::from_str(&env, "viral")],
-    //             String::from_str(&env, "Modern"),
-    //             String::from_str(&env, "Prescription"),
-    //             String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXA"),
-    //         ),
-    //         (
-    //             patient1.clone(),
-    //             String::from_str(&env, "Hypertension"),
-    //             String::from_str(&env, "Lifestyle + meds"),
-    //             true,
-    //             vec![&env],
-    //             String::from_str(&env, "Modern"),
-    //             String::from_str(&env, "Ongoing"),
-    //             String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXB"),
-    //         ),
-    //         (
-    //             patient2.clone(),
-    //             String::from_str(&env, "Malaria"),
-    //             String::from_str(&env, "Artemisinin"),
-    //             false,
-    //             vec![&env, String::from_str(&env, "tropical")],
-    //             String::from_str(&env, "Modern"),
-    //             String::from_str(&env, "Acute"),
-    //             String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXC"),
-    //         ),
-    //     ];
-    //
-    //     let result = client.add_records_batch(&doctor, &records_input);
-    //
-    //     assert_eq!(result.successes.len(), 3);
-    //     assert_eq!(result.failures.len(), 0);
-    //
-    //     let ids = result.successes;
-    //
-    //     // Test batch get - patient1 should see both (one confidential, but owns them)
-    //     let batch1 = client.get_records_batch(&patient1, &patient1, &0, &10);
-    //     assert_eq!(batch1.len(), 2);
-    //
-    //     // Test pagination + limit
-    //     let batch2 = client.get_records_batch(&patient1, &patient1, &0, &1);
-    //     assert_eq!(batch2.len(), 1);
-    //
-    //     let batch3 = client.get_records_batch(&patient1, &patient1, &1, &10);
-    //     assert_eq!(batch3.len(), 1);
-    //
-    //     // Test patient2 access
-    //     let batch_p2 = client.get_records_batch(&patient2, &patient2, &0, &5);
-    //     assert_eq!(batch_p2.len(), 1);
-    //
-    //     // Doctor should see everything
-    //     let batch_doc = client.get_records_batch(&doctor, &patient1, &0, &10);
-    //     assert_eq!(batch_doc.len(), 2); // only the non-confidential one
-    //
-    //     // Admin sees everything
-    //     let batch_admin = client.get_records_batch(&admin, &patient1, &0, &10);
-    //     assert_eq!(batch_admin.len(), 2);
-}
-//
-// #[test]
-// fn test_add_records_batch_partial_failure() {
-//     let env = Env::default();
-//     env.mock_all_auths();
-//     let (client, admin) = create_contract(&env);
-//     let doctor = Address::generate(&env);
-//     let patient = Address::generate(&env);
-//
-//     client.manage_user(&admin, &doctor, &Role::Doctor);
-//     client.manage_user(&admin, &patient, &Role::Patient);
-//
-//     let records = vec![
-//         &env,
-//         // valid
-//         (
-//             patient.clone(),
-//             String::from_str(&env, "Malaria"),
-//             String::from_str(&env, "Artemisinin"),
-//             false,
-//             vec![&env, String::from_str(&env, "tropical")],
-//             String::from_str(&env, "Modern"),
-//             String::from_str(&env, "Acute"),
-//             String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXC"),
-//         ),
-//         // invalid category
-//         (
-//             patient.clone(),
-//             String::from_str(&env, "A"),
-//             String::from_str(&env, "B"),
-//             false,
-//             vec![&env],
-//             String::from_str(&env, "Invalid"),
-//             String::from_str(&env, "C"),
-//             String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXD"),
-//         ),
-//         // empty treatment_type
-//         (
-//             patient.clone(),
-//             String::from_str(&env, "A"),
-//             String::from_str(&env, "B"),
-//             false,
-//             vec![&env],
-//             String::from_str(&env, "Modern"),
-//             String::from_str(&env, ""),
-//             String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXE"),
-//         ),
-//     ];
-//
-//     let result = client.add_records_batch(&doctor, &records);
-//
-//     assert_eq!(result.successes.len(), 1);
-// //     assert_eq!(result.failures.len(), 2);
-// }
 
 #[test]
 fn test_add_and_get_record() {
@@ -220,8 +88,8 @@ fn test_add_and_get_record() {
         .count();
     assert_eq!(access_events_count, 1);
 }
+
 #[test]
-#[should_panic(expected = "Error(Contract, #9)")]
 fn test_empty_data_ref() {
     let env = Env::default();
     env.mock_all_auths();
@@ -233,7 +101,7 @@ fn test_empty_data_ref() {
     client.manage_user(&admin, &patient, &Role::Patient);
 
     // Empty data_ref should fail
-    let _ = client.add_record(
+    let result = client.try_add_record(
         &doctor,
         &patient,
         &String::from_str(&env, "Diagnosis"),
@@ -244,10 +112,11 @@ fn test_empty_data_ref() {
         &String::from_str(&env, "Medication"),
         &String::from_str(&env, ""),
     );
+
+    assert_eq!(result, Err(Ok(Error::EmptyDataRef)));
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #10)")]
 fn test_data_ref_too_short() {
     let env = Env::default();
     env.mock_all_auths();
@@ -259,7 +128,7 @@ fn test_data_ref_too_short() {
     client.manage_user(&admin, &patient, &Role::Patient);
 
     // Data ref shorter than 10 chars should fail
-    let _ = client.add_record(
+    let result = client.try_add_record(
         &doctor,
         &patient,
         &String::from_str(&env, "Diagnosis"),
@@ -270,10 +139,11 @@ fn test_data_ref_too_short() {
         &String::from_str(&env, "Medication"),
         &String::from_str(&env, "Qm123"),
     );
+
+    assert_eq!(result, Err(Ok(Error::InvalidDataRefLength)));
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #10)")]
 fn test_data_ref_too_long() {
     let env = Env::default();
     env.mock_all_auths();
@@ -288,7 +158,7 @@ fn test_data_ref_too_long() {
     // Create a string longer than 200 characters (201 chars)
     let long_ref = String::from_str(&env, "Qmaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
-    let _ = client.add_record(
+    let result = client.try_add_record(
         &doctor,
         &patient,
         &String::from_str(&env, "Diagnosis"),
@@ -299,6 +169,8 @@ fn test_data_ref_too_long() {
         &String::from_str(&env, "Medication"),
         &long_ref,
     );
+
+    assert_eq!(result, Err(Ok(Error::InvalidDataRefLength)));
 }
 
 #[test]
@@ -451,7 +323,6 @@ fn test_role_based_access() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #2)")]
 fn test_deactivate_user() {
     let env = Env::default();
     env.mock_all_auths();
@@ -466,8 +337,8 @@ fn test_deactivate_user() {
     // Deactivate the doctor
     client.deactivate_user(&admin, &doctor);
 
-    // // Try to add a record as the deactivated doctor (should fail)
-    let _result = client.add_record(
+    // Try to add a record as the deactivated doctor (should fail)
+    let result = client.try_add_record(
         &doctor,
         &patient,
         &String::from_str(&env, "Cold"),
@@ -478,10 +349,11 @@ fn test_deactivate_user() {
         &String::from_str(&env, "Herbal Therapy"),
         &String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXx"),
     );
+
+    assert_eq!(result, Err(Ok(Error::NotAuthorized)));
 }
 
 #[test]
-#[should_panic(expected = "Error")]
 fn test_pause_unpause_blocks_sensitive_functions_panic() {
     let env = Env::default();
     env.mock_all_auths();
@@ -511,8 +383,7 @@ fn test_pause_unpause_blocks_sensitive_functions_panic() {
     client.pause(&admin);
 
     // Mutating functions should be blocked when paused
-    // Mutating functions should be blocked when paused
-    client.add_record(
+    let result = client.try_add_record(
         &doctor,
         &patient,
         &String::from_str(&env, "Blocked"),
@@ -521,8 +392,10 @@ fn test_pause_unpause_blocks_sensitive_functions_panic() {
         &vec![&env],
         &String::from_str(&env, "General"),
         &String::from_str(&env, "General"),
-        &String::from_str(&env, "IPFS"),
+        &String::from_str(&env, "QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhXXXXXx"),
     );
+
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
 }
 
 #[test]


### PR DESCRIPTION
## Description
This PR transitions the `medical_records` contract from a basic boolean/panic-based error handling system to a robust, granular `Result<T, Error>` pattern. These changes improve contract reliability, provide actionable feedback for front-end integration, and align the codebase with Soroban best practices.

Closes #59 

### Key Changes
* **Error Handling**: Replaced all `panic!` calls and `bool` return types with a centralized `Error` enum containing 47 specific error variants.
* **Validation Logic**: Centralized input validation (e.g., `data_ref` length, record attributes) within `validation.rs`.
* **Access Control**: Updated `is_paused` and `check_permission` to return `Result<(), Error>`, allowing for immediate error propagation using the `?` operator.
* **Event Logging**: Enhanced helper functions to emit detailed `ERR_LOG` events before returning errors, aiding in off-chain debugging.
* **Test Suite Migration**: 
    * Removed `#[should_panic]` attributes in favor of explicit error matching.
    * Updated `test.rs` to use `client.try_...` calls.
    * Verified that specific contract actions return the exact expected `Error` variants.

## Motivation and Context
The previous system lacked detail when transactions failed. By using a custom `Error` enum, developers and users can now distinguish between a unauthorized access, a paused contract, or specific validation failures like `EmptyDataRef`.

## How Has This Been Tested?
* **Unit Tests**: Ran `cargo test` to verify all existing and new test cases pass.
* **Error Verification**: Explicitly tested boundary conditions for `data_ref` (min/max length) and ensured they return `Error::InvalidDataRefLength`.
* **Permission Testing**: Verified that deactivated users and non-admin users receive `Error::NotAuthorized` where appropriate.

## Types of changes
- [x] Refactor (non-breaking change which improves code structure)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Unit tests updated and passing