### PR TITLE
feat: Implemented proper decimal handling for financial calculations

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -25,6 +25,7 @@ pub enum Error {
     InvalidStateTransition = 11,
     Unauthorized = 12,
     NotAdmin = 13,
+    Overflow = 14,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -359,7 +360,11 @@ impl EscrowContract {
         env.storage().persistent().set(&ESCROWS, &escrows);
 
         // interactions: credit balances via pull-payment pattern
-        let fee = (e.amount as i128).saturating_mul(fee_conf.platform_fee_bps as i128) / 10_000;
+        let fee = e
+            .amount
+            .checked_mul(fee_conf.platform_fee_bps as i128)
+            .map(|n| n / 10_000)
+            .ok_or(Error::Overflow)?;
         let provider_amount = e.amount.saturating_sub(fee);
         add_credit(&env, &e.payee, provider_amount);
         add_credit(&env, &fee_conf.fee_receiver, fee);

--- a/contracts/fp_math/Cargo.toml
+++ b/contracts/fp_math/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "fp-math"
+version = "0.1.0"
+edition = "2021"
+
+[lib]

--- a/contracts/fp_math/src/lib.rs
+++ b/contracts/fp_math/src/lib.rs
@@ -1,0 +1,108 @@
+#![no_std]
+
+/// Multiply `amount` by basis points (1 bps = 0.01%) using floor division.
+///
+/// Floor rounding ensures fees are never rounded up — the fee taker always
+/// receives ≤ the exact fractional amount. Callers can reconstruct the
+/// complementary side as `amount - fee` to guarantee `fee + remainder == amount`.
+///
+/// Returns `None` if the intermediate `amount * bps` overflows `i128`.
+pub fn mul_bps(amount: i128, bps: u32) -> Option<i128> {
+    amount.checked_mul(bps as i128).map(|n| n / 10_000)
+}
+
+/// Multiply `amount` by basis points with round-half-up rounding.
+///
+/// Returns `None` on overflow.
+pub fn mul_bps_round_half_up(amount: i128, bps: u32) -> Option<i128> {
+    amount
+        .checked_mul(bps as i128)
+        .and_then(|n| n.checked_add(5_000))
+        .map(|n| n / 10_000)
+}
+
+/// Calculate tokens to allocate for a payment:
+/// `tokens = payment * 10^token_decimals / price_per_token`
+///
+/// Returns `None` on overflow or if `price_per_token` is zero.
+pub fn tokens_for_payment(
+    payment: u128,
+    price_per_token: u128,
+    token_decimals: u32,
+) -> Option<u128> {
+    if price_per_token == 0 {
+        return None;
+    }
+    let scale = 10u128.checked_pow(token_decimals)?;
+    payment.checked_mul(scale)?.checked_div(price_per_token)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mul_bps_basic() {
+        assert_eq!(mul_bps(1000, 1000), Some(100)); // 10% of 1000
+        assert_eq!(mul_bps(1000, 250), Some(25)); // 2.5% of 1000
+        assert_eq!(mul_bps(1000, 10_000), Some(1000)); // 100%
+        assert_eq!(mul_bps(0, 500), Some(0));
+        assert_eq!(mul_bps(1000, 0), Some(0));
+    }
+
+    #[test]
+    fn test_mul_bps_floor_and_conservation() {
+        // floor: 33.33% of 100 = 33, not 34
+        let fee = mul_bps(100, 3333).unwrap();
+        assert_eq!(fee, 33);
+        // conservation: fee + remainder == amount
+        assert_eq!(fee + (100 - fee), 100);
+    }
+
+    #[test]
+    fn test_mul_bps_overflow() {
+        // i128::MAX * 2 overflows i128 in checked_mul
+        assert_eq!(mul_bps(i128::MAX, 2), None);
+        // i128::MAX * 1 = i128::MAX — no overflow, result is i128::MAX / 10_000
+        assert!(mul_bps(i128::MAX, 1).is_some());
+    }
+
+    #[test]
+    fn test_mul_bps_round_half_up() {
+        // 3 * 3333 = 9999 → floor 0, half-up 1
+        assert_eq!(mul_bps(3, 3333), Some(0));
+        assert_eq!(mul_bps_round_half_up(3, 3333), Some(1));
+        // exact multiple: no rounding difference
+        assert_eq!(mul_bps(1000, 250), mul_bps_round_half_up(1000, 250));
+    }
+
+    #[test]
+    fn test_tokens_for_payment_6_decimals() {
+        // 500 payment at price=100, 6 decimals → 500 * 1_000_000 / 100 = 5_000_000
+        assert_eq!(tokens_for_payment(500, 100, 6), Some(5_000_000));
+    }
+
+    #[test]
+    fn test_tokens_for_payment_7_decimals() {
+        // Stellar standard: 7 decimals
+        assert_eq!(tokens_for_payment(1_000_000, 500_000, 7), Some(20_000_000));
+    }
+
+    #[test]
+    fn test_tokens_for_payment_division_by_zero() {
+        assert_eq!(tokens_for_payment(1000, 0, 6), None);
+    }
+
+    #[test]
+    fn test_tokens_for_payment_overflow() {
+        // 10^39 > u128::MAX so decimals=39 overflows the scale
+        assert_eq!(tokens_for_payment(1, 1, 39), None);
+        // payment * scale overflow
+        assert_eq!(tokens_for_payment(u128::MAX, 1, 1), None);
+    }
+
+    #[test]
+    fn test_tokens_for_payment_zero_payment() {
+        assert_eq!(tokens_for_payment(0, 100, 6), Some(0));
+    }
+}

--- a/contracts/payment_router/Cargo.toml
+++ b/contracts/payment_router/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk.workspace = true
+fp-math = { path = "../fp_math" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/payment_router/src/lib.rs
+++ b/contracts/payment_router/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+extern crate fp_math;
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
 };
@@ -10,6 +12,7 @@ use soroban_sdk::{
 pub enum Error {
     InvalidFeeBps = 1,
     FeeNotSet = 2,
+    Overflow = 3,
     InsufficientFunds = 10,
     DeadlineExceeded = 11,
     InvalidSignature = 12,
@@ -59,7 +62,7 @@ impl PaymentRouter {
             .persistent()
             .get(&FEE_CONF)
             .ok_or(Error::FeeNotSet)?;
-        let fee = amount.saturating_mul(conf.platform_fee_bps as i128) / 10_000;
+        let fee = fp_math::mul_bps(amount, conf.platform_fee_bps).ok_or(Error::Overflow)?;
         let provider = amount.saturating_sub(fee);
         env.events()
             .publish((symbol_short!("FeeSplit"),), (provider, fee));

--- a/contracts/token_sale/Cargo.toml
+++ b/contracts/token_sale/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk.workspace = true
+fp-math = { path = "../fp_math" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/token_sale/src/contract.rs
+++ b/contracts/token_sale/src/contract.rs
@@ -7,6 +7,7 @@
 use crate::storage::*;
 use crate::types::*;
 use soroban_sdk::{contract, contractimpl, contractmeta, token, Address, Env};
+extern crate fp_math;
 
 // Metadata that is added on to every WASM custom section
 contractmeta!(
@@ -27,6 +28,7 @@ impl TokenSaleContract {
         treasury: Address,
         soft_cap: u128,
         hard_cap: u128,
+        token_decimals: u32,
     ) {
         if env.storage().instance().has(&DataKey::Config) {
             return; // Already initialized - early return instead of panic
@@ -35,12 +37,14 @@ impl TokenSaleContract {
         owner.require_auth();
 
         assert!(soft_cap <= hard_cap, "Soft cap must be <= hard cap");
+        assert!(token_decimals <= 18, "Decimals must be <= 18");
 
         let config = SaleConfig {
             token_address: token_address.clone(),
             treasury: treasury.clone(),
             soft_cap,
             hard_cap,
+            token_decimals,
             is_finalized: false,
             refunds_enabled: false,
         };
@@ -157,8 +161,10 @@ impl TokenSaleContract {
         assert!(current_time >= phase.start_time, "Phase not started");
         assert!(current_time <= phase.end_time, "Phase ended");
 
-        // Calculate tokens to allocate
-        let tokens_to_allocate = (amount * 1_000_000) / phase.price_per_token; // Assuming 6 decimal places
+        // Calculate tokens to allocate using configurable decimal precision
+        let tokens_to_allocate =
+            fp_math::tokens_for_payment(amount, phase.price_per_token, config.token_decimals)
+                .expect("token allocation overflow");
         assert!(
             phase.sold_tokens + tokens_to_allocate <= phase.max_tokens,
             "Phase cap exceeded"

--- a/contracts/token_sale/src/test.rs
+++ b/contracts/token_sale/src/test.rs
@@ -34,7 +34,7 @@ fn test_token_sale_initialization() {
     let contract_id = env.register_contract(None, TokenSaleContract);
     let client = TokenSaleContractClient::new(&env, &contract_id);
 
-    client.initialize(&owner, &token_address, &treasury, &1000, &10000);
+    client.initialize(&owner, &token_address, &treasury, &1000, &10000, &6u32);
 
     let config = client.get_config();
     assert_eq!(config.token_address, token_address);
@@ -56,7 +56,7 @@ fn test_add_sale_phase() {
     let contract_id = env.register_contract(None, TokenSaleContract);
     let client = TokenSaleContractClient::new(&env, &contract_id);
 
-    client.initialize(&owner, &token_address, &treasury, &1000, &10000);
+    client.initialize(&owner, &token_address, &treasury, &1000, &10000, &6u32);
 
     // Add a sale phase
     let start_time = 1000;
@@ -101,7 +101,7 @@ fn test_contribution_and_claim() {
     let client = TokenSaleContractClient::new(&env, &contract_id);
 
     // Initialize contract
-    client.initialize(&owner, &sut_token_address, &treasury, &500, &10000);
+    client.initialize(&owner, &sut_token_address, &treasury, &500, &10000, &6u32);
 
     // Add supported payment token
     client.add_supported_token(&payment_token_address);
@@ -221,7 +221,7 @@ fn test_refund_mechanism() {
     let client = TokenSaleContractClient::new(&env, &contract_id);
 
     // Initialize with high soft cap that won't be met
-    client.initialize(&owner, &sut_token_address, &treasury, &10000, &20000);
+    client.initialize(&owner, &sut_token_address, &treasury, &10000, &20000, &6u32);
     client.add_supported_token(&payment_token_address);
 
     env.ledger().with_mut(|li| {

--- a/contracts/token_sale/src/types.rs
+++ b/contracts/token_sale/src/types.rs
@@ -39,6 +39,7 @@ pub struct SaleConfig {
     pub treasury: Address,      // Treasury address for funds
     pub soft_cap: u128,         // Minimum raise target
     pub hard_cap: u128,         // Maximum raise target
+    pub token_decimals: u32,    // Decimal places of the SUT token (e.g. 6 or 7)
     pub is_finalized: bool,
     pub refunds_enabled: bool,
 }

--- a/contracts/token_sale/src/vesting.rs
+++ b/contracts/token_sale/src/vesting.rs
@@ -27,6 +27,7 @@ impl VestingContract {
             treasury: owner.clone(),
             soft_cap: 0,
             hard_cap: 0,
+            token_decimals: 7,
             is_finalized: false,
             refunds_enabled: false,
         };


### PR DESCRIPTION
New: contracts/fp_math/ — shared fixed-point math library

mul_bps(amount, bps) -> Option<i128> — floor division, returns None on overflow
mul_bps_round_half_up(amount, bps) -> Option<i128> — half-up rounding
tokens_for_payment(payment, price, decimals) -> Option<u128> — configurable decimal precision, None on overflow or zero price
9 unit tests covering edge cases, overflow, conservation invariant
payment_router — compute_split replaced saturating_mul / 10_000 with fp_math::mul_bps, returns new Overflow = 3 error instead of silently capping

escrow — release_escrow replaced same pattern with checked_mul().map(|n| n / 10_000).ok_or(Overflow)? inline (excluded from workspace so no path dep)

token_sale — three changes:

SaleConfig gains token_decimals: u32 field (replaces hardcoded 1_000_000)
initialize() takes token_decimals parameter + asserts <= 18
contribute() uses fp_math::tokens_for_payment — panics on overflow rather than silently wrong allocation
All 4 test call-sites updated to pass token_decimals: 6


Closes: #395 