### PR TITLE
Add input validation for credential_registry set_credential_root (#383)

### DIFF
--- a/contracts/credential_registry/src/lib.rs
+++ b/contracts/credential_registry/src/lib.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
 };
 
+const MAX_METADATA_HASH_SIZE: u32 = 32;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct CredentialRootRecord {
@@ -11,6 +13,8 @@ pub struct CredentialRootRecord {
     pub root: BytesN<32>,
     pub metadata_hash: BytesN<32>,
     pub updated_at: u64,
+    pub expiry: u64,
+    pub signature: BytesN<64>,
     pub revoked: bool,
 }
 
@@ -34,6 +38,10 @@ pub enum Error {
     NotAuthorized = 3,
     IssuerNotFound = 4,
     RootVersionNotFound = 5,
+    InvalidCredentialId = 6,
+    InvalidExpiry = 7,
+    InvalidMetadata = 8,
+    InvalidSignature = 9,
 }
 
 #[contract]
@@ -86,10 +94,17 @@ impl CredentialRegistryContract {
         issuer: Address,
         root: BytesN<32>,
         metadata_hash: BytesN<32>,
+        expiry: u64,
+        signature: BytesN<64>,
     ) -> Result<u32, Error> {
         caller.require_auth();
         Self::require_initialized(&env)?;
         Self::require_issuer_manager(&env, &caller, &issuer)?;
+
+        Self::validate_credential_id(&root)?;
+        Self::validate_expiry(&env, expiry)?;
+        Self::validate_metadata_hash(&metadata_hash)?;
+        Self::validate_signature(&signature)?;
 
         let current: u32 = env
             .storage()
@@ -103,6 +118,8 @@ impl CredentialRegistryContract {
             root: root.clone(),
             metadata_hash,
             updated_at: env.ledger().timestamp(),
+            expiry,
+            signature,
             revoked: false,
         };
         env.storage()
@@ -231,6 +248,34 @@ impl CredentialRegistryContract {
         env.storage().persistent().has(&DataKey::ActiveRoot(issuer))
     }
 
+    fn validate_credential_id(root: &BytesN<32>) -> Result<(), Error> {
+        if root.to_array() == [0u8; 32] {
+            return Err(Error::InvalidCredentialId);
+        }
+        Ok(())
+    }
+
+    fn validate_expiry(env: &Env, expiry: u64) -> Result<(), Error> {
+        if expiry <= env.ledger().timestamp() {
+            return Err(Error::InvalidExpiry);
+        }
+        Ok(())
+    }
+
+    fn validate_metadata_hash(metadata_hash: &BytesN<32>) -> Result<(), Error> {
+        if metadata_hash.to_array() == [0u8; MAX_METADATA_HASH_SIZE as usize] {
+            return Err(Error::InvalidMetadata);
+        }
+        Ok(())
+    }
+
+    fn validate_signature(signature: &BytesN<64>) -> Result<(), Error> {
+        if signature.to_array() == [0u8; 64] {
+            return Err(Error::InvalidSignature);
+        }
+        Ok(())
+    }
+
     fn require_initialized(env: &Env) -> Result<(), Error> {
         if env.storage().instance().has(&DataKey::Initialized) {
             Ok(())
@@ -281,26 +326,89 @@ mod tests {
     #![allow(clippy::unwrap_used)]
 
     use super::*;
-    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::testutils::{Address as _, Ledger};
 
-    #[test]
-    fn test_root_lifecycle() {
+    fn setup_env() -> (
+        Env,
+        CredentialRegistryContractClient<'static>,
+        Address,
+        Address,
+    ) {
         let env = Env::default();
         env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
 
         let admin = Address::generate(&env);
         let issuer = Address::generate(&env);
         let contract_id = env.register_contract(None, CredentialRegistryContract);
         let client = CredentialRegistryContractClient::new(&env, &contract_id);
         client.initialize(&admin);
+        (env, client, admin, issuer)
+    }
+
+    #[test]
+    fn test_root_lifecycle() {
+        let (env, client, admin, issuer) = setup_env();
 
         let root_1 = BytesN::from_array(&env, &[11u8; 32]);
         let meta_1 = BytesN::from_array(&env, &[12u8; 32]);
-        let v1 = client.set_credential_root(&admin, &issuer, &root_1, &meta_1);
+        let sig_1 = BytesN::from_array(&env, &[13u8; 64]);
+        let expiry = 2_000_000u64;
+
+        let v1 = client.set_credential_root(&admin, &issuer, &root_1, &meta_1, &expiry, &sig_1);
         assert_eq!(v1, 1);
         assert_eq!(client.get_active_root(&issuer), Some(root_1.clone()));
 
+        let rec = client.get_root(&issuer, &1).unwrap();
+        assert_eq!(rec.expiry, expiry);
+        assert_eq!(rec.signature, sig_1);
+
         assert!(client.revoke_root(&admin, &issuer, &1));
         assert!(client.is_root_revoked(&issuer, &root_1));
+    }
+
+    #[test]
+    fn test_invalid_credential_id_zero_root() {
+        let (env, client, admin, issuer) = setup_env();
+        let zero_root = BytesN::from_array(&env, &[0u8; 32]);
+        let meta = BytesN::from_array(&env, &[12u8; 32]);
+        let sig = BytesN::from_array(&env, &[13u8; 64]);
+        let result =
+            client.try_set_credential_root(&admin, &issuer, &zero_root, &meta, &2_000_000, &sig);
+        assert_eq!(result, Err(Ok(Error::InvalidCredentialId)));
+    }
+
+    #[test]
+    fn test_invalid_expiry_in_past() {
+        let (env, client, admin, issuer) = setup_env();
+        let root = BytesN::from_array(&env, &[11u8; 32]);
+        let meta = BytesN::from_array(&env, &[12u8; 32]);
+        let sig = BytesN::from_array(&env, &[13u8; 64]);
+        let past_expiry = 500_000u64;
+        let result =
+            client.try_set_credential_root(&admin, &issuer, &root, &meta, &past_expiry, &sig);
+        assert_eq!(result, Err(Ok(Error::InvalidExpiry)));
+    }
+
+    #[test]
+    fn test_invalid_metadata_zero_hash() {
+        let (env, client, admin, issuer) = setup_env();
+        let root = BytesN::from_array(&env, &[11u8; 32]);
+        let zero_meta = BytesN::from_array(&env, &[0u8; 32]);
+        let sig = BytesN::from_array(&env, &[13u8; 64]);
+        let result =
+            client.try_set_credential_root(&admin, &issuer, &root, &zero_meta, &2_000_000, &sig);
+        assert_eq!(result, Err(Ok(Error::InvalidMetadata)));
+    }
+
+    #[test]
+    fn test_invalid_signature_zero_bytes() {
+        let (env, client, admin, issuer) = setup_env();
+        let root = BytesN::from_array(&env, &[11u8; 32]);
+        let meta = BytesN::from_array(&env, &[12u8; 32]);
+        let zero_sig = BytesN::from_array(&env, &[0u8; 64]);
+        let result =
+            client.try_set_credential_root(&admin, &issuer, &root, &meta, &2_000_000, &zero_sig);
+        assert_eq!(result, Err(Ok(Error::InvalidSignature)));
     }
 }


### PR DESCRIPTION
Adds expiry date, signature fields, and validation guards to `set_credential_root` in the `credential_registry` contract.

  ## Changes
  - Added `expiry: u64` and `signature: BytesN<64>` to `CredentialRootRecord`
  - Added 4 new error variants: `InvalidCredentialId`, `InvalidExpiry`, `InvalidMetadata`, `InvalidSignature`
  - Validates root/metadata non-zero (required fields + credential ID format), expiry in future, and signature non-zero before any storage write
  - 4 new unit tests covering each error path
  Closes #383