### PR TITLE
Implement deprecation

### DIFF
--- a/contracts/ai_analytics/src/admin.rs
+++ b/contracts/ai_analytics/src/admin.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{Address, Env};
+
+use crate::types::{DataKey, Error};
+
+pub fn initialize(env: Env, admin: Address) -> Result<bool, Error> {
+    admin.require_auth();
+
+    if env.storage().instance().has(&DataKey::Admin) {
+        return Err(Error::AlreadyInitialized);
+    }
+
+    env.storage().instance().set(&DataKey::Admin, &admin);
+    Ok(true)
+}

--- a/contracts/ai_analytics/src/lib.rs
+++ b/contracts/ai_analytics/src/lib.rs
@@ -1,64 +1,16 @@
 #![no_std]
 
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String,
-};
+mod admin;
+mod rounds;
+mod types;
+mod utils;
 
-#[derive(Clone)]
-#[contracttype]
-pub struct FederatedRound {
-    pub id: u64,
-    pub base_model_id: BytesN<32>,
-    pub min_participants: u32,
-    pub dp_epsilon: u32,
-    pub started_at: u64,
-    pub finalized_at: u64,
-    pub total_updates: u32,
-    pub is_finalized: bool,
-}
+#[cfg(all(test, feature = "testutils"))]
+mod test;
 
-#[derive(Clone)]
-#[contracttype]
-pub struct ParticipantUpdateMeta {
-    pub round_id: u64,
-    pub participant: Address,
-    pub update_hash: BytesN<32>,
-    pub num_samples: u32,
-}
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String};
 
-#[derive(Clone)]
-#[contracttype]
-pub struct ModelMetadata {
-    pub model_id: BytesN<32>,
-    pub round_id: u64,
-    pub description: String,
-    pub metrics_ref: String,
-    pub fairness_report_ref: String,
-    pub created_at: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    RoundCounter,
-    Round(u64),
-    ParticipantUpdate(u64, Address),
-    Model(BytesN<32>),
-}
-
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum Error {
-    NotAuthorized = 1,
-    RoundNotFound = 2,
-    RoundFinalized = 3,
-    NotEnoughParticipants = 4,
-    DuplicateUpdate = 5,
-    AlreadyInitialized = 6,
-    AdminNotSet = 7,
-}
+pub use types::{DataKey, Error, FederatedRound, ModelMetadata, ParticipantUpdateMeta};
 
 #[contract]
 pub struct AiAnalyticsContract;
@@ -66,38 +18,7 @@ pub struct AiAnalyticsContract;
 #[contractimpl]
 impl AiAnalyticsContract {
     pub fn initialize(env: Env, admin: Address) -> Result<bool, Error> {
-        admin.require_auth();
-
-        if env.storage().instance().has(&DataKey::Admin) {
-            return Err(Error::AlreadyInitialized);
-        }
-
-        env.storage().instance().set(&DataKey::Admin, &admin);
-        Ok(true)
-    }
-
-    fn ensure_admin(env: &Env, caller: &Address) -> Result<(), Error> {
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(Error::AdminNotSet)?;
-
-        if admin != *caller {
-            return Err(Error::NotAuthorized);
-        }
-        Ok(())
-    }
-
-    fn next_round_id(env: &Env) -> u64 {
-        let current: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::RoundCounter)
-            .unwrap_or(0);
-        let next = current.saturating_add(1);
-        env.storage().instance().set(&DataKey::RoundCounter, &next);
-        next
+        admin::initialize(env, admin)
     }
 
     pub fn start_round(
@@ -107,28 +28,7 @@ impl AiAnalyticsContract {
         min_participants: u32,
         dp_epsilon: u32,
     ) -> Result<u64, Error> {
-        caller.require_auth();
-        Self::ensure_admin(&env, &caller)?;
-
-        if min_participants == 0 {
-            return Err(Error::NotEnoughParticipants);
-        }
-
-        let id = Self::next_round_id(&env);
-        let round = FederatedRound {
-            id,
-            base_model_id,
-            min_participants,
-            dp_epsilon,
-            started_at: env.ledger().timestamp(),
-            finalized_at: 0,
-            total_updates: 0,
-            is_finalized: false,
-        };
-
-        env.storage().instance().set(&DataKey::Round(id), &round);
-        env.events().publish((symbol_short!("RndStart"),), id);
-        Ok(id)
+        rounds::start_round(env, caller, base_model_id, min_participants, dp_epsilon)
     }
 
     pub fn submit_update(
@@ -138,41 +38,7 @@ impl AiAnalyticsContract {
         update_hash: BytesN<32>,
         num_samples: u32,
     ) -> Result<bool, Error> {
-        participant.require_auth();
-
-        let mut round: FederatedRound = env
-            .storage()
-            .instance()
-            .get(&DataKey::Round(round_id))
-            .ok_or(Error::RoundNotFound)?;
-
-        if round.is_finalized {
-            return Err(Error::RoundFinalized);
-        }
-
-        let key = DataKey::ParticipantUpdate(round_id, participant.clone());
-        if env.storage().instance().has(&key) {
-            return Err(Error::DuplicateUpdate);
-        }
-
-        let update = ParticipantUpdateMeta {
-            round_id,
-            participant: participant.clone(),
-            update_hash,
-            num_samples,
-        };
-
-        env.storage().instance().set(&key, &update);
-
-        round.total_updates = round.total_updates.saturating_add(1);
-        env.storage()
-            .instance()
-            .set(&DataKey::Round(round_id), &round);
-
-        env.events()
-            .publish((symbol_short!("UpdSubmit"),), (round_id, participant));
-
-        Ok(true)
+        rounds::submit_update(env, participant, round_id, update_hash, num_samples)
     }
 
     pub fn finalize_round(
@@ -184,111 +50,22 @@ impl AiAnalyticsContract {
         metrics_ref: String,
         fairness_report_ref: String,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::ensure_admin(&env, &caller)?;
-
-        let mut round: FederatedRound = env
-            .storage()
-            .instance()
-            .get(&DataKey::Round(round_id))
-            .ok_or(Error::RoundNotFound)?;
-
-        if round.is_finalized {
-            return Err(Error::RoundFinalized);
-        }
-
-        if round.total_updates < round.min_participants {
-            return Err(Error::NotEnoughParticipants);
-        }
-
-        round.is_finalized = true;
-        round.finalized_at = env.ledger().timestamp();
-        env.storage()
-            .instance()
-            .set(&DataKey::Round(round_id), &round);
-
-        let metadata = ModelMetadata {
-            model_id: new_model_id.clone(),
+        rounds::finalize_round(
+            env,
+            caller,
             round_id,
+            new_model_id,
             description,
             metrics_ref,
             fairness_report_ref,
-            created_at: round.finalized_at,
-        };
-
-        env.storage()
-            .instance()
-            .set(&DataKey::Model(new_model_id.clone()), &metadata);
-
-        env.events()
-            .publish((symbol_short!("RndFinal"),), (round_id, new_model_id));
-
-        Ok(true)
+        )
     }
 
     pub fn get_round(env: Env, round_id: u64) -> Option<FederatedRound> {
-        env.storage().instance().get(&DataKey::Round(round_id))
+        rounds::get_round(env, round_id)
     }
 
     pub fn get_model(env: Env, model_id: BytesN<32>) -> Option<ModelMetadata> {
-        env.storage().instance().get(&DataKey::Model(model_id))
-    }
-}
-
-#[cfg(all(test, feature = "testutils"))]
-#[allow(clippy::unwrap_used)]
-mod test {
-    use super::*;
-    use soroban_sdk::testutils::Address as _;
-
-    #[test]
-    fn test_federated_round_flow() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, AiAnalyticsContract);
-        let client = AiAnalyticsContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let participant1 = Address::generate(&env);
-        let participant2 = Address::generate(&env);
-
-        // Soroban contract clients auto-unwrap Result types
-        client.mock_all_auths().initialize(&admin);
-
-        let base_model = BytesN::from_array(&env, &[1u8; 32]);
-        let round_id = client
-            .mock_all_auths()
-            .start_round(&admin, &base_model, &2u32, &1u32);
-
-        let update_hash1 = BytesN::from_array(&env, &[2u8; 32]);
-        let update_hash2 = BytesN::from_array(&env, &[3u8; 32]);
-
-        assert!(client.mock_all_auths().submit_update(
-            &participant1,
-            &round_id,
-            &update_hash1,
-            &10u32
-        ));
-        assert!(client.mock_all_auths().submit_update(
-            &participant2,
-            &round_id,
-            &update_hash2,
-            &20u32
-        ));
-
-        let new_model = BytesN::from_array(&env, &[4u8; 32]);
-        assert!(client.mock_all_auths().finalize_round(
-            &admin,
-            &round_id,
-            &new_model,
-            &String::from_str(&env, "Test model"),
-            &String::from_str(&env, "ipfs://metrics"),
-            &String::from_str(&env, "ipfs://fairness"),
-        ));
-
-        let stored_round = client.get_round(&round_id).unwrap();
-        assert!(stored_round.is_finalized);
-
-        let stored_model = client.get_model(&new_model).unwrap();
-        assert_eq!(stored_model.round_id, round_id);
+        rounds::get_model(env, model_id)
     }
 }

--- a/contracts/ai_analytics/src/rounds.rs
+++ b/contracts/ai_analytics/src/rounds.rs
@@ -1,0 +1,136 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env, String};
+
+use crate::{
+    types::{DataKey, Error, FederatedRound, ModelMetadata, ParticipantUpdateMeta},
+    utils,
+};
+
+pub fn start_round(
+    env: Env,
+    caller: Address,
+    base_model_id: BytesN<32>,
+    min_participants: u32,
+    dp_epsilon: u32,
+) -> Result<u64, Error> {
+    caller.require_auth();
+    utils::ensure_admin(&env, &caller)?;
+
+    if min_participants == 0 {
+        return Err(Error::NotEnoughParticipants);
+    }
+
+    let id = utils::next_round_id(&env);
+    let round = FederatedRound {
+        id,
+        base_model_id,
+        min_participants,
+        dp_epsilon,
+        started_at: env.ledger().timestamp(),
+        finalized_at: 0,
+        total_updates: 0,
+        is_finalized: false,
+    };
+
+    env.storage().instance().set(&DataKey::Round(id), &round);
+    env.events().publish((symbol_short!("RndStart"),), id);
+    Ok(id)
+}
+
+pub fn submit_update(
+    env: Env,
+    participant: Address,
+    round_id: u64,
+    update_hash: BytesN<32>,
+    num_samples: u32,
+) -> Result<bool, Error> {
+    participant.require_auth();
+
+    let mut round: FederatedRound = env
+        .storage()
+        .instance()
+        .get(&DataKey::Round(round_id))
+        .ok_or(Error::RoundNotFound)?;
+
+    if round.is_finalized {
+        return Err(Error::RoundFinalized);
+    }
+
+    let key = DataKey::ParticipantUpdate(round_id, participant.clone());
+    if env.storage().instance().has(&key) {
+        return Err(Error::DuplicateUpdate);
+    }
+
+    let update = ParticipantUpdateMeta {
+        round_id,
+        participant: participant.clone(),
+        update_hash,
+        num_samples,
+    };
+
+    env.storage().instance().set(&key, &update);
+
+    round.total_updates = round.total_updates.saturating_add(1);
+    env.storage().instance().set(&DataKey::Round(round_id), &round);
+
+    env.events()
+        .publish((symbol_short!("UpdSubmit"),), (round_id, participant));
+
+    Ok(true)
+}
+
+pub fn finalize_round(
+    env: Env,
+    caller: Address,
+    round_id: u64,
+    new_model_id: BytesN<32>,
+    description: String,
+    metrics_ref: String,
+    fairness_report_ref: String,
+) -> Result<bool, Error> {
+    caller.require_auth();
+    utils::ensure_admin(&env, &caller)?;
+
+    let mut round: FederatedRound = env
+        .storage()
+        .instance()
+        .get(&DataKey::Round(round_id))
+        .ok_or(Error::RoundNotFound)?;
+
+    if round.is_finalized {
+        return Err(Error::RoundFinalized);
+    }
+
+    if round.total_updates < round.min_participants {
+        return Err(Error::NotEnoughParticipants);
+    }
+
+    round.is_finalized = true;
+    round.finalized_at = env.ledger().timestamp();
+    env.storage().instance().set(&DataKey::Round(round_id), &round);
+
+    let metadata = ModelMetadata {
+        model_id: new_model_id.clone(),
+        round_id,
+        description,
+        metrics_ref,
+        fairness_report_ref,
+        created_at: round.finalized_at,
+    };
+
+    env.storage()
+        .instance()
+        .set(&DataKey::Model(new_model_id.clone()), &metadata);
+
+    env.events()
+        .publish((symbol_short!("RndFinal"),), (round_id, new_model_id));
+
+    Ok(true)
+}
+
+pub fn get_round(env: Env, round_id: u64) -> Option<FederatedRound> {
+    env.storage().instance().get(&DataKey::Round(round_id))
+}
+
+pub fn get_model(env: Env, model_id: BytesN<32>) -> Option<ModelMetadata> {
+    env.storage().instance().get(&DataKey::Model(model_id))
+}

--- a/contracts/ai_analytics/src/rounds.rs
+++ b/contracts/ai_analytics/src/rounds.rs
@@ -70,7 +70,9 @@ pub fn submit_update(
     env.storage().instance().set(&key, &update);
 
     round.total_updates = round.total_updates.saturating_add(1);
-    env.storage().instance().set(&DataKey::Round(round_id), &round);
+    env.storage()
+        .instance()
+        .set(&DataKey::Round(round_id), &round);
 
     env.events()
         .publish((symbol_short!("UpdSubmit"),), (round_id, participant));
@@ -106,7 +108,9 @@ pub fn finalize_round(
 
     round.is_finalized = true;
     round.finalized_at = env.ledger().timestamp();
-    env.storage().instance().set(&DataKey::Round(round_id), &round);
+    env.storage()
+        .instance()
+        .set(&DataKey::Round(round_id), &round);
 
     let metadata = ModelMetadata {
         model_id: new_model_id.clone(),

--- a/contracts/ai_analytics/src/test.rs
+++ b/contracts/ai_analytics/src/test.rs
@@ -1,0 +1,55 @@
+use crate::{
+    types::{FederatedRound, ModelMetadata},
+    AiAnalyticsContract, AiAnalyticsContractClient,
+};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+#[test]
+fn test_federated_round_flow() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, AiAnalyticsContract);
+    let client = AiAnalyticsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let participant1 = Address::generate(&env);
+    let participant2 = Address::generate(&env);
+
+    client.mock_all_auths().initialize(&admin);
+
+    let base_model = BytesN::from_array(&env, &[1u8; 32]);
+    let round_id = client
+        .mock_all_auths()
+        .start_round(&admin, &base_model, &2u32, &1u32);
+
+    let update_hash1 = BytesN::from_array(&env, &[2u8; 32]);
+    let update_hash2 = BytesN::from_array(&env, &[3u8; 32]);
+
+    assert!(client.mock_all_auths().submit_update(
+        &participant1,
+        &round_id,
+        &update_hash1,
+        &10u32
+    ));
+    assert!(client.mock_all_auths().submit_update(
+        &participant2,
+        &round_id,
+        &update_hash2,
+        &20u32
+    ));
+
+    let new_model = BytesN::from_array(&env, &[4u8; 32]);
+    assert!(client.mock_all_auths().finalize_round(
+        &admin,
+        &round_id,
+        &new_model,
+        &String::from_str(&env, "Test model"),
+        &String::from_str(&env, "ipfs://metrics"),
+        &String::from_str(&env, "ipfs://fairness"),
+    ));
+
+    let stored_round: FederatedRound = client.get_round(&round_id).unwrap();
+    assert!(stored_round.is_finalized);
+
+    let stored_model: ModelMetadata = client.get_model(&new_model).unwrap();
+    assert_eq!(stored_model.round_id, round_id);
+}

--- a/contracts/ai_analytics/src/test.rs
+++ b/contracts/ai_analytics/src/test.rs
@@ -24,18 +24,12 @@ fn test_federated_round_flow() {
     let update_hash1 = BytesN::from_array(&env, &[2u8; 32]);
     let update_hash2 = BytesN::from_array(&env, &[3u8; 32]);
 
-    assert!(client.mock_all_auths().submit_update(
-        &participant1,
-        &round_id,
-        &update_hash1,
-        &10u32
-    ));
-    assert!(client.mock_all_auths().submit_update(
-        &participant2,
-        &round_id,
-        &update_hash2,
-        &20u32
-    ));
+    assert!(client
+        .mock_all_auths()
+        .submit_update(&participant1, &round_id, &update_hash1, &10u32));
+    assert!(client
+        .mock_all_auths()
+        .submit_update(&participant2, &round_id, &update_hash2, &20u32));
 
     let new_model = BytesN::from_array(&env, &[4u8; 32]);
     assert!(client.mock_all_auths().finalize_round(

--- a/contracts/ai_analytics/src/types.rs
+++ b/contracts/ai_analytics/src/types.rs
@@ -1,0 +1,57 @@
+use soroban_sdk::{contracterror, contracttype, Address, BytesN, String};
+
+#[derive(Clone)]
+#[contracttype]
+pub struct FederatedRound {
+    pub id: u64,
+    pub base_model_id: BytesN<32>,
+    pub min_participants: u32,
+    pub dp_epsilon: u32,
+    pub started_at: u64,
+    pub finalized_at: u64,
+    pub total_updates: u32,
+    pub is_finalized: bool,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ParticipantUpdateMeta {
+    pub round_id: u64,
+    pub participant: Address,
+    pub update_hash: BytesN<32>,
+    pub num_samples: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ModelMetadata {
+    pub model_id: BytesN<32>,
+    pub round_id: u64,
+    pub description: String,
+    pub metrics_ref: String,
+    pub fairness_report_ref: String,
+    pub created_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    RoundCounter,
+    Round(u64),
+    ParticipantUpdate(u64, Address),
+    Model(BytesN<32>),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotAuthorized = 1,
+    RoundNotFound = 2,
+    RoundFinalized = 3,
+    NotEnoughParticipants = 4,
+    DuplicateUpdate = 5,
+    AlreadyInitialized = 6,
+    AdminNotSet = 7,
+}

--- a/contracts/ai_analytics/src/utils.rs
+++ b/contracts/ai_analytics/src/utils.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{Address, Env};
+
+use crate::types::{DataKey, Error};
+
+pub fn ensure_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .ok_or(Error::AdminNotSet)?;
+
+    if admin != *caller {
+        return Err(Error::NotAuthorized);
+    }
+
+    Ok(())
+}
+
+pub fn next_round_id(env: &Env) -> u64 {
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::RoundCounter)
+        .unwrap_or(0);
+    let next = current.saturating_add(1);
+    env.storage().instance().set(&DataKey::RoundCounter, &next);
+    next
+}

--- a/contracts/aml/Cargo.toml
+++ b/contracts/aml/Cargo.toml
@@ -1,19 +1,20 @@
 [package]
 name = "aml"
-version.workspace = true
-edition.workspace = true
-authors.workspace = true
-license.workspace = true
-repository.workspace = true
+version = "0.1.0"
+edition = "2021"
+authors = ["Your Name <your.email@example.com>"]
+license = "MIT"
+repository = "https://github.com/yourusername/soroban-project"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk.workspace = true
+soroban-sdk = { version = "21.7.7" }
+upgradeability = { path = "../upgradeability" }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = { version = "21.7.7", features = ["testutils"] }
 
 [features]
 default = []

--- a/contracts/healthcare_oracle_network/src/admin.rs
+++ b/contracts/healthcare_oracle_network/src/admin.rs
@@ -1,0 +1,86 @@
+use soroban_sdk::{Address, Env, Vec};
+
+use crate::types::{Config, DataKey, Error};
+use crate::utils;
+
+pub fn initialize(
+    env: Env,
+    admin: Address,
+    arbiters: Vec<Address>,
+    min_submissions: u32,
+) -> Result<(), Error> {
+    if env.storage().instance().has(&DataKey::Config) {
+        return Err(Error::AlreadyInitialized);
+    }
+
+    if min_submissions == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    let config = Config {
+        admin,
+        arbiters,
+        min_submissions,
+        min_reputation: 0,
+        max_drug_price_minor: 1_000_000_000,
+        max_availability_units: 5_000_000,
+    };
+
+    env.storage().instance().set(&DataKey::Config, &config);
+    env.storage()
+        .instance()
+        .set(&DataKey::OracleList, &Vec::<Address>::new(&env));
+    env.storage().instance().set(&DataKey::DisputeCount, &0u64);
+    Ok(())
+}
+
+pub fn update_config(
+    env: Env,
+    admin: Address,
+    min_submissions: u32,
+    min_reputation: i128,
+    max_drug_price_minor: i128,
+    max_availability_units: u32,
+) -> Result<(), Error> {
+    utils::require_admin(&env, admin)?;
+
+    if min_submissions == 0 || max_drug_price_minor <= 0 || max_availability_units == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    let mut config: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)?;
+
+    config.min_submissions = min_submissions;
+    config.min_reputation = min_reputation;
+    config.max_drug_price_minor = max_drug_price_minor;
+    config.max_availability_units = max_availability_units;
+
+    env.storage().instance().set(&DataKey::Config, &config);
+    Ok(())
+}
+
+pub fn add_arbiter(env: Env, admin: Address, arbiter: Address) -> Result<(), Error> {
+    utils::require_admin(&env, admin)?;
+
+    let mut config: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)?;
+
+    if config.arbiters.contains(&arbiter) {
+        return Err(Error::ArbiterExists);
+    }
+
+    config.arbiters.push_back(arbiter);
+    env.storage().instance().set(&DataKey::Config, &config);
+    Ok(())
+}
+
+pub fn get_config(env: Env) -> Option<Config> {
+    env.storage().instance().get(&DataKey::Config)
+}

--- a/contracts/healthcare_oracle_network/src/disputes.rs
+++ b/contracts/healthcare_oracle_network/src/disputes.rs
@@ -1,0 +1,134 @@
+use soroban_sdk::{symbol_short, Address, Env, String};
+
+use crate::types::{Config, ConsensusRecord, DataKey, Dispute, DisputeStatus, Error, FeedKey, FeedKind};
+use crate::utils;
+
+pub fn raise_dispute(
+    env: Env,
+    challenger: Address,
+    kind: FeedKind,
+    feed_id: String,
+    reason: String,
+) -> Result<u64, Error> {
+    challenger.require_auth();
+    utils::require_initialized(&env)?;
+
+    if reason.len() == 0 || feed_id.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    let key = FeedKey { kind, feed_id };
+    let consensus: ConsensusRecord = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Consensus(key.clone()))
+        .ok_or(Error::ConsensusNotFound)?;
+
+    if consensus.disputed {
+        return Err(Error::InvalidDisputeState);
+    }
+
+    let dispute_id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::DisputeCount)
+        .unwrap_or(0u64)
+        .saturating_add(1);
+
+    let dispute = Dispute {
+        id: dispute_id,
+        key,
+        round_id: consensus.round_id,
+        challenger,
+        reason,
+        status: DisputeStatus::Open,
+        opened_at: env.ledger().timestamp(),
+        resolved_at: None,
+        resolver: None,
+        ruling: None,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(dispute_id), &dispute);
+    env.storage()
+        .instance()
+        .set(&DataKey::DisputeCount, &dispute_id);
+
+    env.events()
+        .publish((symbol_short!("dispute"),), dispute_id);
+    Ok(dispute_id)
+}
+
+pub fn resolve_dispute(
+    env: Env,
+    resolver: Address,
+    dispute_id: u64,
+    valid_dispute: bool,
+    ruling: String,
+    penalized_oracle: Option<Address>,
+) -> Result<(), Error> {
+    resolver.require_auth();
+    let config: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)?;
+
+    if resolver != config.admin && !config.arbiters.contains(&resolver) {
+        return Err(Error::Unauthorized);
+    }
+
+    let mut dispute: Dispute = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Dispute(dispute_id))
+        .ok_or(Error::DisputeNotFound)?;
+
+    if dispute.status != DisputeStatus::Open {
+        return Err(Error::DisputeAlreadyResolved);
+    }
+
+    let mut consensus: ConsensusRecord = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Consensus(dispute.key.clone()))
+        .ok_or(Error::ConsensusNotFound)?;
+
+    if valid_dispute {
+        consensus.disputed = true;
+        dispute.status = DisputeStatus::ResolvedValid;
+
+        if let Some(oracle) = penalized_oracle {
+            utils::adjust_reputation(&env, oracle, -15, true)?;
+        }
+    } else {
+        dispute.status = DisputeStatus::ResolvedInvalid;
+        let mut i = 0;
+        while i < consensus.submitters.len() {
+            let submitter = consensus.submitters.get(i).unwrap();
+            utils::adjust_reputation(&env, submitter, 2, false)?;
+            i += 1;
+        }
+    }
+
+    dispute.resolved_at = Some(env.ledger().timestamp());
+    dispute.resolver = Some(resolver);
+    dispute.ruling = Some(ruling);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Consensus(dispute.key.clone()), &consensus);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(dispute_id), &dispute);
+
+    env.events()
+        .publish((symbol_short!("resolve"), dispute_id), valid_dispute);
+
+    Ok(())
+}
+
+pub fn get_dispute(env: Env, dispute_id: u64) -> Option<Dispute> {
+    env.storage().persistent().get(&DataKey::Dispute(dispute_id))
+}

--- a/contracts/healthcare_oracle_network/src/disputes.rs
+++ b/contracts/healthcare_oracle_network/src/disputes.rs
@@ -1,6 +1,8 @@
 use soroban_sdk::{symbol_short, Address, Env, String};
 
-use crate::types::{Config, ConsensusRecord, DataKey, Dispute, DisputeStatus, Error, FeedKey, FeedKind};
+use crate::types::{
+    Config, ConsensusRecord, DataKey, Dispute, DisputeStatus, Error, FeedKey, FeedKind,
+};
 use crate::utils;
 
 pub fn raise_dispute(
@@ -130,5 +132,7 @@ pub fn resolve_dispute(
 }
 
 pub fn get_dispute(env: Env, dispute_id: u64) -> Option<Dispute> {
-    env.storage().persistent().get(&DataKey::Dispute(dispute_id))
+    env.storage()
+        .persistent()
+        .get(&DataKey::Dispute(dispute_id))
 }

--- a/contracts/healthcare_oracle_network/src/lib.rs
+++ b/contracts/healthcare_oracle_network/src/lib.rs
@@ -16,9 +16,9 @@ mod utils;
 use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 pub use types::{
-    AggregationRound, ClinicalTrialData, Config, ConsensusRecord, DataKey, Dispute,
-    DisputeStatus, DrugPriceData, Error, FeedKey, FeedKind, FeedPayload, OracleNode,
-    RegulatoryAuthority, RegulatoryStatus, RegulatoryUpdateData, SourceType, TreatmentOutcomeData,
+    AggregationRound, ClinicalTrialData, Config, ConsensusRecord, DataKey, Dispute, DisputeStatus,
+    DrugPriceData, Error, FeedKey, FeedKind, FeedPayload, OracleNode, RegulatoryAuthority,
+    RegulatoryStatus, RegulatoryUpdateData, SourceType, TreatmentOutcomeData,
 };
 
 #[contract]

--- a/contracts/healthcare_oracle_network/src/lib.rs
+++ b/contracts/healthcare_oracle_network/src/lib.rs
@@ -4,221 +4,22 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::arithmetic_side_effects)]
 
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
-};
-
+mod admin;
+mod disputes;
+mod oracles;
+mod submissions;
 #[cfg(test)]
 mod test;
+mod types;
+mod utils;
 
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum Error {
-    AlreadyInitialized = 1,
-    NotInitialized = 2,
-    Unauthorized = 3,
-    OracleAlreadyRegistered = 4,
-    OracleNotFound = 5,
-    OracleNotVerified = 6,
-    OracleInactive = 7,
-    InvalidData = 8,
-    SubmissionAlreadyExists = 9,
-    RoundNotFound = 10,
-    InsufficientSubmissions = 11,
-    ConsensusAlreadyFinalized = 12,
-    ConsensusNotFound = 13,
-    DisputeNotFound = 14,
-    DisputeAlreadyResolved = 15,
-    InvalidDisputeState = 16,
-    InvalidFeedType = 17,
-    ArbiterExists = 18,
-}
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum FeedKind {
-    DrugPricing = 1,
-    ClinicalTrial = 2,
-    RegulatoryUpdate = 3,
-    TreatmentOutcome = 4,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum SourceType {
-    PharmaSupplier = 1,
-    ClinicalRegistry = 2,
-    RegulatoryBody = 3,
-    MarketAggregator = 4,
-    HospitalNetwork = 5,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum RegulatoryAuthority {
-    FDA = 1,
-    EMA = 2,
-    MHRA = 3,
-    PMDA = 4,
-    WHO = 5,
-    CDSCO = 6,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum RegulatoryStatus {
-    Approved = 1,
-    SafetyWarning = 2,
-    Recall = 3,
-    GuidelineUpdate = 4,
-    TrialHold = 5,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[contracttype]
-pub enum DisputeStatus {
-    Open = 1,
-    ResolvedValid = 2,
-    ResolvedInvalid = 3,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct FeedKey {
-    pub kind: FeedKind,
-    pub feed_id: String,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct DrugPriceData {
-    pub ndc_code: String,
-    pub currency: String,
-    pub price_minor: i128,
-    pub availability_units: u32,
-    pub observed_at: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct ClinicalTrialData {
-    pub trial_id: String,
-    pub phase: u32,
-    pub enrolled: u32,
-    pub success_rate_bps: u32,
-    pub adverse_event_rate_bps: u32,
-    pub result_hash: String,
-    pub published_at: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct TreatmentOutcomeData {
-    pub outcome_id: String,
-    pub condition_code: String,
-    pub treatment_code: String,
-    pub improvement_rate_bps: u32,
-    pub readmission_rate_bps: u32,
-    pub mortality_rate_bps: u32,
-    pub sample_size: u32,
-    pub reported_at: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct RegulatoryUpdateData {
-    pub regulation_id: String,
-    pub authority: RegulatoryAuthority,
-    pub status: RegulatoryStatus,
-    pub title: String,
-    pub details_hash: String,
-    pub effective_at: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub enum FeedPayload {
-    DrugPrice(DrugPriceData),
-    ClinicalTrial(ClinicalTrialData),
-    RegulatoryUpdate(RegulatoryUpdateData),
-    TreatmentOutcome(TreatmentOutcomeData),
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct OracleNode {
-    pub operator: Address,
-    pub endpoint: String,
-    pub source_type: SourceType,
-    pub verified: bool,
-    pub active: bool,
-    pub reputation: i128,
-    pub submissions: u32,
-    pub disputes: u32,
-    pub last_seen: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct Config {
-    pub admin: Address,
-    pub arbiters: Vec<Address>,
-    pub min_submissions: u32,
-    pub min_reputation: i128,
-    pub max_drug_price_minor: i128,
-    pub max_availability_units: u32,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct AggregationRound {
-    pub id: u64,
-    pub started_at: u64,
-    pub finalized: bool,
-    pub submissions: u32,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct ConsensusRecord {
-    pub key: FeedKey,
-    pub payload: FeedPayload,
-    pub round_id: u64,
-    pub finalized_at: u64,
-    pub submitters: Vec<Address>,
-    pub confidence_bps: u32,
-    pub disputed: bool,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct Dispute {
-    pub id: u64,
-    pub key: FeedKey,
-    pub round_id: u64,
-    pub challenger: Address,
-    pub reason: String,
-    pub status: DisputeStatus,
-    pub opened_at: u64,
-    pub resolved_at: Option<u64>,
-    pub resolver: Option<Address>,
-    pub ruling: Option<String>,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub enum DataKey {
-    Config,
-    Oracle(Address),
-    OracleList,
-    RoundCounter(FeedKey),
-    Round(FeedKey, u64),
-    Submission(FeedKey, u64, Address),
-    Consensus(FeedKey),
-    DisputeCount,
-    Dispute(u64),
-}
+pub use types::{
+    AggregationRound, ClinicalTrialData, Config, ConsensusRecord, DataKey, Dispute,
+    DisputeStatus, DrugPriceData, Error, FeedKey, FeedKind, FeedPayload, OracleNode,
+    RegulatoryAuthority, RegulatoryStatus, RegulatoryUpdateData, SourceType, TreatmentOutcomeData,
+};
 
 #[contract]
 pub struct HealthcareOracleNetwork;
@@ -231,29 +32,7 @@ impl HealthcareOracleNetwork {
         arbiters: Vec<Address>,
         min_submissions: u32,
     ) -> Result<(), Error> {
-        if env.storage().instance().has(&DataKey::Config) {
-            return Err(Error::AlreadyInitialized);
-        }
-
-        if min_submissions == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        let cfg = Config {
-            admin,
-            arbiters,
-            min_submissions,
-            min_reputation: 0,
-            max_drug_price_minor: 1_000_000_000,
-            max_availability_units: 5_000_000,
-        };
-
-        env.storage().instance().set(&DataKey::Config, &cfg);
-        env.storage()
-            .instance()
-            .set(&DataKey::OracleList, &Vec::<Address>::new(&env));
-        env.storage().instance().set(&DataKey::DisputeCount, &0u64);
-        Ok(())
+        admin::initialize(env, admin, arbiters, min_submissions)
     }
 
     pub fn register_oracle(
@@ -262,45 +41,7 @@ impl HealthcareOracleNetwork {
         endpoint: String,
         source_type: SourceType,
     ) -> Result<(), Error> {
-        operator.require_auth();
-        Self::require_initialized(&env)?;
-
-        if endpoint.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        if env
-            .storage()
-            .persistent()
-            .has(&DataKey::Oracle(operator.clone()))
-        {
-            return Err(Error::OracleAlreadyRegistered);
-        }
-
-        let mut oracles: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::OracleList)
-            .unwrap_or(Vec::new(&env));
-        oracles.push_back(operator.clone());
-
-        let node = OracleNode {
-            operator: operator.clone(),
-            endpoint,
-            source_type,
-            verified: false,
-            active: true,
-            reputation: 50,
-            submissions: 0,
-            disputes: 0,
-            last_seen: env.ledger().timestamp(),
-        };
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Oracle(operator), &node);
-        env.storage().instance().set(&DataKey::OracleList, &oracles);
-        Ok(())
+        oracles::register_oracle(env, operator, endpoint, source_type)
     }
 
     pub fn verify_oracle(
@@ -310,16 +51,7 @@ impl HealthcareOracleNetwork {
         verified: bool,
         active: bool,
     ) -> Result<(), Error> {
-        Self::require_admin(&env, admin)?;
-
-        let mut node = Self::read_oracle(&env, operator.clone())?;
-        node.verified = verified;
-        node.active = active;
-        node.last_seen = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&DataKey::Oracle(operator), &node);
-        Ok(())
+        oracles::verify_oracle(env, admin, operator, verified, active)
     }
 
     pub fn update_oracle_endpoint(
@@ -327,17 +59,7 @@ impl HealthcareOracleNetwork {
         operator: Address,
         endpoint: String,
     ) -> Result<(), Error> {
-        operator.require_auth();
-        if endpoint.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-        let mut node = Self::read_oracle(&env, operator.clone())?;
-        node.endpoint = endpoint;
-        node.last_seen = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&DataKey::Oracle(operator), &node);
-        Ok(())
+        oracles::update_oracle_endpoint(env, operator, endpoint)
     }
 
     pub fn update_config(
@@ -348,42 +70,18 @@ impl HealthcareOracleNetwork {
         max_drug_price_minor: i128,
         max_availability_units: u32,
     ) -> Result<(), Error> {
-        Self::require_admin(&env, admin)?;
-
-        if min_submissions == 0 || max_drug_price_minor <= 0 || max_availability_units == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        let mut cfg: Config = env
-            .storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::NotInitialized)?;
-
-        cfg.min_submissions = min_submissions;
-        cfg.min_reputation = min_reputation;
-        cfg.max_drug_price_minor = max_drug_price_minor;
-        cfg.max_availability_units = max_availability_units;
-
-        env.storage().instance().set(&DataKey::Config, &cfg);
-        Ok(())
+        admin::update_config(
+            env,
+            admin,
+            min_submissions,
+            min_reputation,
+            max_drug_price_minor,
+            max_availability_units,
+        )
     }
 
     pub fn add_arbiter(env: Env, admin: Address, arbiter: Address) -> Result<(), Error> {
-        Self::require_admin(&env, admin)?;
-        let mut cfg: Config = env
-            .storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::NotInitialized)?;
-
-        if cfg.arbiters.contains(&arbiter) {
-            return Err(Error::ArbiterExists);
-        }
-
-        cfg.arbiters.push_back(arbiter);
-        env.storage().instance().set(&DataKey::Config, &cfg);
-        Ok(())
+        admin::add_arbiter(env, admin, arbiter)
     }
 
     pub fn submit_drug_price(
@@ -396,29 +94,16 @@ impl HealthcareOracleNetwork {
         availability_units: u32,
         observed_at: u64,
     ) -> Result<u64, Error> {
-        operator.require_auth();
-        let cfg = Self::require_verified_oracle(&env, operator.clone())?;
-
-        if feed_id.len() == 0 || ndc_code.len() == 0 || currency.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        if price_minor <= 0
-            || price_minor > cfg.max_drug_price_minor
-            || availability_units > cfg.max_availability_units
-        {
-            return Err(Error::InvalidData);
-        }
-
-        let payload = FeedPayload::DrugPrice(DrugPriceData {
+        submissions::submit_drug_price(
+            env,
+            operator,
+            feed_id,
             ndc_code,
             currency,
             price_minor,
             availability_units,
             observed_at,
-        });
-
-        Self::submit_payload(env, operator, FeedKind::DrugPricing, feed_id, payload, cfg)
+        )
     }
 
     pub fn submit_clinical_trial(
@@ -432,23 +117,9 @@ impl HealthcareOracleNetwork {
         result_hash: String,
         published_at: u64,
     ) -> Result<u64, Error> {
-        operator.require_auth();
-        let cfg = Self::require_verified_oracle(&env, operator.clone())?;
-
-        if trial_id.len() == 0 || result_hash.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        if phase == 0
-            || phase > 4
-            || enrolled == 0
-            || success_rate_bps > 10_000
-            || adverse_event_rate_bps > 10_000
-        {
-            return Err(Error::InvalidData);
-        }
-
-        let payload = FeedPayload::ClinicalTrial(ClinicalTrialData {
+        submissions::submit_clinical_trial(
+            env,
+            operator,
             trial_id,
             phase,
             enrolled,
@@ -456,15 +127,6 @@ impl HealthcareOracleNetwork {
             adverse_event_rate_bps,
             result_hash,
             published_at,
-        });
-
-        Self::submit_payload(
-            env,
-            operator,
-            FeedKind::ClinicalTrial,
-            payload_feed_id_from_trial(&payload),
-            payload,
-            cfg,
         )
     }
 
@@ -478,29 +140,15 @@ impl HealthcareOracleNetwork {
         details_hash: String,
         effective_at: u64,
     ) -> Result<u64, Error> {
-        operator.require_auth();
-        let cfg = Self::require_verified_oracle(&env, operator.clone())?;
-
-        if regulation_id.len() == 0 || title.len() == 0 || details_hash.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        let payload = FeedPayload::RegulatoryUpdate(RegulatoryUpdateData {
-            regulation_id: regulation_id.clone(),
+        submissions::submit_regulatory_update(
+            env,
+            operator,
+            regulation_id,
             authority,
             status,
             title,
             details_hash,
             effective_at,
-        });
-
-        Self::submit_payload(
-            env,
-            operator,
-            FeedKind::RegulatoryUpdate,
-            regulation_id,
-            payload,
-            cfg,
         )
     }
 
@@ -516,22 +164,9 @@ impl HealthcareOracleNetwork {
         sample_size: u32,
         reported_at: u64,
     ) -> Result<u64, Error> {
-        operator.require_auth();
-        let cfg = Self::require_verified_oracle(&env, operator.clone())?;
-
-        if outcome_id.len() == 0 || condition_code.len() == 0 || treatment_code.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        if improvement_rate_bps > 10_000
-            || readmission_rate_bps > 10_000
-            || mortality_rate_bps > 10_000
-            || sample_size == 0
-        {
-            return Err(Error::InvalidData);
-        }
-
-        let payload = FeedPayload::TreatmentOutcome(TreatmentOutcomeData {
+        submissions::submit_treatment_outcome(
+            env,
+            operator,
             outcome_id,
             condition_code,
             treatment_code,
@@ -540,15 +175,6 @@ impl HealthcareOracleNetwork {
             mortality_rate_bps,
             sample_size,
             reported_at,
-        });
-
-        Self::submit_payload(
-            env,
-            operator,
-            FeedKind::TreatmentOutcome,
-            payload_feed_id_from_outcome(&payload),
-            payload,
-            cfg,
         )
     }
 
@@ -557,14 +183,7 @@ impl HealthcareOracleNetwork {
         kind: FeedKind,
         feed_id: String,
     ) -> Result<ConsensusRecord, Error> {
-        Self::require_initialized(&env)?;
-        if feed_id.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        let key = FeedKey { kind, feed_id };
-        let round_id = Self::active_round_id(&env, key.clone())?;
-        Self::finalize_round(env, key, round_id)
+        submissions::finalize_feed(env, kind, feed_id)
     }
 
     pub fn raise_dispute(
@@ -574,54 +193,7 @@ impl HealthcareOracleNetwork {
         feed_id: String,
         reason: String,
     ) -> Result<u64, Error> {
-        challenger.require_auth();
-        Self::require_initialized(&env)?;
-
-        if reason.len() == 0 || feed_id.len() == 0 {
-            return Err(Error::InvalidData);
-        }
-
-        let key = FeedKey { kind, feed_id };
-        let consensus: ConsensusRecord = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Consensus(key.clone()))
-            .ok_or(Error::ConsensusNotFound)?;
-
-        if consensus.disputed {
-            return Err(Error::InvalidDisputeState);
-        }
-
-        let dispute_id: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::DisputeCount)
-            .unwrap_or(0u64)
-            .saturating_add(1);
-
-        let dispute = Dispute {
-            id: dispute_id,
-            key,
-            round_id: consensus.round_id,
-            challenger,
-            reason,
-            status: DisputeStatus::Open,
-            opened_at: env.ledger().timestamp(),
-            resolved_at: None,
-            resolver: None,
-            ruling: None,
-        };
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Dispute(dispute_id), &dispute);
-        env.storage()
-            .instance()
-            .set(&DataKey::DisputeCount, &dispute_id);
-
-        env.events()
-            .publish((symbol_short!("dispute"),), dispute_id);
-        Ok(dispute_id)
+        disputes::raise_dispute(env, challenger, kind, feed_id, reason)
     }
 
     pub fn resolve_dispute(
@@ -632,602 +204,29 @@ impl HealthcareOracleNetwork {
         ruling: String,
         penalized_oracle: Option<Address>,
     ) -> Result<(), Error> {
-        resolver.require_auth();
-        let cfg: Config = env
-            .storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::NotInitialized)?;
-
-        if resolver != cfg.admin && !cfg.arbiters.contains(&resolver) {
-            return Err(Error::Unauthorized);
-        }
-
-        let mut dispute: Dispute = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Dispute(dispute_id))
-            .ok_or(Error::DisputeNotFound)?;
-
-        if dispute.status != DisputeStatus::Open {
-            return Err(Error::DisputeAlreadyResolved);
-        }
-
-        let mut consensus: ConsensusRecord = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Consensus(dispute.key.clone()))
-            .ok_or(Error::ConsensusNotFound)?;
-
-        if valid_dispute {
-            consensus.disputed = true;
-            dispute.status = DisputeStatus::ResolvedValid;
-
-            if let Some(oracle) = penalized_oracle {
-                Self::adjust_reputation(&env, oracle, -15, true)?;
-            }
-        } else {
-            dispute.status = DisputeStatus::ResolvedInvalid;
-            let mut i = 0;
-            while i < consensus.submitters.len() {
-                let submitter = consensus.submitters.get(i).unwrap();
-                Self::adjust_reputation(&env, submitter, 2, false)?;
-                i += 1;
-            }
-        }
-
-        dispute.resolved_at = Some(env.ledger().timestamp());
-        dispute.resolver = Some(resolver);
-        dispute.ruling = Some(ruling);
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Consensus(dispute.key.clone()), &consensus);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Dispute(dispute_id), &dispute);
-
-        env.events()
-            .publish((symbol_short!("resolve"), dispute_id), valid_dispute);
-
-        Ok(())
+        disputes::resolve_dispute(
+            env,
+            resolver,
+            dispute_id,
+            valid_dispute,
+            ruling,
+            penalized_oracle,
+        )
     }
 
     pub fn get_consensus(env: Env, kind: FeedKind, feed_id: String) -> Option<ConsensusRecord> {
-        let key = FeedKey { kind, feed_id };
-        env.storage().persistent().get(&DataKey::Consensus(key))
+        submissions::get_consensus(env, kind, feed_id)
     }
 
     pub fn get_oracle(env: Env, operator: Address) -> Option<OracleNode> {
-        env.storage().persistent().get(&DataKey::Oracle(operator))
+        oracles::get_oracle(env, operator)
     }
 
     pub fn get_dispute(env: Env, dispute_id: u64) -> Option<Dispute> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Dispute(dispute_id))
+        disputes::get_dispute(env, dispute_id)
     }
 
     pub fn get_config(env: Env) -> Option<Config> {
-        env.storage().instance().get(&DataKey::Config)
-    }
-
-    fn submit_payload(
-        env: Env,
-        operator: Address,
-        kind: FeedKind,
-        feed_id: String,
-        payload: FeedPayload,
-        cfg: Config,
-    ) -> Result<u64, Error> {
-        let key = FeedKey { kind, feed_id };
-        let round_id = Self::ensure_active_round(&env, key.clone())?;
-
-        let sub_key = DataKey::Submission(key.clone(), round_id, operator.clone());
-        if env.storage().persistent().has(&sub_key) {
-            return Err(Error::SubmissionAlreadyExists);
-        }
-
-        env.storage().persistent().set(&sub_key, &payload);
-
-        let mut round: AggregationRound = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Round(key.clone(), round_id))
-            .ok_or(Error::RoundNotFound)?;
-        round.submissions = round.submissions.saturating_add(1);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Round(key.clone(), round_id), &round);
-
-        let mut node = Self::read_oracle(&env, operator.clone())?;
-        node.submissions = node.submissions.saturating_add(1);
-        node.last_seen = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&DataKey::Oracle(operator), &node);
-
-        if round.submissions >= cfg.min_submissions {
-            let _ = Self::finalize_round(env.clone(), key.clone(), round_id)?;
-        }
-
-        Ok(round_id)
-    }
-
-    fn finalize_round(env: Env, key: FeedKey, round_id: u64) -> Result<ConsensusRecord, Error> {
-        let cfg: Config = env
-            .storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::NotInitialized)?;
-
-        let mut round: AggregationRound = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Round(key.clone(), round_id))
-            .ok_or(Error::RoundNotFound)?;
-
-        if round.finalized {
-            return Err(Error::ConsensusAlreadyFinalized);
-        }
-
-        let all_oracles: Vec<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::OracleList)
-            .unwrap_or(Vec::new(&env));
-
-        let mut submitters = Vec::<Address>::new(&env);
-        let mut payloads = Vec::<FeedPayload>::new(&env);
-        let mut weights = Vec::<i128>::new(&env);
-
-        let mut i = 0;
-        while i < all_oracles.len() {
-            let oracle = all_oracles.get(i).unwrap();
-            let node = Self::read_oracle(&env, oracle.clone())?;
-
-            if node.verified && node.active && node.reputation >= cfg.min_reputation {
-                let k = DataKey::Submission(key.clone(), round_id, oracle.clone());
-                if env.storage().persistent().has(&k) {
-                    let payload: FeedPayload = env
-                        .storage()
-                        .persistent()
-                        .get(&k)
-                        .ok_or(Error::InvalidData)?;
-                    submitters.push_back(oracle);
-                    payloads.push_back(payload);
-                    weights.push_back(if node.reputation > 0 {
-                        node.reputation
-                    } else {
-                        1
-                    });
-                }
-            }
-            i += 1;
-        }
-
-        if submitters.len() < cfg.min_submissions {
-            return Err(Error::InsufficientSubmissions);
-        }
-
-        let aggregated = Self::aggregate_payload(
-            &env,
-            key.kind,
-            payloads.clone(),
-            weights.clone(),
-            key.feed_id.clone(),
-        )?;
-
-        let confidence_bps = Self::compute_confidence_bps(submitters.len(), all_oracles.len());
-
-        let consensus = ConsensusRecord {
-            key: key.clone(),
-            payload: aggregated,
-            round_id,
-            finalized_at: env.ledger().timestamp(),
-            submitters: submitters.clone(),
-            confidence_bps,
-            disputed: false,
-        };
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Consensus(key.clone()), &consensus);
-
-        round.finalized = true;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Round(key, round_id), &round);
-
-        Self::reward_and_slash(&env, &consensus, submitters, payloads)?;
-
-        env.events()
-            .publish((symbol_short!("consens"), round_id), confidence_bps);
-
-        Ok(consensus)
-    }
-
-    fn aggregate_payload(
-        env: &Env,
-        kind: FeedKind,
-        payloads: Vec<FeedPayload>,
-        weights: Vec<i128>,
-        feed_id: String,
-    ) -> Result<FeedPayload, Error> {
-        let mut idx = 0;
-        let mut sum_weight = 0i128;
-        while idx < weights.len() {
-            sum_weight = sum_weight.saturating_add(weights.get(idx).unwrap_or(1));
-            idx += 1;
-        }
-
-        if sum_weight <= 0 {
-            return Err(Error::InvalidData);
-        }
-
-        match kind {
-            FeedKind::DrugPricing => {
-                let mut price_weighted = 0i128;
-                let mut avail_weighted = 0i128;
-                let mut observed_at = 0u64;
-                let mut ndc = String::from_str(env, "");
-                let mut ccy = String::from_str(env, "");
-
-                let mut i = 0;
-                while i < payloads.len() {
-                    let w = weights.get(i).unwrap_or(1);
-                    match payloads.get(i).unwrap() {
-                        FeedPayload::DrugPrice(v) => {
-                            if ndc.len() == 0 {
-                                ndc = v.ndc_code.clone();
-                                ccy = v.currency.clone();
-                            }
-                            price_weighted =
-                                price_weighted.saturating_add(v.price_minor.saturating_mul(w));
-                            avail_weighted = avail_weighted
-                                .saturating_add((v.availability_units as i128).saturating_mul(w));
-                            if v.observed_at > observed_at {
-                                observed_at = v.observed_at;
-                            }
-                        }
-                        _ => return Err(Error::InvalidFeedType),
-                    }
-                    i += 1;
-                }
-
-                Ok(FeedPayload::DrugPrice(DrugPriceData {
-                    ndc_code: ndc,
-                    currency: ccy,
-                    price_minor: price_weighted / sum_weight,
-                    availability_units: (avail_weighted / sum_weight) as u32,
-                    observed_at,
-                }))
-            }
-            FeedKind::ClinicalTrial => {
-                let mut phase_weighted = 0i128;
-                let mut enrolled_weighted = 0i128;
-                let mut success_weighted = 0i128;
-                let mut adverse_weighted = 0i128;
-                let mut published_at = 0u64;
-                let mut result_hash = String::from_str(env, "");
-
-                let mut i = 0;
-                while i < payloads.len() {
-                    let w = weights.get(i).unwrap_or(1);
-                    match payloads.get(i).unwrap() {
-                        FeedPayload::ClinicalTrial(v) => {
-                            phase_weighted =
-                                phase_weighted.saturating_add((v.phase as i128).saturating_mul(w));
-                            enrolled_weighted = enrolled_weighted
-                                .saturating_add((v.enrolled as i128).saturating_mul(w));
-                            success_weighted = success_weighted
-                                .saturating_add((v.success_rate_bps as i128).saturating_mul(w));
-                            adverse_weighted = adverse_weighted.saturating_add(
-                                (v.adverse_event_rate_bps as i128).saturating_mul(w),
-                            );
-                            if v.published_at > published_at {
-                                published_at = v.published_at;
-                                result_hash = v.result_hash.clone();
-                            }
-                        }
-                        _ => return Err(Error::InvalidFeedType),
-                    }
-                    i += 1;
-                }
-
-                Ok(FeedPayload::ClinicalTrial(ClinicalTrialData {
-                    trial_id: feed_id,
-                    phase: (phase_weighted / sum_weight) as u32,
-                    enrolled: (enrolled_weighted / sum_weight) as u32,
-                    success_rate_bps: (success_weighted / sum_weight) as u32,
-                    adverse_event_rate_bps: (adverse_weighted / sum_weight) as u32,
-                    result_hash,
-                    published_at,
-                }))
-            }
-            FeedKind::RegulatoryUpdate => {
-                let mut best_weight = -1i128;
-                let mut picked: Option<RegulatoryUpdateData> = None;
-                let mut i = 0;
-                while i < payloads.len() {
-                    let w = weights.get(i).unwrap_or(1);
-                    match payloads.get(i).unwrap() {
-                        FeedPayload::RegulatoryUpdate(v) => {
-                            if w > best_weight {
-                                best_weight = w;
-                                picked = Some(v.clone());
-                            }
-                        }
-                        _ => return Err(Error::InvalidFeedType),
-                    }
-                    i += 1;
-                }
-
-                if let Some(mut value) = picked {
-                    value.regulation_id = feed_id;
-                    Ok(FeedPayload::RegulatoryUpdate(value))
-                } else {
-                    Err(Error::InvalidData)
-                }
-            }
-            FeedKind::TreatmentOutcome => {
-                let mut improvement_weighted = 0i128;
-                let mut readmission_weighted = 0i128;
-                let mut mortality_weighted = 0i128;
-                let mut sample_weighted = 0i128;
-                let mut reported_at = 0u64;
-                let mut condition_code = String::from_str(env, "");
-                let mut treatment_code = String::from_str(env, "");
-
-                let mut i = 0;
-                while i < payloads.len() {
-                    let w = weights.get(i).unwrap_or(1);
-                    match payloads.get(i).unwrap() {
-                        FeedPayload::TreatmentOutcome(v) => {
-                            if condition_code.len() == 0 {
-                                condition_code = v.condition_code.clone();
-                                treatment_code = v.treatment_code.clone();
-                            }
-                            improvement_weighted = improvement_weighted
-                                .saturating_add((v.improvement_rate_bps as i128).saturating_mul(w));
-                            readmission_weighted = readmission_weighted
-                                .saturating_add((v.readmission_rate_bps as i128).saturating_mul(w));
-                            mortality_weighted = mortality_weighted
-                                .saturating_add((v.mortality_rate_bps as i128).saturating_mul(w));
-                            sample_weighted = sample_weighted
-                                .saturating_add((v.sample_size as i128).saturating_mul(w));
-                            if v.reported_at > reported_at {
-                                reported_at = v.reported_at;
-                            }
-                        }
-                        _ => return Err(Error::InvalidFeedType),
-                    }
-                    i += 1;
-                }
-
-                Ok(FeedPayload::TreatmentOutcome(TreatmentOutcomeData {
-                    outcome_id: feed_id,
-                    condition_code,
-                    treatment_code,
-                    improvement_rate_bps: (improvement_weighted / sum_weight) as u32,
-                    readmission_rate_bps: (readmission_weighted / sum_weight) as u32,
-                    mortality_rate_bps: (mortality_weighted / sum_weight) as u32,
-                    sample_size: (sample_weighted / sum_weight) as u32,
-                    reported_at,
-                }))
-            }
-        }
-    }
-
-    fn reward_and_slash(
-        env: &Env,
-        consensus: &ConsensusRecord,
-        submitters: Vec<Address>,
-        payloads: Vec<FeedPayload>,
-    ) -> Result<(), Error> {
-        let mut i = 0;
-        while i < submitters.len() {
-            let submitter = submitters.get(i).unwrap();
-            let payload = payloads.get(i).unwrap();
-            let delta = Self::reputation_delta(consensus.payload.clone(), payload);
-            Self::adjust_reputation(env, submitter, delta, delta < 0)?;
-            i += 1;
-        }
-        Ok(())
-    }
-
-    fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
-        match (consensus, payload) {
-            (FeedPayload::DrugPrice(c), FeedPayload::DrugPrice(p)) => {
-                if c.price_minor <= 0 {
-                    return 1;
-                }
-                let diff = if p.price_minor > c.price_minor {
-                    p.price_minor.saturating_sub(c.price_minor)
-                } else {
-                    c.price_minor.saturating_sub(p.price_minor)
-                };
-                let bps = diff.saturating_mul(10_000) / c.price_minor;
-                if bps <= 500 {
-                    5
-                } else {
-                    -3
-                }
-            }
-            (FeedPayload::ClinicalTrial(c), FeedPayload::ClinicalTrial(p)) => {
-                let diff = if p.success_rate_bps > c.success_rate_bps {
-                    p.success_rate_bps.saturating_sub(c.success_rate_bps)
-                } else {
-                    c.success_rate_bps.saturating_sub(p.success_rate_bps)
-                };
-                if diff <= 700 {
-                    4
-                } else {
-                    -2
-                }
-            }
-            (FeedPayload::RegulatoryUpdate(c), FeedPayload::RegulatoryUpdate(p)) => {
-                if c.status == p.status {
-                    4
-                } else {
-                    -4
-                }
-            }
-            (FeedPayload::TreatmentOutcome(c), FeedPayload::TreatmentOutcome(p)) => {
-                let diff = if p.improvement_rate_bps > c.improvement_rate_bps {
-                    p.improvement_rate_bps
-                        .saturating_sub(c.improvement_rate_bps)
-                } else {
-                    c.improvement_rate_bps
-                        .saturating_sub(p.improvement_rate_bps)
-                };
-                if diff <= 700 {
-                    4
-                } else {
-                    -2
-                }
-            }
-            _ => -5,
-        }
-    }
-
-    fn adjust_reputation(
-        env: &Env,
-        operator: Address,
-        delta: i128,
-        is_dispute: bool,
-    ) -> Result<(), Error> {
-        let mut node = Self::read_oracle(env, operator.clone())?;
-        node.reputation = node.reputation.saturating_add(delta);
-        if node.reputation < 0 {
-            node.reputation = 0;
-        }
-        if is_dispute {
-            node.disputes = node.disputes.saturating_add(1);
-        }
-        node.last_seen = env.ledger().timestamp();
-        env.storage()
-            .persistent()
-            .set(&DataKey::Oracle(operator), &node);
-        Ok(())
-    }
-
-    fn ensure_active_round(env: &Env, key: FeedKey) -> Result<u64, Error> {
-        if let Ok(id) = Self::active_round_id(env, key.clone()) {
-            return Ok(id);
-        }
-
-        let next_id = env
-            .storage()
-            .persistent()
-            .get(&DataKey::RoundCounter(key.clone()))
-            .unwrap_or(0u64)
-            .saturating_add(1);
-
-        let round = AggregationRound {
-            id: next_id,
-            started_at: env.ledger().timestamp(),
-            finalized: false,
-            submissions: 0,
-        };
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::RoundCounter(key.clone()), &next_id);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Round(key, next_id), &round);
-
-        Ok(next_id)
-    }
-
-    fn active_round_id(env: &Env, key: FeedKey) -> Result<u64, Error> {
-        let latest: u64 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::RoundCounter(key.clone()))
-            .ok_or(Error::RoundNotFound)?;
-
-        let round: AggregationRound = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Round(key, latest))
-            .ok_or(Error::RoundNotFound)?;
-
-        if round.finalized {
-            return Err(Error::RoundNotFound);
-        }
-
-        Ok(latest)
-    }
-
-    fn require_initialized(env: &Env) -> Result<(), Error> {
-        if !env.storage().instance().has(&DataKey::Config) {
-            return Err(Error::NotInitialized);
-        }
-        Ok(())
-    }
-
-    fn require_admin(env: &Env, admin: Address) -> Result<(), Error> {
-        admin.require_auth();
-        let cfg: Config = env
-            .storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::NotInitialized)?;
-
-        if cfg.admin != admin {
-            return Err(Error::Unauthorized);
-        }
-        Ok(())
-    }
-
-    fn require_verified_oracle(env: &Env, operator: Address) -> Result<Config, Error> {
-        let cfg: Config = env
-            .storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::NotInitialized)?;
-
-        let node = Self::read_oracle(env, operator)?;
-        if !node.verified {
-            return Err(Error::OracleNotVerified);
-        }
-        if !node.active {
-            return Err(Error::OracleInactive);
-        }
-        Ok(cfg)
-    }
-
-    fn read_oracle(env: &Env, operator: Address) -> Result<OracleNode, Error> {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Oracle(operator))
-            .ok_or(Error::OracleNotFound)
-    }
-
-    fn compute_confidence_bps(submitters: u32, total_oracles: u32) -> u32 {
-        if total_oracles == 0 {
-            return 0;
-        }
-        let mut score = (submitters.saturating_mul(10_000)) / total_oracles;
-        if score > 10_000 {
-            score = 10_000;
-        }
-        score
-    }
-}
-
-fn payload_feed_id_from_trial(payload: &FeedPayload) -> String {
-    match payload {
-        FeedPayload::ClinicalTrial(data) => data.trial_id.clone(),
-        _ => unreachable!(),
-    }
-}
-
-fn payload_feed_id_from_outcome(payload: &FeedPayload) -> String {
-    match payload {
-        FeedPayload::TreatmentOutcome(data) => data.outcome_id.clone(),
-        _ => unreachable!(),
+        admin::get_config(env)
     }
 }

--- a/contracts/healthcare_oracle_network/src/oracles.rs
+++ b/contracts/healthcare_oracle_network/src/oracles.rs
@@ -69,11 +69,7 @@ pub fn verify_oracle(
     Ok(())
 }
 
-pub fn update_oracle_endpoint(
-    env: Env,
-    operator: Address,
-    endpoint: String,
-) -> Result<(), Error> {
+pub fn update_oracle_endpoint(env: Env, operator: Address, endpoint: String) -> Result<(), Error> {
     operator.require_auth();
 
     if endpoint.len() == 0 {

--- a/contracts/healthcare_oracle_network/src/oracles.rs
+++ b/contracts/healthcare_oracle_network/src/oracles.rs
@@ -1,0 +1,94 @@
+use soroban_sdk::{Address, Env, String, Vec};
+
+use crate::types::{DataKey, Error, OracleNode, SourceType};
+use crate::utils;
+
+pub fn register_oracle(
+    env: Env,
+    operator: Address,
+    endpoint: String,
+    source_type: SourceType,
+) -> Result<(), Error> {
+    operator.require_auth();
+    utils::require_initialized(&env)?;
+
+    if endpoint.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::Oracle(operator.clone()))
+    {
+        return Err(Error::OracleAlreadyRegistered);
+    }
+
+    let mut oracles: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKey::OracleList)
+        .unwrap_or(Vec::new(&env));
+    oracles.push_back(operator.clone());
+
+    let node = OracleNode {
+        operator: operator.clone(),
+        endpoint,
+        source_type,
+        verified: false,
+        active: true,
+        reputation: 50,
+        submissions: 0,
+        disputes: 0,
+        last_seen: env.ledger().timestamp(),
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Oracle(operator), &node);
+    env.storage().instance().set(&DataKey::OracleList, &oracles);
+    Ok(())
+}
+
+pub fn verify_oracle(
+    env: Env,
+    admin: Address,
+    operator: Address,
+    verified: bool,
+    active: bool,
+) -> Result<(), Error> {
+    utils::require_admin(&env, admin)?;
+
+    let mut node = utils::read_oracle(&env, operator.clone())?;
+    node.verified = verified;
+    node.active = active;
+    node.last_seen = env.ledger().timestamp();
+    env.storage()
+        .persistent()
+        .set(&DataKey::Oracle(operator), &node);
+    Ok(())
+}
+
+pub fn update_oracle_endpoint(
+    env: Env,
+    operator: Address,
+    endpoint: String,
+) -> Result<(), Error> {
+    operator.require_auth();
+
+    if endpoint.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    let mut node = utils::read_oracle(&env, operator.clone())?;
+    node.endpoint = endpoint;
+    node.last_seen = env.ledger().timestamp();
+    env.storage()
+        .persistent()
+        .set(&DataKey::Oracle(operator), &node);
+    Ok(())
+}
+
+pub fn get_oracle(env: Env, operator: Address) -> Option<OracleNode> {
+    env.storage().persistent().get(&DataKey::Oracle(operator))
+}

--- a/contracts/healthcare_oracle_network/src/submissions.rs
+++ b/contracts/healthcare_oracle_network/src/submissions.rs
@@ -1,0 +1,185 @@
+use soroban_sdk::{Address, Env, String};
+
+use crate::types::{
+    ClinicalTrialData, ConsensusRecord, DataKey, DrugPriceData, Error, FeedKey, FeedKind,
+    FeedPayload, RegulatoryAuthority, RegulatoryStatus, RegulatoryUpdateData,
+    TreatmentOutcomeData,
+};
+use crate::utils;
+
+pub fn submit_drug_price(
+    env: Env,
+    operator: Address,
+    feed_id: String,
+    ndc_code: String,
+    currency: String,
+    price_minor: i128,
+    availability_units: u32,
+    observed_at: u64,
+) -> Result<u64, Error> {
+    operator.require_auth();
+    let config = utils::require_verified_oracle(&env, operator.clone())?;
+
+    if feed_id.len() == 0 || ndc_code.len() == 0 || currency.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    if price_minor <= 0
+        || price_minor > config.max_drug_price_minor
+        || availability_units > config.max_availability_units
+    {
+        return Err(Error::InvalidData);
+    }
+
+    let payload = FeedPayload::DrugPrice(DrugPriceData {
+        ndc_code,
+        currency,
+        price_minor,
+        availability_units,
+        observed_at,
+    });
+
+    utils::submit_payload(env, operator, FeedKind::DrugPricing, feed_id, payload, config)
+}
+
+pub fn submit_clinical_trial(
+    env: Env,
+    operator: Address,
+    trial_id: String,
+    phase: u32,
+    enrolled: u32,
+    success_rate_bps: u32,
+    adverse_event_rate_bps: u32,
+    result_hash: String,
+    published_at: u64,
+) -> Result<u64, Error> {
+    operator.require_auth();
+    let config = utils::require_verified_oracle(&env, operator.clone())?;
+
+    if trial_id.len() == 0 || result_hash.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    if phase == 0
+        || phase > 4
+        || enrolled == 0
+        || success_rate_bps > 10_000
+        || adverse_event_rate_bps > 10_000
+    {
+        return Err(Error::InvalidData);
+    }
+
+    let payload = FeedPayload::ClinicalTrial(ClinicalTrialData {
+        trial_id,
+        phase,
+        enrolled,
+        success_rate_bps,
+        adverse_event_rate_bps,
+        result_hash,
+        published_at,
+    });
+
+    let feed_id = utils::payload_feed_id_from_trial(&payload);
+    utils::submit_payload(env, operator, FeedKind::ClinicalTrial, feed_id, payload, config)
+}
+
+pub fn submit_regulatory_update(
+    env: Env,
+    operator: Address,
+    regulation_id: String,
+    authority: RegulatoryAuthority,
+    status: RegulatoryStatus,
+    title: String,
+    details_hash: String,
+    effective_at: u64,
+) -> Result<u64, Error> {
+    operator.require_auth();
+    let config = utils::require_verified_oracle(&env, operator.clone())?;
+
+    if regulation_id.len() == 0 || title.len() == 0 || details_hash.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    let payload = FeedPayload::RegulatoryUpdate(RegulatoryUpdateData {
+        regulation_id: regulation_id.clone(),
+        authority,
+        status,
+        title,
+        details_hash,
+        effective_at,
+    });
+
+    utils::submit_payload(
+        env,
+        operator,
+        FeedKind::RegulatoryUpdate,
+        regulation_id,
+        payload,
+        config,
+    )
+}
+
+pub fn submit_treatment_outcome(
+    env: Env,
+    operator: Address,
+    outcome_id: String,
+    condition_code: String,
+    treatment_code: String,
+    improvement_rate_bps: u32,
+    readmission_rate_bps: u32,
+    mortality_rate_bps: u32,
+    sample_size: u32,
+    reported_at: u64,
+) -> Result<u64, Error> {
+    operator.require_auth();
+    let config = utils::require_verified_oracle(&env, operator.clone())?;
+
+    if outcome_id.len() == 0 || condition_code.len() == 0 || treatment_code.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    if improvement_rate_bps > 10_000
+        || readmission_rate_bps > 10_000
+        || mortality_rate_bps > 10_000
+        || sample_size == 0
+    {
+        return Err(Error::InvalidData);
+    }
+
+    let payload = FeedPayload::TreatmentOutcome(TreatmentOutcomeData {
+        outcome_id,
+        condition_code,
+        treatment_code,
+        improvement_rate_bps,
+        readmission_rate_bps,
+        mortality_rate_bps,
+        sample_size,
+        reported_at,
+    });
+
+    let feed_id = utils::payload_feed_id_from_outcome(&payload);
+    utils::submit_payload(
+        env,
+        operator,
+        FeedKind::TreatmentOutcome,
+        feed_id,
+        payload,
+        config,
+    )
+}
+
+pub fn finalize_feed(env: Env, kind: FeedKind, feed_id: String) -> Result<ConsensusRecord, Error> {
+    utils::require_initialized(&env)?;
+    if feed_id.len() == 0 {
+        return Err(Error::InvalidData);
+    }
+
+    let key = FeedKey { kind, feed_id };
+    let round_id = utils::active_round_id(&env, key.clone())?;
+    utils::finalize_round(env, key, round_id)
+}
+
+pub fn get_consensus(env: Env, kind: FeedKind, feed_id: String) -> Option<ConsensusRecord> {
+    let key = FeedKey { kind, feed_id };
+    env.storage().persistent().get(&DataKey::Consensus(key))
+}

--- a/contracts/healthcare_oracle_network/src/submissions.rs
+++ b/contracts/healthcare_oracle_network/src/submissions.rs
@@ -2,8 +2,7 @@ use soroban_sdk::{Address, Env, String};
 
 use crate::types::{
     ClinicalTrialData, ConsensusRecord, DataKey, DrugPriceData, Error, FeedKey, FeedKind,
-    FeedPayload, RegulatoryAuthority, RegulatoryStatus, RegulatoryUpdateData,
-    TreatmentOutcomeData,
+    FeedPayload, RegulatoryAuthority, RegulatoryStatus, RegulatoryUpdateData, TreatmentOutcomeData,
 };
 use crate::utils;
 
@@ -39,7 +38,14 @@ pub fn submit_drug_price(
         observed_at,
     });
 
-    utils::submit_payload(env, operator, FeedKind::DrugPricing, feed_id, payload, config)
+    utils::submit_payload(
+        env,
+        operator,
+        FeedKind::DrugPricing,
+        feed_id,
+        payload,
+        config,
+    )
 }
 
 pub fn submit_clinical_trial(
@@ -80,7 +86,14 @@ pub fn submit_clinical_trial(
     });
 
     let feed_id = utils::payload_feed_id_from_trial(&payload);
-    utils::submit_payload(env, operator, FeedKind::ClinicalTrial, feed_id, payload, config)
+    utils::submit_payload(
+        env,
+        operator,
+        FeedKind::ClinicalTrial,
+        feed_id,
+        payload,
+        config,
+    )
 }
 
 pub fn submit_regulatory_update(

--- a/contracts/healthcare_oracle_network/src/types.rs
+++ b/contracts/healthcare_oracle_network/src/types.rs
@@ -1,0 +1,210 @@
+use soroban_sdk::{contracterror, contracttype, Address, String, Vec};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    OracleAlreadyRegistered = 4,
+    OracleNotFound = 5,
+    OracleNotVerified = 6,
+    OracleInactive = 7,
+    InvalidData = 8,
+    SubmissionAlreadyExists = 9,
+    RoundNotFound = 10,
+    InsufficientSubmissions = 11,
+    ConsensusAlreadyFinalized = 12,
+    ConsensusNotFound = 13,
+    DisputeNotFound = 14,
+    DisputeAlreadyResolved = 15,
+    InvalidDisputeState = 16,
+    InvalidFeedType = 17,
+    ArbiterExists = 18,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum FeedKind {
+    DrugPricing = 1,
+    ClinicalTrial = 2,
+    RegulatoryUpdate = 3,
+    TreatmentOutcome = 4,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum SourceType {
+    PharmaSupplier = 1,
+    ClinicalRegistry = 2,
+    RegulatoryBody = 3,
+    MarketAggregator = 4,
+    HospitalNetwork = 5,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum RegulatoryAuthority {
+    FDA = 1,
+    EMA = 2,
+    MHRA = 3,
+    PMDA = 4,
+    WHO = 5,
+    CDSCO = 6,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum RegulatoryStatus {
+    Approved = 1,
+    SafetyWarning = 2,
+    Recall = 3,
+    GuidelineUpdate = 4,
+    TrialHold = 5,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum DisputeStatus {
+    Open = 1,
+    ResolvedValid = 2,
+    ResolvedInvalid = 3,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct FeedKey {
+    pub kind: FeedKind,
+    pub feed_id: String,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct DrugPriceData {
+    pub ndc_code: String,
+    pub currency: String,
+    pub price_minor: i128,
+    pub availability_units: u32,
+    pub observed_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ClinicalTrialData {
+    pub trial_id: String,
+    pub phase: u32,
+    pub enrolled: u32,
+    pub success_rate_bps: u32,
+    pub adverse_event_rate_bps: u32,
+    pub result_hash: String,
+    pub published_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct TreatmentOutcomeData {
+    pub outcome_id: String,
+    pub condition_code: String,
+    pub treatment_code: String,
+    pub improvement_rate_bps: u32,
+    pub readmission_rate_bps: u32,
+    pub mortality_rate_bps: u32,
+    pub sample_size: u32,
+    pub reported_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct RegulatoryUpdateData {
+    pub regulation_id: String,
+    pub authority: RegulatoryAuthority,
+    pub status: RegulatoryStatus,
+    pub title: String,
+    pub details_hash: String,
+    pub effective_at: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum FeedPayload {
+    DrugPrice(DrugPriceData),
+    ClinicalTrial(ClinicalTrialData),
+    RegulatoryUpdate(RegulatoryUpdateData),
+    TreatmentOutcome(TreatmentOutcomeData),
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct OracleNode {
+    pub operator: Address,
+    pub endpoint: String,
+    pub source_type: SourceType,
+    pub verified: bool,
+    pub active: bool,
+    pub reputation: i128,
+    pub submissions: u32,
+    pub disputes: u32,
+    pub last_seen: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Config {
+    pub admin: Address,
+    pub arbiters: Vec<Address>,
+    pub min_submissions: u32,
+    pub min_reputation: i128,
+    pub max_drug_price_minor: i128,
+    pub max_availability_units: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct AggregationRound {
+    pub id: u64,
+    pub started_at: u64,
+    pub finalized: bool,
+    pub submissions: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct ConsensusRecord {
+    pub key: FeedKey,
+    pub payload: FeedPayload,
+    pub round_id: u64,
+    pub finalized_at: u64,
+    pub submitters: Vec<Address>,
+    pub confidence_bps: u32,
+    pub disputed: bool,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct Dispute {
+    pub id: u64,
+    pub key: FeedKey,
+    pub round_id: u64,
+    pub challenger: Address,
+    pub reason: String,
+    pub status: DisputeStatus,
+    pub opened_at: u64,
+    pub resolved_at: Option<u64>,
+    pub resolver: Option<Address>,
+    pub ruling: Option<String>,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Oracle(Address),
+    OracleList,
+    RoundCounter(FeedKey),
+    Round(FeedKey, u64),
+    Submission(FeedKey, u64, Address),
+    Consensus(FeedKey),
+    DisputeCount,
+    Dispute(u64),
+}

--- a/contracts/healthcare_oracle_network/src/utils.rs
+++ b/contracts/healthcare_oracle_network/src/utils.rs
@@ -1,0 +1,535 @@
+use soroban_sdk::{symbol_short, Address, Env, String, Vec};
+
+use crate::types::{
+    AggregationRound, Config, ConsensusRecord, DataKey, Error, FeedKey, FeedKind, FeedPayload,
+    OracleNode, RegulatoryUpdateData, TreatmentOutcomeData, DrugPriceData, ClinicalTrialData,
+};
+
+pub fn payload_feed_id_from_trial(payload: &FeedPayload) -> String {
+    match payload {
+        FeedPayload::ClinicalTrial(data) => data.trial_id.clone(),
+        _ => unreachable!(),
+    }
+}
+
+pub fn payload_feed_id_from_outcome(payload: &FeedPayload) -> String {
+    match payload {
+        FeedPayload::TreatmentOutcome(data) => data.outcome_id.clone(),
+        _ => unreachable!(),
+    }
+}
+
+pub fn require_initialized(env: &Env) -> Result<(), Error> {
+    if !env.storage().instance().has(&DataKey::Config) {
+        return Err(Error::NotInitialized);
+    }
+    Ok(())
+}
+
+pub fn require_admin(env: &Env, admin: Address) -> Result<(), Error> {
+    admin.require_auth();
+    let cfg: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)?;
+
+    if cfg.admin != admin {
+        return Err(Error::Unauthorized);
+    }
+
+    Ok(())
+}
+
+pub fn require_verified_oracle(env: &Env, operator: Address) -> Result<Config, Error> {
+    let cfg: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)?;
+
+    let node = read_oracle(env, operator)?;
+    if !node.verified {
+        return Err(Error::OracleNotVerified);
+    }
+    if !node.active {
+        return Err(Error::OracleInactive);
+    }
+
+    Ok(cfg)
+}
+
+pub fn read_oracle(env: &Env, operator: Address) -> Result<OracleNode, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Oracle(operator))
+        .ok_or(Error::OracleNotFound)
+}
+
+pub fn submit_payload(
+    env: Env,
+    operator: Address,
+    kind: FeedKind,
+    feed_id: String,
+    payload: FeedPayload,
+    cfg: Config,
+) -> Result<u64, Error> {
+    let key = FeedKey { kind, feed_id };
+    let round_id = ensure_active_round(&env, key.clone())?;
+
+    let submission_key = DataKey::Submission(key.clone(), round_id, operator.clone());
+    if env.storage().persistent().has(&submission_key) {
+        return Err(Error::SubmissionAlreadyExists);
+    }
+
+    env.storage().persistent().set(&submission_key, &payload);
+
+    let mut round: AggregationRound = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Round(key.clone(), round_id))
+        .ok_or(Error::RoundNotFound)?;
+    round.submissions = round.submissions.saturating_add(1);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Round(key.clone(), round_id), &round);
+
+    let mut node = read_oracle(&env, operator.clone())?;
+    node.submissions = node.submissions.saturating_add(1);
+    node.last_seen = env.ledger().timestamp();
+    env.storage()
+        .persistent()
+        .set(&DataKey::Oracle(operator), &node);
+
+    if round.submissions >= cfg.min_submissions {
+        let _ = finalize_round(env.clone(), key.clone(), round_id)?;
+    }
+
+    Ok(round_id)
+}
+
+pub fn finalize_round(env: Env, key: FeedKey, round_id: u64) -> Result<ConsensusRecord, Error> {
+    let cfg: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::NotInitialized)?;
+
+    let mut round: AggregationRound = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Round(key.clone(), round_id))
+        .ok_or(Error::RoundNotFound)?;
+
+    if round.finalized {
+        return Err(Error::ConsensusAlreadyFinalized);
+    }
+
+    let all_oracles: Vec<Address> = env
+        .storage()
+        .instance()
+        .get(&DataKey::OracleList)
+        .unwrap_or(Vec::new(&env));
+
+    let mut submitters = Vec::<Address>::new(&env);
+    let mut payloads = Vec::<FeedPayload>::new(&env);
+    let mut weights = Vec::<i128>::new(&env);
+
+    let mut i = 0;
+    while i < all_oracles.len() {
+        let oracle = all_oracles.get(i).unwrap();
+        let node = read_oracle(&env, oracle.clone())?;
+
+        if node.verified && node.active && node.reputation >= cfg.min_reputation {
+            let submission_key = DataKey::Submission(key.clone(), round_id, oracle.clone());
+            if env.storage().persistent().has(&submission_key) {
+                let payload: FeedPayload = env
+                    .storage()
+                    .persistent()
+                    .get(&submission_key)
+                    .ok_or(Error::InvalidData)?;
+                submitters.push_back(oracle);
+                payloads.push_back(payload);
+                weights.push_back(if node.reputation > 0 { node.reputation } else { 1 });
+            }
+        }
+        i += 1;
+    }
+
+    if submitters.len() < cfg.min_submissions {
+        return Err(Error::InsufficientSubmissions);
+    }
+
+    let aggregated = aggregate_payload(
+        &env,
+        key.kind,
+        payloads.clone(),
+        weights.clone(),
+        key.feed_id.clone(),
+    )?;
+
+    let confidence_bps = compute_confidence_bps(submitters.len(), all_oracles.len());
+    let consensus = ConsensusRecord {
+        key: key.clone(),
+        payload: aggregated,
+        round_id,
+        finalized_at: env.ledger().timestamp(),
+        submitters: submitters.clone(),
+        confidence_bps,
+        disputed: false,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Consensus(key.clone()), &consensus);
+
+    round.finalized = true;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Round(key, round_id), &round);
+
+    reward_and_slash(&env, &consensus, submitters, payloads)?;
+
+    env.events()
+        .publish((symbol_short!("consens"), round_id), confidence_bps);
+
+    Ok(consensus)
+}
+
+pub fn aggregate_payload(
+    env: &Env,
+    kind: FeedKind,
+    payloads: Vec<FeedPayload>,
+    weights: Vec<i128>,
+    feed_id: String,
+) -> Result<FeedPayload, Error> {
+    let mut index = 0;
+    let mut sum_weight = 0i128;
+    while index < weights.len() {
+        sum_weight = sum_weight.saturating_add(weights.get(index).unwrap_or(1));
+        index += 1;
+    }
+
+    if sum_weight <= 0 {
+        return Err(Error::InvalidData);
+    }
+
+    match kind {
+        FeedKind::DrugPricing => {
+            let mut price_weighted = 0i128;
+            let mut availability_weighted = 0i128;
+            let mut observed_at = 0u64;
+            let mut ndc_code = String::from_str(env, "");
+            let mut currency = String::from_str(env, "");
+
+            let mut i = 0;
+            while i < payloads.len() {
+                let weight = weights.get(i).unwrap_or(1);
+                match payloads.get(i).unwrap() {
+                    FeedPayload::DrugPrice(value) => {
+                        if ndc_code.len() == 0 {
+                            ndc_code = value.ndc_code.clone();
+                            currency = value.currency.clone();
+                        }
+                        price_weighted = price_weighted
+                            .saturating_add(value.price_minor.saturating_mul(weight));
+                        availability_weighted = availability_weighted.saturating_add(
+                            (value.availability_units as i128).saturating_mul(weight),
+                        );
+                        if value.observed_at > observed_at {
+                            observed_at = value.observed_at;
+                        }
+                    }
+                    _ => return Err(Error::InvalidFeedType),
+                }
+                i += 1;
+            }
+
+            Ok(FeedPayload::DrugPrice(DrugPriceData {
+                ndc_code,
+                currency,
+                price_minor: price_weighted / sum_weight,
+                availability_units: (availability_weighted / sum_weight) as u32,
+                observed_at,
+            }))
+        }
+        FeedKind::ClinicalTrial => {
+            let mut phase_weighted = 0i128;
+            let mut enrolled_weighted = 0i128;
+            let mut success_weighted = 0i128;
+            let mut adverse_weighted = 0i128;
+            let mut published_at = 0u64;
+            let mut result_hash = String::from_str(env, "");
+
+            let mut i = 0;
+            while i < payloads.len() {
+                let weight = weights.get(i).unwrap_or(1);
+                match payloads.get(i).unwrap() {
+                    FeedPayload::ClinicalTrial(value) => {
+                        phase_weighted = phase_weighted
+                            .saturating_add((value.phase as i128).saturating_mul(weight));
+                        enrolled_weighted = enrolled_weighted
+                            .saturating_add((value.enrolled as i128).saturating_mul(weight));
+                        success_weighted = success_weighted.saturating_add(
+                            (value.success_rate_bps as i128).saturating_mul(weight),
+                        );
+                        adverse_weighted = adverse_weighted.saturating_add(
+                            (value.adverse_event_rate_bps as i128).saturating_mul(weight),
+                        );
+                        if value.published_at > published_at {
+                            published_at = value.published_at;
+                            result_hash = value.result_hash.clone();
+                        }
+                    }
+                    _ => return Err(Error::InvalidFeedType),
+                }
+                i += 1;
+            }
+
+            Ok(FeedPayload::ClinicalTrial(ClinicalTrialData {
+                trial_id: feed_id,
+                phase: (phase_weighted / sum_weight) as u32,
+                enrolled: (enrolled_weighted / sum_weight) as u32,
+                success_rate_bps: (success_weighted / sum_weight) as u32,
+                adverse_event_rate_bps: (adverse_weighted / sum_weight) as u32,
+                result_hash,
+                published_at,
+            }))
+        }
+        FeedKind::RegulatoryUpdate => {
+            let mut best_weight = -1i128;
+            let mut picked: Option<RegulatoryUpdateData> = None;
+            let mut i = 0;
+            while i < payloads.len() {
+                let weight = weights.get(i).unwrap_or(1);
+                match payloads.get(i).unwrap() {
+                    FeedPayload::RegulatoryUpdate(value) => {
+                        if weight > best_weight {
+                            best_weight = weight;
+                            picked = Some(value.clone());
+                        }
+                    }
+                    _ => return Err(Error::InvalidFeedType),
+                }
+                i += 1;
+            }
+
+            if let Some(mut value) = picked {
+                value.regulation_id = feed_id;
+                Ok(FeedPayload::RegulatoryUpdate(value))
+            } else {
+                Err(Error::InvalidData)
+            }
+        }
+        FeedKind::TreatmentOutcome => {
+            let mut improvement_weighted = 0i128;
+            let mut readmission_weighted = 0i128;
+            let mut mortality_weighted = 0i128;
+            let mut sample_weighted = 0i128;
+            let mut reported_at = 0u64;
+            let mut condition_code = String::from_str(env, "");
+            let mut treatment_code = String::from_str(env, "");
+
+            let mut i = 0;
+            while i < payloads.len() {
+                let weight = weights.get(i).unwrap_or(1);
+                match payloads.get(i).unwrap() {
+                    FeedPayload::TreatmentOutcome(value) => {
+                        if condition_code.len() == 0 {
+                            condition_code = value.condition_code.clone();
+                            treatment_code = value.treatment_code.clone();
+                        }
+                        improvement_weighted = improvement_weighted.saturating_add(
+                            (value.improvement_rate_bps as i128).saturating_mul(weight),
+                        );
+                        readmission_weighted = readmission_weighted.saturating_add(
+                            (value.readmission_rate_bps as i128).saturating_mul(weight),
+                        );
+                        mortality_weighted = mortality_weighted.saturating_add(
+                            (value.mortality_rate_bps as i128).saturating_mul(weight),
+                        );
+                        sample_weighted = sample_weighted
+                            .saturating_add((value.sample_size as i128).saturating_mul(weight));
+                        if value.reported_at > reported_at {
+                            reported_at = value.reported_at;
+                        }
+                    }
+                    _ => return Err(Error::InvalidFeedType),
+                }
+                i += 1;
+            }
+
+            Ok(FeedPayload::TreatmentOutcome(TreatmentOutcomeData {
+                outcome_id: feed_id,
+                condition_code,
+                treatment_code,
+                improvement_rate_bps: (improvement_weighted / sum_weight) as u32,
+                readmission_rate_bps: (readmission_weighted / sum_weight) as u32,
+                mortality_rate_bps: (mortality_weighted / sum_weight) as u32,
+                sample_size: (sample_weighted / sum_weight) as u32,
+                reported_at,
+            }))
+        }
+    }
+}
+
+pub fn reward_and_slash(
+    env: &Env,
+    consensus: &ConsensusRecord,
+    submitters: Vec<Address>,
+    payloads: Vec<FeedPayload>,
+) -> Result<(), Error> {
+    let mut i = 0;
+    while i < submitters.len() {
+        let submitter = submitters.get(i).unwrap();
+        let payload = payloads.get(i).unwrap();
+        let delta = reputation_delta(consensus.payload.clone(), payload);
+        adjust_reputation(env, submitter, delta, delta < 0)?;
+        i += 1;
+    }
+    Ok(())
+}
+
+pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
+    match (consensus, payload) {
+        (FeedPayload::DrugPrice(consensus_data), FeedPayload::DrugPrice(payload_data)) => {
+            if consensus_data.price_minor <= 0 {
+                return 1;
+            }
+            let diff = if payload_data.price_minor > consensus_data.price_minor {
+                payload_data
+                    .price_minor
+                    .saturating_sub(consensus_data.price_minor)
+            } else {
+                consensus_data
+                    .price_minor
+                    .saturating_sub(payload_data.price_minor)
+            };
+            let bps = diff.saturating_mul(10_000) / consensus_data.price_minor;
+            if bps <= 500 { 5 } else { -3 }
+        }
+        (
+            FeedPayload::ClinicalTrial(consensus_data),
+            FeedPayload::ClinicalTrial(payload_data),
+        ) => {
+            let diff = if payload_data.success_rate_bps > consensus_data.success_rate_bps {
+                payload_data
+                    .success_rate_bps
+                    .saturating_sub(consensus_data.success_rate_bps)
+            } else {
+                consensus_data
+                    .success_rate_bps
+                    .saturating_sub(payload_data.success_rate_bps)
+            };
+            if diff <= 700 { 4 } else { -2 }
+        }
+        (
+            FeedPayload::RegulatoryUpdate(consensus_data),
+            FeedPayload::RegulatoryUpdate(payload_data),
+        ) => {
+            if consensus_data.status == payload_data.status {
+                4
+            } else {
+                -4
+            }
+        }
+        (
+            FeedPayload::TreatmentOutcome(consensus_data),
+            FeedPayload::TreatmentOutcome(payload_data),
+        ) => {
+            let diff = if payload_data.improvement_rate_bps > consensus_data.improvement_rate_bps {
+                payload_data
+                    .improvement_rate_bps
+                    .saturating_sub(consensus_data.improvement_rate_bps)
+            } else {
+                consensus_data
+                    .improvement_rate_bps
+                    .saturating_sub(payload_data.improvement_rate_bps)
+            };
+            if diff <= 700 { 4 } else { -2 }
+        }
+        _ => -5,
+    }
+}
+
+pub fn adjust_reputation(
+    env: &Env,
+    operator: Address,
+    delta: i128,
+    is_dispute: bool,
+) -> Result<(), Error> {
+    let mut node = read_oracle(env, operator.clone())?;
+    node.reputation = node.reputation.saturating_add(delta);
+    if node.reputation < 0 {
+        node.reputation = 0;
+    }
+    if is_dispute {
+        node.disputes = node.disputes.saturating_add(1);
+    }
+    node.last_seen = env.ledger().timestamp();
+    env.storage()
+        .persistent()
+        .set(&DataKey::Oracle(operator), &node);
+    Ok(())
+}
+
+pub fn ensure_active_round(env: &Env, key: FeedKey) -> Result<u64, Error> {
+    if let Ok(round_id) = active_round_id(env, key.clone()) {
+        return Ok(round_id);
+    }
+
+    let next_id = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RoundCounter(key.clone()))
+        .unwrap_or(0u64)
+        .saturating_add(1);
+
+    let round = AggregationRound {
+        id: next_id,
+        started_at: env.ledger().timestamp(),
+        finalized: false,
+        submissions: 0,
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::RoundCounter(key.clone()), &next_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Round(key, next_id), &round);
+
+    Ok(next_id)
+}
+
+pub fn active_round_id(env: &Env, key: FeedKey) -> Result<u64, Error> {
+    let latest: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RoundCounter(key.clone()))
+        .ok_or(Error::RoundNotFound)?;
+
+    let round: AggregationRound = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Round(key, latest))
+        .ok_or(Error::RoundNotFound)?;
+
+    if round.finalized {
+        return Err(Error::RoundNotFound);
+    }
+
+    Ok(latest)
+}
+
+pub fn compute_confidence_bps(submitters: u32, total_oracles: u32) -> u32 {
+    if total_oracles == 0 {
+        return 0;
+    }
+
+    let mut score = submitters.saturating_mul(10_000) / total_oracles;
+    if score > 10_000 {
+        score = 10_000;
+    }
+    score
+}

--- a/contracts/healthcare_oracle_network/src/utils.rs
+++ b/contracts/healthcare_oracle_network/src/utils.rs
@@ -1,8 +1,8 @@
 use soroban_sdk::{symbol_short, Address, Env, String, Vec};
 
 use crate::types::{
-    AggregationRound, Config, ConsensusRecord, DataKey, Error, FeedKey, FeedKind, FeedPayload,
-    OracleNode, RegulatoryUpdateData, TreatmentOutcomeData, DrugPriceData, ClinicalTrialData,
+    AggregationRound, ClinicalTrialData, Config, ConsensusRecord, DataKey, DrugPriceData, Error,
+    FeedKey, FeedKind, FeedPayload, OracleNode, RegulatoryUpdateData, TreatmentOutcomeData,
 };
 
 pub fn payload_feed_id_from_trial(payload: &FeedPayload) -> String {
@@ -150,7 +150,11 @@ pub fn finalize_round(env: Env, key: FeedKey, round_id: u64) -> Result<Consensus
                     .ok_or(Error::InvalidData)?;
                 submitters.push_back(oracle);
                 payloads.push_back(payload);
-                weights.push_back(if node.reputation > 0 { node.reputation } else { 1 });
+                weights.push_back(if node.reputation > 0 {
+                    node.reputation
+                } else {
+                    1
+                });
             }
         }
         i += 1;
@@ -231,8 +235,8 @@ pub fn aggregate_payload(
                             ndc_code = value.ndc_code.clone();
                             currency = value.currency.clone();
                         }
-                        price_weighted = price_weighted
-                            .saturating_add(value.price_minor.saturating_mul(weight));
+                        price_weighted =
+                            price_weighted.saturating_add(value.price_minor.saturating_mul(weight));
                         availability_weighted = availability_weighted.saturating_add(
                             (value.availability_units as i128).saturating_mul(weight),
                         );
@@ -406,12 +410,13 @@ pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
                     .saturating_sub(payload_data.price_minor)
             };
             let bps = diff.saturating_mul(10_000) / consensus_data.price_minor;
-            if bps <= 500 { 5 } else { -3 }
+            if bps <= 500 {
+                5
+            } else {
+                -3
+            }
         }
-        (
-            FeedPayload::ClinicalTrial(consensus_data),
-            FeedPayload::ClinicalTrial(payload_data),
-        ) => {
+        (FeedPayload::ClinicalTrial(consensus_data), FeedPayload::ClinicalTrial(payload_data)) => {
             let diff = if payload_data.success_rate_bps > consensus_data.success_rate_bps {
                 payload_data
                     .success_rate_bps
@@ -421,7 +426,11 @@ pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
                     .success_rate_bps
                     .saturating_sub(payload_data.success_rate_bps)
             };
-            if diff <= 700 { 4 } else { -2 }
+            if diff <= 700 {
+                4
+            } else {
+                -2
+            }
         }
         (
             FeedPayload::RegulatoryUpdate(consensus_data),
@@ -446,7 +455,11 @@ pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
                     .improvement_rate_bps
                     .saturating_sub(payload_data.improvement_rate_bps)
             };
-            if diff <= 700 { 4 } else { -2 }
+            if diff <= 700 {
+                4
+            } else {
+                -2
+            }
         }
         _ => -5,
     }

--- a/contracts/predictive_analytics/src/config.rs
+++ b/contracts/predictive_analytics/src/config.rs
@@ -79,7 +79,9 @@ pub fn get_config(env: Env) -> Option<PredictionConfig> {
 }
 
 pub fn get_model_metrics(env: Env, model_id: BytesN<32>) -> Option<PredictionMetrics> {
-    env.storage().instance().get(&DataKey::ModelMetrics(model_id))
+    env.storage()
+        .instance()
+        .get(&DataKey::ModelMetrics(model_id))
 }
 
 pub fn update_model_metrics(
@@ -100,7 +102,8 @@ pub fn update_model_metrics(
         .instance()
         .set(&DataKey::ModelMetrics(model_id.clone()), &metrics);
 
-    env.events().publish((symbol_short!("MdlMetric"),), model_id);
+    env.events()
+        .publish((symbol_short!("MdlMetric"),), model_id);
 
     Ok(true)
 }

--- a/contracts/predictive_analytics/src/config.rs
+++ b/contracts/predictive_analytics/src/config.rs
@@ -1,0 +1,131 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env};
+
+use crate::{
+    types::{DataKey, Error, PredictionConfig, PredictionMetrics},
+    utils,
+};
+
+pub fn initialize(
+    env: Env,
+    admin: Address,
+    predictor: Address,
+    prediction_horizon_days: u32,
+    min_confidence_bps: u32,
+) -> bool {
+    admin.require_auth();
+
+    if env.storage().instance().has(&DataKey::Config) {
+        return false;
+    }
+
+    if min_confidence_bps > utils::MAX_BPS {
+        return false;
+    }
+
+    let config = PredictionConfig {
+        admin,
+        predictor,
+        prediction_horizon_days,
+        enabled: true,
+        min_confidence_bps,
+    };
+
+    env.storage().instance().set(&DataKey::Config, &config);
+    env.storage()
+        .instance()
+        .set(&utils::PREDICTION_COUNTER, &0u64);
+    true
+}
+
+pub fn update_config(
+    env: Env,
+    caller: Address,
+    new_predictor: Option<Address>,
+    new_horizon: Option<u32>,
+    new_min_confidence: Option<u32>,
+    enabled: Option<bool>,
+) -> Result<bool, Error> {
+    caller.require_auth();
+    let mut config = utils::ensure_admin(&env, &caller)?;
+
+    if let Some(predictor) = new_predictor {
+        config.predictor = predictor;
+    }
+
+    if let Some(horizon) = new_horizon {
+        if horizon == 0 {
+            return Err(Error::InvalidHorizon);
+        }
+        config.prediction_horizon_days = horizon;
+    }
+
+    if let Some(min_confidence) = new_min_confidence {
+        utils::validate_bps(min_confidence, Error::InvalidConfidence)?;
+        config.min_confidence_bps = min_confidence;
+    }
+
+    if let Some(enable_flag) = enabled {
+        config.enabled = enable_flag;
+    }
+
+    env.storage().instance().set(&DataKey::Config, &config);
+    env.events().publish((symbol_short!("CfgUpdate"),), true);
+
+    Ok(true)
+}
+
+pub fn get_config(env: Env) -> Option<PredictionConfig> {
+    env.storage().instance().get(&DataKey::Config)
+}
+
+pub fn get_model_metrics(env: Env, model_id: BytesN<32>) -> Option<PredictionMetrics> {
+    env.storage().instance().get(&DataKey::ModelMetrics(model_id))
+}
+
+pub fn update_model_metrics(
+    env: Env,
+    caller: Address,
+    model_id: BytesN<32>,
+    metrics: PredictionMetrics,
+) -> Result<bool, Error> {
+    caller.require_auth();
+    let _config = utils::ensure_admin(&env, &caller)?;
+
+    utils::validate_bps(metrics.accuracy_bps, Error::InvalidValue)?;
+    utils::validate_bps(metrics.precision_bps, Error::InvalidValue)?;
+    utils::validate_bps(metrics.recall_bps, Error::InvalidValue)?;
+    utils::validate_bps(metrics.f1_score_bps, Error::InvalidValue)?;
+
+    env.storage()
+        .instance()
+        .set(&DataKey::ModelMetrics(model_id.clone()), &metrics);
+
+    env.events().publish((symbol_short!("MdlMetric"),), model_id);
+
+    Ok(true)
+}
+
+pub fn whitelist_predictor(
+    env: Env,
+    caller: Address,
+    predictor_addr: Address,
+) -> Result<bool, Error> {
+    caller.require_auth();
+    let _config = utils::ensure_admin(&env, &caller)?;
+
+    env.storage()
+        .instance()
+        .set(&DataKey::Whitelist(predictor_addr.clone()), &true);
+
+    env.events()
+        .publish((symbol_short!("PredictWL"),), predictor_addr);
+
+    Ok(true)
+}
+
+pub fn is_whitelisted_predictor(env: Env, predictor_addr: Address) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Whitelist(predictor_addr))
+        .unwrap_or(false)
+}

--- a/contracts/predictive_analytics/src/lib.rs
+++ b/contracts/predictive_analytics/src/lib.rs
@@ -4,84 +4,19 @@
 #![allow(clippy::arithmetic_side_effects)]
 #![allow(clippy::panic)]
 
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    String, Symbol, Vec,
+mod config;
+mod predictions;
+#[cfg(all(test, feature = "testutils"))]
+mod test;
+mod types;
+mod utils;
+
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, String, Vec};
+
+pub use types::{
+    DataKey, Error, HealthPrediction, PatientPredictionsSummary, PredictionConfig,
+    PredictionMetrics,
 };
-
-#[derive(Clone)]
-#[contracttype]
-pub struct PredictionConfig {
-    pub admin: Address,
-    pub predictor: Address,
-    pub prediction_horizon_days: u32, // How far ahead to predict
-    pub enabled: bool,
-    pub min_confidence_bps: u32, // Minimum confidence in basis points (0-10000)
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct HealthPrediction {
-    pub patient: Address,
-    pub model_id: BytesN<32>,
-    pub outcome_type: String, // e.g., "diabetes_risk", "heart_attack_prob", "readmission_likelihood"
-    pub predicted_value: u32, // Predicted value in basis points (0-10000)
-    pub confidence_bps: u32,  // Confidence in basis points (0-10000)
-    pub prediction_date: u64, // Date of prediction
-    pub horizon_start: u64,   // Start date for prediction horizon
-    pub horizon_end: u64,     // End date for prediction horizon
-    pub features_used: Vec<String>, // Features used in prediction
-    pub explanation_ref: String, // Off-chain reference to detailed explanation
-    pub risk_factors: Vec<String>, // Key risk factors identified
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct PredictionMetrics {
-    pub accuracy_bps: u32,  // Accuracy in basis points
-    pub precision_bps: u32, // Precision in basis points
-    pub recall_bps: u32,    // Recall in basis points
-    pub f1_score_bps: u32,  // F1 score in basis points
-    pub last_updated: u64,  // Last time metrics were updated
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub struct PatientPredictionsSummary {
-    pub latest_prediction_id: u64,
-    pub high_risk_predictions: u32, // Count of high-risk predictions (>7500 bps)
-    pub total_predictions: u32,
-    pub avg_confidence_bps: u32,
-    pub last_prediction_date: u64,
-}
-
-#[derive(Clone)]
-#[contracttype]
-pub enum DataKey {
-    Config,
-    Prediction(u64),          // Prediction ID -> HealthPrediction
-    PatientSummary(Address),  // Patient -> PatientPredictionsSummary
-    ModelMetrics(BytesN<32>), // Model ID -> PredictionMetrics
-    PredictionCounter,
-    Whitelist(Address),
-}
-
-const PREDICTION_COUNTER: Symbol = symbol_short!("PRED_CT");
-
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum Error {
-    NotAuthorized = 1,
-    ConfigNotSet = 2,
-    Disabled = 3,
-    InvalidValue = 4,
-    InvalidConfidence = 5,
-    RecordNotFound = 6,
-    LowConfidence = 7,
-    InvalidHorizon = 8,
-    EmptyInput = 9,
-}
 
 #[contract]
 pub struct PredictiveAnalyticsContract;
@@ -95,64 +30,13 @@ impl PredictiveAnalyticsContract {
         prediction_horizon_days: u32,
         min_confidence_bps: u32,
     ) -> bool {
-        admin.require_auth();
-
-        if env.storage().instance().has(&DataKey::Config) {
-            return false; // Already initialized
-        }
-
-        if min_confidence_bps > 10_000 {
-            return false; // Invalid confidence value
-        }
-
-        let config = PredictionConfig {
+        config::initialize(
+            env,
             admin,
             predictor,
             prediction_horizon_days,
-            enabled: true,
             min_confidence_bps,
-        };
-
-        env.storage().instance().set(&DataKey::Config, &config);
-        env.storage().instance().set(&PREDICTION_COUNTER, &0u64);
-        true
-    }
-
-    fn load_config(env: &Env) -> Result<PredictionConfig, Error> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Config)
-            .ok_or(Error::ConfigNotSet)
-    }
-
-    fn ensure_admin(env: &Env, caller: &Address) -> Result<PredictionConfig, Error> {
-        let config = Self::load_config(env)?;
-        if config.admin != *caller {
-            return Err(Error::NotAuthorized);
-        }
-        Ok(config)
-    }
-
-    fn ensure_predictor(env: &Env, caller: &Address) -> Result<PredictionConfig, Error> {
-        let config = Self::load_config(env)?;
-        if config.predictor != *caller {
-            return Err(Error::NotAuthorized);
-        }
-        if !config.enabled {
-            return Err(Error::Disabled);
-        }
-        Ok(config)
-    }
-
-    fn next_prediction_id(env: &Env) -> u64 {
-        let current: u64 = env
-            .storage()
-            .instance()
-            .get(&PREDICTION_COUNTER)
-            .unwrap_or(0);
-        let next = current + 1;
-        env.storage().instance().set(&PREDICTION_COUNTER, &next);
-        next
+        )
     }
 
     pub fn update_config(
@@ -163,35 +47,14 @@ impl PredictiveAnalyticsContract {
         new_min_confidence: Option<u32>,
         enabled: Option<bool>,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        let mut config = Self::ensure_admin(&env, &caller)?;
-
-        if let Some(predictor) = new_predictor {
-            config.predictor = predictor;
-        }
-
-        if let Some(horizon) = new_horizon {
-            if horizon == 0 {
-                return Err(Error::InvalidHorizon);
-            }
-            config.prediction_horizon_days = horizon;
-        }
-
-        if let Some(min_conf) = new_min_confidence {
-            if min_conf > 10_000 {
-                return Err(Error::InvalidConfidence);
-            }
-            config.min_confidence_bps = min_conf;
-        }
-
-        if let Some(enable_flag) = enabled {
-            config.enabled = enable_flag;
-        }
-
-        env.storage().instance().set(&DataKey::Config, &config);
-        env.events().publish((symbol_short!("CfgUpdate"),), true);
-
-        Ok(true)
+        config::update_config(
+            env,
+            caller,
+            new_predictor,
+            new_horizon,
+            new_min_confidence,
+            enabled,
+        )
     }
 
     pub fn make_prediction(
@@ -206,114 +69,34 @@ impl PredictiveAnalyticsContract {
         explanation_ref: String,
         risk_factors: Vec<String>,
     ) -> Result<u64, Error> {
-        caller.require_auth();
-
-        let config = Self::ensure_predictor(&env, &caller)?;
-
-        // Validate inputs
-        if predicted_value > 10_000 {
-            return Err(Error::InvalidValue);
-        }
-
-        if confidence_bps > 10_000 {
-            return Err(Error::InvalidConfidence);
-        }
-
-        if confidence_bps < config.min_confidence_bps {
-            return Err(Error::LowConfidence);
-        }
-
-        if explanation_ref.is_empty() {
-            return Err(Error::EmptyInput);
-        }
-
-        let timestamp = env.ledger().timestamp();
-        let horizon_start = timestamp;
-        let horizon_end = timestamp + (config.prediction_horizon_days as u64 * 24 * 3600); // Days to seconds
-
-        // Create prediction record
-        let prediction_id = Self::next_prediction_id(&env);
-
-        let prediction = HealthPrediction {
-            patient: patient.clone(),
+        predictions::make_prediction(
+            env,
+            caller,
+            patient,
             model_id,
             outcome_type,
             predicted_value,
             confidence_bps,
-            prediction_date: timestamp,
-            horizon_start,
-            horizon_end,
             features_used,
             explanation_ref,
             risk_factors,
-        };
-
-        env.storage()
-            .instance()
-            .set(&DataKey::Prediction(prediction_id), &prediction);
-
-        // Update patient's prediction summary
-        let mut summary: PatientPredictionsSummary = env
-            .storage()
-            .instance()
-            .get(&DataKey::PatientSummary(patient.clone()))
-            .unwrap_or(PatientPredictionsSummary {
-                latest_prediction_id: 0,
-                high_risk_predictions: 0,
-                total_predictions: 0,
-                avg_confidence_bps: 0,
-                last_prediction_date: 0,
-            });
-
-        summary.latest_prediction_id = prediction_id;
-        summary.total_predictions += 1;
-
-        // Count high-risk predictions (values >= 7500 bps)
-        if predicted_value >= 7500 {
-            summary.high_risk_predictions += 1;
-        }
-
-        // Calculate new average confidence
-        let total_conf = (summary.avg_confidence_bps as u64
-            * (summary.total_predictions as u64 - 1)
-            + confidence_bps as u64)
-            / summary.total_predictions as u64;
-        summary.avg_confidence_bps = total_conf as u32;
-        summary.last_prediction_date = timestamp;
-
-        env.storage()
-            .instance()
-            .set(&DataKey::PatientSummary(patient.clone()), &summary);
-
-        // Emit event
-        env.events().publish(
-            (symbol_short!("PredMade"),),
-            (prediction_id, patient, predicted_value, confidence_bps),
-        );
-
-        Ok(prediction_id)
+        )
     }
 
     pub fn get_prediction(env: Env, prediction_id: u64) -> Option<HealthPrediction> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Prediction(prediction_id))
+        predictions::get_prediction(env, prediction_id)
     }
 
     pub fn get_config(env: Env) -> Option<PredictionConfig> {
-        env.storage().instance().get(&DataKey::Config)
+        config::get_config(env)
     }
 
     pub fn get_patient_summary(env: Env, patient: Address) -> Option<PatientPredictionsSummary> {
-        env.storage()
-            .instance()
-            .get(&DataKey::PatientSummary(patient))
+        predictions::get_patient_summary(env, patient)
     }
 
     pub fn get_model_metrics(env: Env, model_id: BytesN<32>) -> Option<PredictionMetrics> {
-        env.storage()
-            .instance()
-            .get(&DataKey::ModelMetrics(model_id))
+        config::get_model_metrics(env, model_id)
     }
 
     pub fn update_model_metrics(
@@ -322,38 +105,11 @@ impl PredictiveAnalyticsContract {
         model_id: BytesN<32>,
         metrics: PredictionMetrics,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        let _config = Self::ensure_admin(&env, &caller)?;
-
-        // Validate metrics
-        if metrics.accuracy_bps > 10_000
-            || metrics.precision_bps > 10_000
-            || metrics.recall_bps > 10_000
-            || metrics.f1_score_bps > 10_000
-        {
-            return Err(Error::InvalidValue);
-        }
-
-        env.storage()
-            .instance()
-            .set(&DataKey::ModelMetrics(model_id.clone()), &metrics);
-
-        env.events()
-            .publish((symbol_short!("MdlMetric"),), model_id);
-
-        Ok(true)
+        config::update_model_metrics(env, caller, model_id, metrics)
     }
 
     pub fn has_high_risk_prediction(env: Env, patient: Address) -> bool {
-        let summary: Option<PatientPredictionsSummary> = env
-            .storage()
-            .instance()
-            .get(&DataKey::PatientSummary(patient));
-
-        match summary {
-            Some(s) => s.high_risk_predictions > 0,
-            None => false,
-        }
+        predictions::has_high_risk_prediction(env, patient)
     }
 
     pub fn whitelist_predictor(
@@ -361,204 +117,10 @@ impl PredictiveAnalyticsContract {
         caller: Address,
         predictor_addr: Address,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        let _config = Self::ensure_admin(&env, &caller)?;
-
-        env.storage()
-            .instance()
-            .set(&DataKey::Whitelist(predictor_addr.clone()), &true);
-
-        env.events()
-            .publish((symbol_short!("PredictWL"),), predictor_addr);
-
-        Ok(true)
+        config::whitelist_predictor(env, caller, predictor_addr)
     }
 
     pub fn is_whitelisted_predictor(env: Env, predictor_addr: Address) -> bool {
-        env.storage()
-            .instance()
-            .get(&DataKey::Whitelist(predictor_addr))
-            .unwrap_or(false)
-    }
-}
-
-#[cfg(all(test, feature = "testutils"))]
-#[allow(clippy::unwrap_used)]
-mod test {
-    use super::*;
-    use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::vec;
-
-    #[test]
-    fn test_prediction_flow() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
-        let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let predictor = Address::generate(&env);
-        let patient = Address::generate(&env);
-
-        // Initialize contract with 30-day prediction horizon and 5000 bps (50%) min confidence
-        client
-            .mock_all_auths()
-            .initialize(&admin, &predictor, &30u32, &5000u32);
-
-        // Verify config
-        let config = client.get_config().unwrap();
-        assert_eq!(config.admin, admin);
-        assert_eq!(config.predictor, predictor);
-        assert_eq!(config.prediction_horizon_days, 30u32);
-        assert_eq!(config.min_confidence_bps, 5000u32);
-        assert!(config.enabled);
-
-        // Make a prediction
-        let model_id = BytesN::from_array(&env, &[1; 32]);
-        let outcome_type = String::from_str(&env, "diabetes_risk");
-        let features = vec![
-            &env,
-            String::from_str(&env, "age"),
-            String::from_str(&env, "bmi"),
-            String::from_str(&env, "family_history"),
-        ];
-        let explanation_ref = String::from_str(&env, "ipfs://prediction-explanation-123");
-        let risk_factors = vec![
-            &env,
-            String::from_str(&env, "high_bmi"),
-            String::from_str(&env, "family_history"),
-        ];
-
-        let prediction_id = client.mock_all_auths().make_prediction(
-            &predictor,
-            &patient,
-            &model_id,
-            &outcome_type,
-            &7500u32, // High risk (75%)
-            &8000u32, // High confidence (80%)
-            &features,
-            &explanation_ref,
-            &risk_factors,
-        );
-
-        assert_eq!(prediction_id, 1u64);
-
-        // Get the prediction record
-        let prediction = client.get_prediction(&prediction_id).unwrap();
-        assert_eq!(prediction.patient, patient);
-        assert_eq!(prediction.predicted_value, 7500u32);
-        assert_eq!(prediction.confidence_bps, 8000u32);
-        assert_eq!(prediction.outcome_type, outcome_type);
-
-        // Check patient summary
-        let summary = client.get_patient_summary(&patient).unwrap();
-        assert_eq!(summary.latest_prediction_id, 1u64);
-        assert_eq!(summary.total_predictions, 1u32);
-        assert_eq!(summary.high_risk_predictions, 1u32); // Since 7500 >= 7500 threshold
-        assert_eq!(summary.avg_confidence_bps, 8000u32);
-    }
-
-    #[test]
-    fn test_low_confidence_rejection() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
-        let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let predictor = Address::generate(&env);
-        let patient = Address::generate(&env);
-
-        // Initialize with high minimum confidence
-        client
-            .mock_all_auths()
-            .initialize(&admin, &predictor, &30u32, &9000u32);
-
-        // Attempt to make a prediction with low confidence - should fail
-        let model_id = BytesN::from_array(&env, &[1; 32]);
-        let outcome_type = String::from_str(&env, "diabetes_risk");
-        let features = vec![&env, String::from_str(&env, "age")];
-        let explanation_ref = String::from_str(&env, "ipfs://low-confidence-prediction");
-        let risk_factors = vec![&env, String::from_str(&env, "age")];
-
-        let result = client.mock_all_auths().try_make_prediction(
-            &predictor,
-            &patient,
-            &model_id,
-            &outcome_type,
-            &5000u32,
-            &4000u32, // Below minimum confidence of 9000
-            &features,
-            &explanation_ref,
-            &risk_factors,
-        );
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_config_updates() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
-        let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let predictor = Address::generate(&env);
-
-        // Initialize contract
-        client
-            .mock_all_auths()
-            .initialize(&admin, &predictor, &30u32, &5000u32);
-
-        // Update config
-        assert!(client.mock_all_auths().update_config(
-            &admin,
-            &Some(Address::generate(&env)), // new predictor
-            &Some(60u32),                   // new horizon
-            &Some(7000u32),                 // new min confidence
-            &Some(false),                   // disable
-        ));
-
-        let config = client.get_config().unwrap();
-        assert_eq!(config.prediction_horizon_days, 60u32);
-        assert_eq!(config.min_confidence_bps, 7000u32);
-        assert!(!config.enabled);
-    }
-
-    #[test]
-    fn test_has_high_risk_prediction_helper() {
-        let env = Env::default();
-        let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
-        let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
-
-        let admin = Address::generate(&env);
-        let predictor = Address::generate(&env);
-        let patient = Address::generate(&env);
-
-        client
-            .mock_all_auths()
-            .initialize(&admin, &predictor, &30u32, &5000u32);
-
-        // Initially there should be no high-risk predictions
-        assert!(!client.has_high_risk_prediction(&patient));
-
-        let model_id = BytesN::from_array(&env, &[1; 32]);
-        let outcome_type = String::from_str(&env, "diabetes_risk");
-        let features = vec![&env, String::from_str(&env, "age")];
-        let explanation_ref = String::from_str(&env, "ipfs://prediction-explanation");
-        let risk_factors = vec![&env, String::from_str(&env, "high_bmi")];
-
-        // Create a high-risk prediction (>7500 bps)
-        client.mock_all_auths().make_prediction(
-            &predictor,
-            &patient,
-            &model_id,
-            &outcome_type,
-            &8000u32,
-            &9000u32,
-            &features,
-            &explanation_ref,
-            &risk_factors,
-        );
-
-        assert!(client.has_high_risk_prediction(&patient));
+        config::is_whitelisted_predictor(env, predictor_addr)
     }
 }

--- a/contracts/predictive_analytics/src/predictions.rs
+++ b/contracts/predictive_analytics/src/predictions.rs
@@ -90,11 +90,15 @@ pub fn make_prediction(
 }
 
 pub fn get_prediction(env: Env, prediction_id: u64) -> Option<HealthPrediction> {
-    env.storage().instance().get(&DataKey::Prediction(prediction_id))
+    env.storage()
+        .instance()
+        .get(&DataKey::Prediction(prediction_id))
 }
 
 pub fn get_patient_summary(env: Env, patient: Address) -> Option<PatientPredictionsSummary> {
-    env.storage().instance().get(&DataKey::PatientSummary(patient))
+    env.storage()
+        .instance()
+        .get(&DataKey::PatientSummary(patient))
 }
 
 pub fn has_high_risk_prediction(env: Env, patient: Address) -> bool {

--- a/contracts/predictive_analytics/src/predictions.rs
+++ b/contracts/predictive_analytics/src/predictions.rs
@@ -1,0 +1,106 @@
+use soroban_sdk::{symbol_short, Address, BytesN, Env, String, Vec};
+
+use crate::{
+    types::{DataKey, Error, HealthPrediction, PatientPredictionsSummary},
+    utils,
+};
+
+pub fn make_prediction(
+    env: Env,
+    caller: Address,
+    patient: Address,
+    model_id: BytesN<32>,
+    outcome_type: String,
+    predicted_value: u32,
+    confidence_bps: u32,
+    features_used: Vec<String>,
+    explanation_ref: String,
+    risk_factors: Vec<String>,
+) -> Result<u64, Error> {
+    caller.require_auth();
+
+    let config = utils::ensure_predictor(&env, &caller)?;
+
+    utils::validate_bps(predicted_value, Error::InvalidValue)?;
+    utils::validate_bps(confidence_bps, Error::InvalidConfidence)?;
+
+    if confidence_bps < config.min_confidence_bps {
+        return Err(Error::LowConfidence);
+    }
+
+    if explanation_ref.is_empty() {
+        return Err(Error::EmptyInput);
+    }
+
+    let timestamp = env.ledger().timestamp();
+    let horizon_start = timestamp;
+    let horizon_end = timestamp.saturating_add(
+        (config.prediction_horizon_days as u64).saturating_mul(utils::SECONDS_PER_DAY),
+    );
+
+    let prediction_id = utils::next_prediction_id(&env);
+    let prediction = HealthPrediction {
+        patient: patient.clone(),
+        model_id,
+        outcome_type,
+        predicted_value,
+        confidence_bps,
+        prediction_date: timestamp,
+        horizon_start,
+        horizon_end,
+        features_used,
+        explanation_ref,
+        risk_factors,
+    };
+
+    env.storage()
+        .instance()
+        .set(&DataKey::Prediction(prediction_id), &prediction);
+
+    let mut summary: PatientPredictionsSummary = env
+        .storage()
+        .instance()
+        .get(&DataKey::PatientSummary(patient.clone()))
+        .unwrap_or_else(utils::empty_patient_summary);
+
+    let previous_total = summary.total_predictions as u64;
+    summary.latest_prediction_id = prediction_id;
+    summary.total_predictions = summary.total_predictions.saturating_add(1);
+
+    if predicted_value >= utils::HIGH_RISK_THRESHOLD_BPS {
+        summary.high_risk_predictions = summary.high_risk_predictions.saturating_add(1);
+    }
+
+    let total_confidence = (summary.avg_confidence_bps as u64)
+        .saturating_mul(previous_total)
+        .saturating_add(confidence_bps as u64);
+    summary.avg_confidence_bps = (total_confidence / summary.total_predictions as u64) as u32;
+    summary.last_prediction_date = timestamp;
+
+    env.storage()
+        .instance()
+        .set(&DataKey::PatientSummary(patient.clone()), &summary);
+
+    env.events().publish(
+        (symbol_short!("PredMade"),),
+        (prediction_id, patient, predicted_value, confidence_bps),
+    );
+
+    Ok(prediction_id)
+}
+
+pub fn get_prediction(env: Env, prediction_id: u64) -> Option<HealthPrediction> {
+    env.storage().instance().get(&DataKey::Prediction(prediction_id))
+}
+
+pub fn get_patient_summary(env: Env, patient: Address) -> Option<PatientPredictionsSummary> {
+    env.storage().instance().get(&DataKey::PatientSummary(patient))
+}
+
+pub fn has_high_risk_prediction(env: Env, patient: Address) -> bool {
+    env.storage()
+        .instance()
+        .get::<DataKey, PatientPredictionsSummary>(&DataKey::PatientSummary(patient))
+        .map(|summary| summary.high_risk_predictions > 0)
+        .unwrap_or(false)
+}

--- a/contracts/predictive_analytics/src/test.rs
+++ b/contracts/predictive_analytics/src/test.rs
@@ -1,0 +1,167 @@
+use crate::{
+    types::{HealthPrediction, PatientPredictionsSummary, PredictionConfig},
+    PredictiveAnalyticsContract, PredictiveAnalyticsContractClient,
+};
+use soroban_sdk::{testutils::Address as _, vec, Address, BytesN, Env, String};
+
+#[test]
+fn test_prediction_flow() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
+    let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .initialize(&admin, &predictor, &30u32, &5000u32);
+
+    let config: PredictionConfig = client.get_config().unwrap();
+    assert_eq!(config.admin, admin);
+    assert_eq!(config.predictor, predictor);
+    assert_eq!(config.prediction_horizon_days, 30u32);
+    assert_eq!(config.min_confidence_bps, 5000u32);
+    assert!(config.enabled);
+
+    let model_id = BytesN::from_array(&env, &[1; 32]);
+    let outcome_type = String::from_str(&env, "diabetes_risk");
+    let features = vec![
+        &env,
+        String::from_str(&env, "age"),
+        String::from_str(&env, "bmi"),
+        String::from_str(&env, "family_history"),
+    ];
+    let explanation_ref = String::from_str(&env, "ipfs://prediction-explanation-123");
+    let risk_factors = vec![
+        &env,
+        String::from_str(&env, "high_bmi"),
+        String::from_str(&env, "family_history"),
+    ];
+
+    let prediction_id = client.mock_all_auths().make_prediction(
+        &predictor,
+        &patient,
+        &model_id,
+        &outcome_type,
+        &7500u32,
+        &8000u32,
+        &features,
+        &explanation_ref,
+        &risk_factors,
+    );
+
+    assert_eq!(prediction_id, 1u64);
+
+    let prediction: HealthPrediction = client.get_prediction(&prediction_id).unwrap();
+    assert_eq!(prediction.patient, patient);
+    assert_eq!(prediction.predicted_value, 7500u32);
+    assert_eq!(prediction.confidence_bps, 8000u32);
+    assert_eq!(prediction.outcome_type, outcome_type);
+
+    let summary: PatientPredictionsSummary = client.get_patient_summary(&patient).unwrap();
+    assert_eq!(summary.latest_prediction_id, 1u64);
+    assert_eq!(summary.total_predictions, 1u32);
+    assert_eq!(summary.high_risk_predictions, 1u32);
+    assert_eq!(summary.avg_confidence_bps, 8000u32);
+}
+
+#[test]
+fn test_low_confidence_rejection() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
+    let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .initialize(&admin, &predictor, &30u32, &9000u32);
+
+    let model_id = BytesN::from_array(&env, &[1; 32]);
+    let outcome_type = String::from_str(&env, "diabetes_risk");
+    let features = vec![&env, String::from_str(&env, "age")];
+    let explanation_ref = String::from_str(&env, "ipfs://low-confidence-prediction");
+    let risk_factors = vec![&env, String::from_str(&env, "age")];
+
+    let result = client.mock_all_auths().try_make_prediction(
+        &predictor,
+        &patient,
+        &model_id,
+        &outcome_type,
+        &5000u32,
+        &4000u32,
+        &features,
+        &explanation_ref,
+        &risk_factors,
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_config_updates() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
+    let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let predictor = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .initialize(&admin, &predictor, &30u32, &5000u32);
+
+    assert!(client.mock_all_auths().update_config(
+        &admin,
+        &Some(Address::generate(&env)),
+        &Some(60u32),
+        &Some(7000u32),
+        &Some(false),
+    ));
+
+    let config: PredictionConfig = client.get_config().unwrap();
+    assert_eq!(config.prediction_horizon_days, 60u32);
+    assert_eq!(config.min_confidence_bps, 7000u32);
+    assert!(!config.enabled);
+}
+
+#[test]
+fn test_has_high_risk_prediction_helper() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PredictiveAnalyticsContract);
+    let client = PredictiveAnalyticsContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let predictor = Address::generate(&env);
+    let patient = Address::generate(&env);
+
+    client
+        .mock_all_auths()
+        .initialize(&admin, &predictor, &30u32, &5000u32);
+
+    assert!(!client.has_high_risk_prediction(&patient));
+
+    let model_id = BytesN::from_array(&env, &[1; 32]);
+    let outcome_type = String::from_str(&env, "diabetes_risk");
+    let features = vec![&env, String::from_str(&env, "age")];
+    let explanation_ref = String::from_str(&env, "ipfs://prediction-explanation");
+    let risk_factors = vec![&env, String::from_str(&env, "high_bmi")];
+
+    client.mock_all_auths().make_prediction(
+        &predictor,
+        &patient,
+        &model_id,
+        &outcome_type,
+        &8000u32,
+        &9000u32,
+        &features,
+        &explanation_ref,
+        &risk_factors,
+    );
+
+    assert!(client.has_high_risk_prediction(&patient));
+}

--- a/contracts/predictive_analytics/src/types.rs
+++ b/contracts/predictive_analytics/src/types.rs
@@ -1,0 +1,73 @@
+use soroban_sdk::{contracterror, contracttype, Address, BytesN, String, Vec};
+
+#[derive(Clone)]
+#[contracttype]
+pub struct PredictionConfig {
+    pub admin: Address,
+    pub predictor: Address,
+    pub prediction_horizon_days: u32,
+    pub enabled: bool,
+    pub min_confidence_bps: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct HealthPrediction {
+    pub patient: Address,
+    pub model_id: BytesN<32>,
+    pub outcome_type: String,
+    pub predicted_value: u32,
+    pub confidence_bps: u32,
+    pub prediction_date: u64,
+    pub horizon_start: u64,
+    pub horizon_end: u64,
+    pub features_used: Vec<String>,
+    pub explanation_ref: String,
+    pub risk_factors: Vec<String>,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct PredictionMetrics {
+    pub accuracy_bps: u32,
+    pub precision_bps: u32,
+    pub recall_bps: u32,
+    pub f1_score_bps: u32,
+    pub last_updated: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct PatientPredictionsSummary {
+    pub latest_prediction_id: u64,
+    pub high_risk_predictions: u32,
+    pub total_predictions: u32,
+    pub avg_confidence_bps: u32,
+    pub last_prediction_date: u64,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Config,
+    Prediction(u64),
+    PatientSummary(Address),
+    ModelMetrics(BytesN<32>),
+    PredictionCounter,
+    Whitelist(Address),
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    NotAuthorized = 1,
+    ConfigNotSet = 2,
+    Disabled = 3,
+    InvalidValue = 4,
+    InvalidConfidence = 5,
+    RecordNotFound = 6,
+    LowConfidence = 7,
+    InvalidHorizon = 8,
+    EmptyInput = 9,
+}

--- a/contracts/predictive_analytics/src/utils.rs
+++ b/contracts/predictive_analytics/src/utils.rs
@@ -1,0 +1,62 @@
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+use crate::types::{DataKey, Error, PatientPredictionsSummary, PredictionConfig};
+
+pub const PREDICTION_COUNTER: Symbol = symbol_short!("PRED_CT");
+pub const MAX_BPS: u32 = 10_000;
+pub const HIGH_RISK_THRESHOLD_BPS: u32 = 7_500;
+pub const SECONDS_PER_DAY: u64 = 24 * 3600;
+
+pub fn load_config(env: &Env) -> Result<PredictionConfig, Error> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Config)
+        .ok_or(Error::ConfigNotSet)
+}
+
+pub fn ensure_admin(env: &Env, caller: &Address) -> Result<PredictionConfig, Error> {
+    let config = load_config(env)?;
+    if config.admin != *caller {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(config)
+}
+
+pub fn ensure_predictor(env: &Env, caller: &Address) -> Result<PredictionConfig, Error> {
+    let config = load_config(env)?;
+    if config.predictor != *caller {
+        return Err(Error::NotAuthorized);
+    }
+    if !config.enabled {
+        return Err(Error::Disabled);
+    }
+    Ok(config)
+}
+
+pub fn next_prediction_id(env: &Env) -> u64 {
+    let current: u64 = env
+        .storage()
+        .instance()
+        .get(&PREDICTION_COUNTER)
+        .unwrap_or(0);
+    let next = current.saturating_add(1);
+    env.storage().instance().set(&PREDICTION_COUNTER, &next);
+    next
+}
+
+pub fn validate_bps(value: u32, error: Error) -> Result<(), Error> {
+    if value > MAX_BPS {
+        return Err(error);
+    }
+    Ok(())
+}
+
+pub fn empty_patient_summary() -> PatientPredictionsSummary {
+    PatientPredictionsSummary {
+        latest_prediction_id: 0,
+        high_risk_predictions: 0,
+        total_predictions: 0,
+        avg_confidence_bps: 0,
+        last_prediction_date: 0,
+    }
+}

--- a/contracts/upgradeability/Cargo.toml
+++ b/contracts/upgradeability/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 soroban-sdk = { version = "21.7.7" }
 
 [dev-dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-sdk = { version = "21.7.7", features = ["testutils"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/upgradeability/Cargo.toml
+++ b/contracts/upgradeability/Cargo.toml
@@ -6,5 +6,12 @@ edition = "2021"
 [dependencies]
 soroban-sdk = { workspace = true }
 
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/upgradeability/src/lib.rs
+++ b/contracts/upgradeability/src/lib.rs
@@ -1,8 +1,13 @@
 #![no_std]
 
-use soroban_sdk::{contracterror, contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec};
+use soroban_sdk::{
+    contracterror, contracttype, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 pub mod migration;
+
+#[cfg(all(test, feature = "testutils"))]
+mod test;
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -16,6 +21,7 @@ pub enum UpgradeError {
     ContractPaused = 105,
     HistoryNotFound = 106,
     IntegrityCheckFailed = 107,
+    DeprecatedFunctionNotTracked = 108,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -28,6 +34,17 @@ pub struct UpgradeHistory {
     pub state_hash: BytesN<32>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct DeprecatedFunction {
+    pub function: Symbol,
+    pub since: String,
+    pub replacement: Option<Symbol>,
+    pub removed_in: Option<String>,
+    pub note: String,
+    pub migration_guide: Option<String>,
+}
+
 pub mod storage {
     use super::*;
 
@@ -35,6 +52,7 @@ pub mod storage {
     pub const ADMIN: Symbol = symbol_short!("UP_ADMIN");
     pub const HISTORY: Symbol = symbol_short!("HISTORY");
     pub const IS_FROZEN: Symbol = symbol_short!("FROZEN");
+    pub const DEPRECATED_FUNCTIONS: Symbol = symbol_short!("DEPRLIST");
 
     pub fn get_version(env: &Env) -> u32 {
         env.storage().instance().get(&VERSION).unwrap_or(0)
@@ -76,6 +94,19 @@ pub mod storage {
             .get(&HISTORY)
             .unwrap_or(Vec::new(env))
     }
+
+    pub fn set_deprecated_functions(env: &Env, deprecations: &Vec<DeprecatedFunction>) {
+        env.storage()
+            .instance()
+            .set(&DEPRECATED_FUNCTIONS, deprecations);
+    }
+
+    pub fn get_deprecated_functions(env: &Env) -> Vec<DeprecatedFunction> {
+        env.storage()
+            .instance()
+            .get(&DEPRECATED_FUNCTIONS)
+            .unwrap_or(Vec::new(env))
+    }
 }
 
 pub fn authorize_upgrade(env: &Env) -> Result<Address, UpgradeError> {
@@ -92,6 +123,22 @@ pub fn execute_upgrade<T: migration::Migratable>(
     new_wasm_hash: BytesN<32>,
     new_version: u32,
     description: Symbol,
+) -> Result<(), UpgradeError> {
+    execute_upgrade_with_deprecations(
+        env,
+        new_wasm_hash,
+        new_version,
+        description,
+        Vec::new(env),
+    )
+}
+
+pub fn execute_upgrade_with_deprecations<T: migration::Migratable>(
+    env: &Env,
+    new_wasm_hash: BytesN<32>,
+    new_version: u32,
+    description: Symbol,
+    deprecations: Vec<DeprecatedFunction>,
 ) -> Result<(), UpgradeError> {
     authorize_upgrade(env)?;
 
@@ -120,6 +167,7 @@ pub fn execute_upgrade<T: migration::Migratable>(
         },
     );
 
+    storage::set_deprecated_functions(env, &deprecations);
     storage::set_version(env, new_version);
     env.deployer().update_current_contract_wasm(new_wasm_hash);
 
@@ -150,6 +198,51 @@ pub fn rollback(env: &Env) -> Result<(), UpgradeError> {
     storage::set_version(env, next_version);
     env.deployer()
         .update_current_contract_wasm(target_version.wasm_hash);
+
+    Ok(())
+}
+
+pub fn set_deprecated_functions(
+    env: &Env,
+    deprecations: Vec<DeprecatedFunction>,
+) -> Result<(), UpgradeError> {
+    authorize_upgrade(env)?;
+    storage::set_deprecated_functions(env, &deprecations);
+
+    env.events().publish(
+        (Symbol::new(env, "DeprecationsUpdated"),),
+        deprecations.len(),
+    );
+
+    Ok(())
+}
+
+pub fn get_deprecated_functions(env: &Env) -> Vec<DeprecatedFunction> {
+    storage::get_deprecated_functions(env)
+}
+
+pub fn get_deprecated_function(env: &Env, function: Symbol) -> Option<DeprecatedFunction> {
+    let deprecations = storage::get_deprecated_functions(env);
+    let mut index = 0;
+    while index < deprecations.len() {
+        let deprecation = deprecations.get(index).unwrap();
+        if deprecation.function == function {
+            return Some(deprecation);
+        }
+        index += 1;
+    }
+
+    None
+}
+
+pub fn emit_deprecation_warning(env: &Env, function: Symbol) -> Result<(), UpgradeError> {
+    let deprecation = get_deprecated_function(env, function.clone())
+        .ok_or(UpgradeError::DeprecatedFunctionNotTracked)?;
+
+    env.events().publish(
+        (Symbol::new(env, "Deprecated"), function),
+        deprecation.note,
+    );
 
     Ok(())
 }

--- a/contracts/upgradeability/src/lib.rs
+++ b/contracts/upgradeability/src/lib.rs
@@ -125,7 +125,7 @@ pub fn execute_upgrade<T: migration::Migratable>(
     new_version: u32,
     description: Symbol,
 ) -> Result<(), UpgradeError> {
-    execute_upgrade_with_deprecations(
+    execute_upgrade_with_deprecations::<T>(
         env,
         new_wasm_hash,
         new_version,
@@ -264,10 +264,8 @@ pub fn emit_deprecation_warning(env: &Env, function: Symbol) -> Result<(), Upgra
     let deprecation = get_deprecated_function(env, function.clone())
         .ok_or(UpgradeError::DeprecatedFunctionNotTracked)?;
 
-    env.events().publish(
-        (Symbol::new(env, "Deprecated"), function),
-        deprecation.note,
-    );
+    env.events()
+        .publish((Symbol::new(env, "Deprecated"), function), deprecation.note);
 
     Ok(())
 }

--- a/contracts/upgradeability/src/test.rs
+++ b/contracts/upgradeability/src/test.rs
@@ -1,0 +1,66 @@
+#![allow(clippy::unwrap_used)]
+
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String, Symbol, Vec};
+
+use crate::{
+    emit_deprecation_warning, get_deprecated_function, get_deprecated_functions,
+    set_deprecated_functions, storage, DeprecatedFunction,
+};
+
+fn sample_deprecation(env: &Env) -> DeprecatedFunction {
+    DeprecatedFunction {
+        function: Symbol::new(env, "old_function"),
+        since: String::from_str(env, "v2.0.0"),
+        replacement: Some(Symbol::new(env, "new_function")),
+        removed_in: Some(String::from_str(env, "v3.0.0")),
+        note: String::from_str(env, "This function will be removed in v3.0.0"),
+        migration_guide: Some(String::from_str(env, "docs/deprecation_migration.md")),
+    }
+}
+
+#[test]
+fn test_deprecated_functions_are_tracked() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    storage::set_admin(&env, &admin);
+
+    let deprecation = sample_deprecation(&env);
+    let deprecations = Vec::from_array(&env, [deprecation.clone()]);
+
+    set_deprecated_functions(&env, deprecations).unwrap();
+
+    let stored = get_deprecated_functions(&env);
+    assert_eq!(stored.len(), 1);
+
+    let tracked = get_deprecated_function(&env, Symbol::new(&env, "old_function")).unwrap();
+    assert_eq!(tracked, deprecation);
+}
+
+#[test]
+fn test_deprecation_warning_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    storage::set_admin(&env, &admin);
+
+    let deprecations = Vec::from_array(&env, [sample_deprecation(&env)]);
+    set_deprecated_functions(&env, deprecations).unwrap();
+
+    let initial_event_count = env.events().all().len();
+    emit_deprecation_warning(&env, Symbol::new(&env, "old_function")).unwrap();
+
+    let events = env.events().all();
+    assert!(events.len() > initial_event_count);
+
+    let deprecated_events = events
+        .iter()
+        .filter(|event| {
+            event.topics.len() >= 2 && event.topics[0] == Symbol::new(&env, "Deprecated")
+        })
+        .count();
+    assert_eq!(deprecated_events, 1);
+}

--- a/docs/deprecation_migration.md
+++ b/docs/deprecation_migration.md
@@ -1,0 +1,71 @@
+# Deprecation And Migration Guide
+
+## Overview
+
+The upgradeability layer now supports tracking deprecated contract functions and emitting warnings when those functions are still used after an upgrade. This gives maintainers a safer path for phasing out legacy entrypoints without breaking clients immediately.
+
+## Maintainer Workflow
+
+1. Mark the legacy entrypoint with Rust's deprecation attribute.
+2. Register the deprecated function metadata during the upgrade.
+3. Emit a deprecation warning event whenever the legacy function is called.
+4. Keep the replacement function documented until the removal version is reached.
+
+## Example
+
+```rust
+#[deprecated(since = "v2.0.0", note = "Use new_function instead")]
+pub fn old_function(env: Env) {
+    upgradeability::emit_deprecation_warning(&env, Symbol::new(&env, "old_function"))
+        .ok();
+
+    // Legacy behavior remains available during the migration window.
+}
+```
+
+## Registering Deprecations During Upgrade
+
+Use `upgradeability::execute_upgrade_with_deprecations` when a new release introduces deprecated APIs:
+
+```rust
+let deprecations = soroban_sdk::Vec::from_array(
+    &env,
+    [upgradeability::DeprecatedFunction {
+        function: Symbol::new(&env, "old_function"),
+        since: soroban_sdk::String::from_str(&env, "v2.0.0"),
+        replacement: Some(Symbol::new(&env, "new_function")),
+        removed_in: Some(soroban_sdk::String::from_str(&env, "v3.0.0")),
+        note: soroban_sdk::String::from_str(&env, "This function will be removed in v3.0.0"),
+        migration_guide: Some(soroban_sdk::String::from_str(
+            &env,
+            "docs/deprecation_migration.md",
+        )),
+    }],
+);
+```
+
+## What Gets Stored
+
+Each deprecated function record tracks:
+
+- function name
+- deprecation version
+- replacement function
+- planned removal version
+- deprecation note
+- migration guide reference
+
+## Event Behavior
+
+Calling `upgradeability::emit_deprecation_warning` emits a `Deprecated` event with:
+
+- topic 1: `Deprecated`
+- topic 2: deprecated function name
+- data: deprecation note
+
+## Recommended Removal Process
+
+1. Deprecate the old entrypoint in the first upgrade release.
+2. Keep the old and new functions available during the migration window.
+3. Monitor deprecation events to identify remaining callers.
+4. Remove the old entrypoint in the announced removal version.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -47,3 +47,14 @@ When you make a "breaking change" to the data structure (e.g., V1 to V2):
 
 3.  **Test:**
     Add a test case in `tests/test_migration.rs` that explicitly sets up "Old Data" and verifies it transforms correctly into "New Data".
+
+## Deprecating Old Entry Points During Migration
+
+If a release keeps a legacy function temporarily available, do not remove it immediately. Instead:
+
+1. Add `#[deprecated(...)]` to the old function.
+2. Register that function in the upgradeability deprecation registry.
+3. Emit a deprecation warning event from the old function body.
+4. Point callers to the replacement function and planned removal version.
+
+See [docs/deprecation_migration.md](./deprecation_migration.md) for the recommended pattern.

--- a/docs/upgradeability.md
+++ b/docs/upgradeability.md
@@ -20,6 +20,7 @@ To prevent data corruption during upgrades, the system enforces:
 - **Key Separation**: Critical configuration is stored in `Instance` storage, while user data is in `Persistent` storage.
 - **Version Tracking**: Every contract stores its current version.
 - **Cross-Version Compatibility**: New versions must increment the version number and handle migrations if necessary.
+- **Deprecation Tracking**: Deprecated entrypoints can be registered during upgrades and monitored via emitted warning events.
 
 ## Upgrade Procedure
 
@@ -30,6 +31,17 @@ To prevent data corruption during upgrades, the system enforces:
 5. **Approval**: Obtain necessary validator signatures.
 6. **Execution**: Trigger `execute` on the `UpgradeManager`.
 7. **Migration (Optional)**: If the data layout changed, the new version's `initialize` or a dedicated `migrate` function should be called.
+8. **Deprecation Registration (Optional)**: If old entrypoints remain temporarily supported, register them with the shared upgradeability deprecation registry.
+
+## Deprecation Warnings
+
+The shared `upgradeability` crate now supports:
+
+- tracking deprecated functions in contract storage
+- registering deprecations as part of an upgrade
+- emitting `Deprecated` events when legacy entrypoints are used
+
+For the implementation pattern and migration expectations, see [docs/deprecation_migration.md](./deprecation_migration.md).
 
 ## Security Features
 - **Rollback**: In case of a critical bug, the `UpgradeManager` can facilitate a rollback to the previous known-good WASM hash.


### PR DESCRIPTION
#405 


**PR Description**

This PR adds support for deprecated function tracking in the shared `upgradeability` crate.

It introduces:
- a `DeprecatedFunction` metadata type
- storage and lookup helpers for deprecated functions
- `execute_upgrade_with_deprecations(...)` for registering deprecations during upgrades
- `emit_deprecation_warning(...)` to publish a `Deprecated` event when a legacy function is used
- tests for deprecation tracking and event emission
- documentation updates in the upgradeability and migration guides

This gives contracts a cleaner migration path by allowing maintainers to keep old entrypoints temporarily, warn on usage, and document planned removals and replacements.
