### PR TITLE
fix: resolve CI workflow bugs and add quality/security tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Run Clippy
+      - name: Run Clippy (static analysis)
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   # Tests
@@ -137,6 +137,66 @@ jobs:
 
       - name: Run all tests
         run: cargo test --all
+
+  # Coverage Enforcement (#465)
+  coverage:
+    name: Test Coverage Enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config libudev-dev libhidapi-dev
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-tarpaulin
+        run: cargo install --locked cargo-tarpaulin
+
+      - name: Run coverage with threshold enforcement
+        run: |
+          cargo tarpaulin \
+            --out Xml Html \
+            --output-dir coverage/ \
+            --timeout 600 \
+            --exclude-files "tests/*" \
+            --ignore-panics \
+            --ignore-timeouts \
+            --fail-under 70
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
+      - name: Publish coverage summary
+        if: always()
+        run: |
+          echo "## Coverage Report" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f coverage/tarpaulin-report.xml ]; then
+            echo "Coverage report generated. See artifact for full HTML report." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
   # Node.js Integration Tests
   test-nodejs:
@@ -193,7 +253,7 @@ jobs:
       - name: Build optimized contracts
         run: |
           set -euo pipefail
-          
+
           # Build all workspace contracts from root (respects workspace dependencies)
           echo "Building all workspace contracts..."
           if cargo build --target wasm32-unknown-unknown --release --workspace; then
@@ -202,7 +262,7 @@ jobs:
             echo "❌ Workspace build failed"
             exit 1
           fi
-          
+
           # Copy WASM files from root target directory
           mkdir -p dist
           if ls target/wasm32-unknown-unknown/release/*.wasm 1> /dev/null 2>&1; then
@@ -212,6 +272,13 @@ jobs:
           else
             echo "⚠️ No WASM files found in target directory"
           fi
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-contracts
+          path: dist/*.wasm
+          retention-days: 7
 
   # Contract interoperability tests
   test-interoperability:
@@ -245,16 +312,6 @@ jobs:
 
       - name: Run interoperability suite
         run: cargo test -p interoperability_suite --test contract_interoperability -- --nocapture
-
-  # Build contracts
-  build:
-    name: Build Contracts
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: wasm-contracts
-          path: dist/*.wasm
-          retention-days: 7
 
   # Security Scan (lightweight - only on PRs and main branch)
   security:
@@ -328,31 +385,65 @@ jobs:
             cat security-reports/security-summary.md >> "$GITHUB_STEP_SUMMARY"
           fi
 
+  # Quality Metrics Dashboard (#469)
+  quality-metrics:
+    name: Quality Metrics Dashboard
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [lint, test, test-nodejs, build, security]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate quality metrics dashboard
+        run: |
+          mkdir -p reports/quality
+          cat > reports/quality/dashboard.md << 'DASHBOARD'
+          # Quality Metrics Dashboard
+
+          | Metric | Job | Status |
+          |--------|-----|--------|
+          | Lint & Format | lint | ${{ needs.lint.result }} |
+          | Unit/Integration Tests | test | ${{ needs.test.result }} |
+          | Node.js API Tests | test-nodejs | ${{ needs.test-nodejs.result }} |
+          | WASM Build | build | ${{ needs.build.result }} |
+          | Security Scan | security | ${{ needs.security.result }} |
+          DASHBOARD
+
+          echo "## 📊 Quality Metrics Dashboard" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Metric | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Lint & Format | ${{ needs.lint.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Tests | ${{ needs.test.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Node.js Tests | ${{ needs.test-nodejs.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Build | ${{ needs.build.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Security | ${{ needs.security.result }} |" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload quality dashboard
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-metrics-dashboard
+          path: reports/quality/
+          retention-days: 30
+
   # Summary
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [test-unit, test-integration, test-interoperability, build]
     needs: [lint, test, test-nodejs, build, security]
     if: always()
     steps:
       - name: Generate summary
         run: |
-          echo "## Test Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- Unit Tests: ${{ needs.test-unit.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Integration Tests: ${{ needs.test-integration.result }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Interoperability Suite: ${{ needs.test-interoperability.result }}" >> $GITHUB_STEP_SUMMARY
           echo "## CI Summary" >> $GITHUB_STEP_SUMMARY
           echo "- Lint & Format: ${{ needs.lint.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Tests: ${{ needs.test.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Node.js Tests: ${{ needs.test-nodejs.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Build: ${{ needs.build.result }}" >> $GITHUB_STEP_SUMMARY
           echo "- Security: ${{ needs.security.result }}" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "${{ needs.test-unit.result }}" != "success" ] || \
-             [ "${{ needs.test-integration.result }}" != "success" ] || \
-             [ "${{ needs.test-interoperability.result }}" != "success" ] || \
-             [ "${{ needs.build.result }}" != "success" ]; then
+
           if [ "${{ needs.lint.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.test-nodejs.result }}" != "success" ] || \

--- a/docs/QUALITY_METRICS_DASHBOARD.md
+++ b/docs/QUALITY_METRICS_DASHBOARD.md
@@ -1,0 +1,122 @@
+# Quality Metrics Dashboard
+
+This document describes the automated quality metrics tracked across all Uzima contracts and how to access them.
+
+---
+
+## Metrics Tracked in CI
+
+Every CI run produces a quality metrics summary in the GitHub Actions job summary. The `quality-metrics` job in `.github/workflows/ci.yml` aggregates results from all CI jobs.
+
+| Metric | Source | Threshold |
+|--------|--------|-----------|
+| Lint & Format | `cargo fmt --check` + `cargo clippy` | Zero warnings/errors |
+| Test pass rate | `cargo test --all` | 100% pass |
+| Code coverage | `cargo-tarpaulin` | ≥ 70% (enforced) |
+| Node.js API tests | `npm test` in `integrations/cloud_health_api` | 100% pass |
+| WASM build | `cargo build --target wasm32-unknown-unknown` | Must succeed |
+| Security scan | `cargo-audit`, `cargo-geiger`, Gitleaks | Zero critical findings |
+| Testing pyramid | `npm run test:pyramid:report` | Pyramid ratios met |
+| Event schema validation | `npm run events:validate` | All schemas valid |
+
+---
+
+## Accessing Reports
+
+### GitHub Actions (per-run)
+
+1. Go to the **Actions** tab on GitHub
+2. Select a workflow run
+3. Scroll to **Artifacts** at the bottom of the run summary
+4. Download any of:
+   - `coverage-report` – HTML coverage report from tarpaulin
+   - `quality-metrics-dashboard` – Markdown dashboard for the run
+   - `testing-pyramid-report` – JSON + Markdown pyramid report
+   - `security-reports` – Security scan results
+
+### Job Summary
+
+Each CI run writes a quality dashboard directly to the GitHub Actions job summary, visible inline on the run page without downloading artifacts.
+
+---
+
+## Coverage Trends
+
+Coverage is enforced at **≥ 70%** overall via `cargo-tarpaulin --fail-under 70` in the `coverage` CI job. The threshold is defined in `.github/workflows/ci.yml`.
+
+To run coverage locally:
+
+```bash
+# Install tarpaulin (once)
+cargo install cargo-tarpaulin
+
+# Run with HTML output
+cargo tarpaulin --out Html --output-dir coverage/ --timeout 600 \
+  --exclude-files "tests/*" --ignore-panics --ignore-timeouts
+
+# Open report
+open coverage/tarpaulin-report.html
+```
+
+Or use the project script:
+
+```bash
+./scripts/coverage_report.sh
+```
+
+---
+
+## Code Complexity
+
+Clippy enforces complexity limits as part of the `lint` CI job:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+To check locally:
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+---
+
+## Security Scan Results
+
+Security metrics are produced by the `security` CI job (runs on PRs and pushes to `main`) and the weekly scan in `weekly-security-report.yml`.
+
+Tools used:
+- `cargo-audit` – known CVEs in dependencies
+- `cargo-geiger` – unsafe code usage
+- Gitleaks – secret detection
+
+Weekly reports are uploaded as artifacts and retained for 30 days.
+
+---
+
+## Documentation Completeness
+
+All public contract functions should have doc comments. Clippy's `missing_docs` lint is available but not yet enforced globally. Track documentation coverage manually via:
+
+```bash
+cargo doc --no-deps --document-private-items 2>&1 | grep "warning: missing documentation"
+```
+
+---
+
+## Issue and Bug Trends
+
+Track open issues by label on GitHub:
+- [`bug`](https://github.com/Stellar-Uzima/Uzima-Contracts/labels/bug)
+- [`security`](https://github.com/Stellar-Uzima/Uzima-Contracts/labels/security)
+- [`quality-metrics`](https://github.com/Stellar-Uzima/Uzima-Contracts/labels/quality-metrics)
+
+---
+
+## Related
+
+- [Testing Best Practices](testing/TESTING_BEST_PRACTICES.md)
+- [Testing Pyramid](testing/TESTING_PYRAMID.md)
+- [Static Analysis Integration](STATIC_ANALYSIS.md)
+- [Security Controls Mapping](SECURITY_CONTROLS_MAPPING.md)

--- a/docs/SECURITY_INCIDENT_RESPONSE.md
+++ b/docs/SECURITY_INCIDENT_RESPONSE.md
@@ -1,0 +1,174 @@
+# Security Incident Response Procedures
+
+This document defines the procedures for detecting, responding to, and recovering from security incidents in the Uzima Contracts system.
+
+---
+
+## Severity Classification
+
+| Severity | Description | Response Time |
+|----------|-------------|---------------|
+| **P0 – Critical** | Active exploit, data breach, contract funds at risk | Immediate (< 1 hour) |
+| **P1 – High** | Vulnerability confirmed, no active exploit yet | < 4 hours |
+| **P2 – Medium** | Potential vulnerability, limited impact | < 24 hours |
+| **P3 – Low** | Minor issue, no immediate risk | < 72 hours |
+
+---
+
+## 1. Vulnerability Disclosure Process
+
+### Reporting a Vulnerability
+
+- **Private disclosure**: Email `security@uzima.health` with subject `[SECURITY] <brief description>`
+- **GitHub**: Use [GitHub Security Advisories](https://github.com/Stellar-Uzima/Uzima-Contracts/security/advisories/new) (do **not** open a public issue)
+- Include: affected contract(s), reproduction steps, potential impact, and suggested fix if known
+
+### Acknowledgement & Triage
+
+1. Acknowledge receipt within **24 hours**
+2. Assign severity (P0–P3) within **4 hours** of acknowledgement
+3. Notify reporter of severity and expected timeline
+4. Open a private tracking issue with label `security`
+
+---
+
+## 2. Emergency Response Plan
+
+### P0 / P1 Incident Steps
+
+```
+1. DETECT   → Alert fires or report received
+2. TRIAGE   → Confirm severity, identify affected contracts/networks
+3. CONTAIN  → Pause affected contract functions if possible (emergency_access_override)
+4. ASSESS   → Determine scope: funds at risk? data exposed? which users?
+5. PATCH    → Develop and test fix on local/testnet
+6. DEPLOY   → Deploy patch via deploy workflow (requires 2-person approval for mainnet)
+7. VERIFY   → Confirm fix resolves issue; monitor for 24 hours
+8. DISCLOSE → Publish advisory after patch is live
+9. POSTMORTEM → Complete postmortem within 5 business days (see INCIDENT_POSTMORTEM_TEMPLATE.md)
+```
+
+### Incident Commander Responsibilities
+
+- Declare incident severity and own the response timeline
+- Coordinate communication between engineering, security, and stakeholders
+- Authorize emergency contract pauses or rollbacks
+- Sign off on patch deployment to mainnet
+
+### On-Call Rotation
+
+Maintain a documented on-call schedule. The on-call engineer is the first responder for P0/P1 alerts and must be reachable within 30 minutes.
+
+---
+
+## 3. Communication Templates
+
+### Internal Alert (Slack / Email)
+
+```
+🚨 SECURITY INCIDENT – [P0/P1/P2/P3]
+Contract(s): <name>
+Network: <testnet/mainnet>
+Summary: <one sentence>
+Impact: <what is at risk>
+Incident Commander: <name>
+Tracking: <private issue link>
+Next update: <time>
+```
+
+### External Disclosure (after patch)
+
+```
+Subject: Security Advisory – Uzima Contracts [CVE/GHSA ID]
+
+We have identified and patched a [severity] vulnerability in [contract name].
+
+Affected versions: <range>
+Fixed in: <version/commit>
+Impact: <description>
+Recommended action: <upgrade instructions>
+
+Full details: <advisory link>
+```
+
+### User Notification (if data or funds affected)
+
+```
+Subject: Important Security Notice – Action Required
+
+We are contacting you because a security issue may have affected your account.
+
+What happened: <brief description>
+What data/funds were affected: <specifics>
+What we have done: <remediation steps>
+What you should do: <user action items>
+
+Contact: security@uzima.health
+```
+
+---
+
+## 4. Post-Incident Analysis Process
+
+After every P0/P1 incident, and optionally for P2/P3:
+
+1. **Schedule postmortem** within 48 hours of resolution
+2. **Complete postmortem document** using `docs/INCIDENT_POSTMORTEM_TEMPLATE.md`
+3. **Identify root cause** (not blame) and contributing factors
+4. **Define action items** with owners and due dates
+5. **Publish postmortem** internally within 5 business days
+6. **Track action items** to completion in GitHub issues
+
+Postmortem examples: `docs/examples/INCIDENT_POSTMORTEM_EXAMPLE.md`
+
+---
+
+## 5. Patch and Deployment Procedures
+
+### Emergency Patch Process
+
+1. Create a private branch: `security/fix-<short-description>`
+2. Develop fix with tests covering the vulnerability
+3. Review: minimum 2 engineers must approve (one must be a maintainer)
+4. Deploy to testnet and verify fix
+5. For mainnet: use `deploy.yml` workflow with `confirm_mainnet: DEPLOY`
+6. Tag release with patch version (e.g., `v1.2.1`)
+7. Publish GitHub Security Advisory
+
+### Contract Pause (Emergency)
+
+If a contract must be paused immediately:
+
+```bash
+# Via emergency_access_override contract
+./scripts/interact.sh <CONTRACT_ID> mainnet emergency_pause \
+  --reason "Security incident <ID>" \
+  --duration 3600
+```
+
+### Rollback
+
+If a patch introduces regressions:
+
+```bash
+./scripts/rollback_deployment.sh <contract_name> mainnet <backup_file>
+```
+
+See `docs/EMERGENCY_PLAYBOOKS.md` for detailed runbooks.
+
+---
+
+## 6. Tools and References
+
+| Resource | Location |
+|----------|----------|
+| Postmortem template | `docs/INCIDENT_POSTMORTEM_TEMPLATE.md` |
+| Emergency playbooks | `docs/EMERGENCY_PLAYBOOKS.md` |
+| Security controls mapping | `docs/SECURITY_CONTROLS_MAPPING.md` |
+| Threat models | `docs/MASTER_THREAT_MODEL.md` |
+| Weekly security scan | `.github/workflows/weekly-security-report.yml` |
+| Security scan script | `scripts/security-scan.sh` |
+
+---
+
+*Maintained by the Uzima security team. Review and update this document after every P0/P1 incident.*

--- a/docs/STATIC_ANALYSIS.md
+++ b/docs/STATIC_ANALYSIS.md
@@ -1,0 +1,145 @@
+# Static Analysis Tool Integration
+
+This document describes the static analysis tools integrated into the Uzima Contracts CI/CD pipeline and how to use them locally.
+
+---
+
+## Tools
+
+### 1. Clippy (Rust Linting)
+
+Clippy is the primary static analysis tool for Rust code. It is enforced in the `lint` CI job on every push and pull request.
+
+**CI command:**
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+All Clippy warnings are treated as errors (`-D warnings`). PRs cannot merge if Clippy reports any issues.
+
+**Run locally:**
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+**Fix automatically where possible:**
+```bash
+cargo clippy --fix --all-targets --all-features
+```
+
+### 2. rustfmt (Formatting)
+
+Code formatting is enforced in the `lint` CI job.
+
+**CI command:**
+```bash
+cargo fmt --all -- --check
+```
+
+**Fix locally:**
+```bash
+cargo fmt --all
+```
+
+### 3. cargo-audit (Dependency Vulnerability Scanning)
+
+Scans `Cargo.lock` for dependencies with known CVEs.
+
+**CI:** Runs in the `security` job (PRs + main branch) and weekly via `weekly-security-report.yml`.
+
+**Run locally:**
+```bash
+cargo install cargo-audit
+cargo audit
+```
+
+### 4. cargo-geiger (Unsafe Code Detection)
+
+Counts and reports `unsafe` code usage across the workspace and all dependencies.
+
+**CI:** Runs in the `security` job via `scripts/security-scan.sh`.
+
+**Run locally:**
+```bash
+cargo install cargo-geiger
+cargo geiger
+```
+
+### 5. Gitleaks (Secret Detection)
+
+Scans git history and working tree for accidentally committed secrets (API keys, private keys, tokens).
+
+**CI:** Runs in the `security` job. On PRs, scans only the PR commit range. On main branch pushes, scans the full repository.
+
+**Run locally:**
+```bash
+# Install
+brew install gitleaks  # macOS
+# or download from https://github.com/gitleaks/gitleaks/releases
+
+# Scan working directory
+gitleaks detect --source . --redact
+```
+
+---
+
+## CI Integration Summary
+
+| Tool | CI Job | Trigger | Failure Behavior |
+|------|--------|---------|-----------------|
+| Clippy | `lint` | Every push/PR | Blocks merge |
+| rustfmt | `lint` | Every push/PR | Blocks merge |
+| cargo-audit | `security` | PRs + main | Blocks merge |
+| cargo-geiger | `security` | PRs + main | Reports only |
+| Gitleaks | `security` | PRs + main | Blocks merge |
+
+---
+
+## Baseline Issues
+
+Run the following to establish a baseline of existing issues before enforcing new rules:
+
+```bash
+# Clippy baseline
+cargo clippy --all-targets --all-features 2>&1 | grep "^error\|^warning" | wc -l
+
+# Audit baseline
+cargo audit 2>&1 | tail -5
+
+# Unsafe code baseline
+cargo geiger 2>&1 | grep "Total"
+```
+
+---
+
+## Adding New Lint Rules
+
+To add project-wide Clippy lints, edit the workspace `Cargo.toml`:
+
+```toml
+[workspace.lints.clippy]
+# Example: enforce explicit returns
+explicit_returns = "warn"
+```
+
+Or add to individual contract `lib.rs` files:
+
+```rust
+#![warn(clippy::pedantic)]
+#![deny(clippy::unwrap_used)]
+```
+
+---
+
+## Formal Verification (Future)
+
+Formal verification tooling (e.g., Kani, Prusti) is tracked as a future enhancement. See `docs/DECISION_PROCEDURES.md` for the current decision framework.
+
+---
+
+## Related
+
+- [Quality Metrics Dashboard](QUALITY_METRICS_DASHBOARD.md)
+- [Security Controls Mapping](SECURITY_CONTROLS_MAPPING.md)
+- [Security Incident Response](SECURITY_INCIDENT_RESPONSE.md)
+- [Weekly Security Report workflow](../.github/workflows/weekly-security-report.yml)


### PR DESCRIPTION
## Summary

Fixes CI workflow bugs and implements the tooling/documentation required by issues #465, #466, #469, and #471.

## Workflow Bugs Fixed

- **Duplicate `build` job**: The `ci.yml` had two `build:` job definitions. The second (broken) one with orphaned steps has been removed.
- **Duplicate `needs` key in `summary` job**: YAML only honours the last key when duplicated; the first (referencing non-existent `test-unit` / `test-integration` jobs) has been removed.
- **Wrong job references in `summary`**: References to `test-unit` and `test-integration` (which don't exist) replaced with the correct jobs: `lint`, `test`, `test-nodejs`, `build`, `security`.

## Issue Resolutions

| Issue | Change |
|-------|--------|
| #465 – Test coverage enforcement | Added `coverage` CI job running `cargo-tarpaulin --fail-under 70`; uploads HTML report as artifact |
| #466 – Security incident response | Created `docs/SECURITY_INCIDENT_RESPONSE.md` with severity classification, disclosure process, emergency response plan, communication templates, post-incident analysis, and patch/deployment procedures |
| #469 – Quality metrics dashboard | Added `quality-metrics` CI job that writes a metrics table to the job summary; created `docs/QUALITY_METRICS_DASHBOARD.md` documenting all tracked metrics and how to access reports |
| #471 – Static analysis integration | Created `docs/STATIC_ANALYSIS.md` documenting Clippy, rustfmt, cargo-audit, cargo-geiger, and Gitleaks integration; CI enforcement details and local usage instructions |

## Files Changed

- `.github/workflows/ci.yml` – bug fixes + new `coverage` and `quality-metrics` jobs
- `docs/SECURITY_INCIDENT_RESPONSE.md` – new
- `docs/QUALITY_METRICS_DASHBOARD.md` – new
- `docs/STATIC_ANALYSIS.md` – new

Closes #465
Closes #466
Closes #469
Closes #471