### PR TITLE
Fix: Replace hardcoded SDK versions with workspace dependencies

### DIFF
--- a/contracts/credential_notifications/Cargo.toml
+++ b/contracts/credential_notifications/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/yourusername/soroban-project"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "22.0.10"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "22.0.10", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/patient_gamification/Cargo.toml
+++ b/contracts/patient_gamification/Cargo.toml
@@ -8,10 +8,10 @@ description = "Patient engagement gamification system with achievements, challen
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "21.7.7"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.7.7", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
 [features]
 default = []


### PR DESCRIPTION
 Updates patient_gamification and credential_notifications contracts to use workspace dependencies instead of hardcoded SDK versions, preventing dependency conflicts and ensuring consistent SDK usage across the workspace.

Changes:
patient_gamification: 21.7.7 → { workspace = true }
credential_notifications: 22.0.10 → { workspace = true }
Verification: ✅ cargo build successful

Closes #393 