### PR TITLE
Fix: Potential Integer overflow in token calculations

### DIFF
--- a/contract_optimizer/src/lib.rs
+++ b/contract_optimizer/src/lib.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
-use syn::{visit::Visit, File, ItemFn, ExprCall, ExprMethodCall, Expr};
+use syn::{visit::Visit, Expr, ExprCall, ExprMethodCall, File, ItemFn};
 use walkdir::WalkDir;
 
 pub mod metrics;
@@ -10,7 +10,7 @@ pub mod metrics;
 pub struct OptimizationRecommendation {
     pub category: String,
     pub description: String,
-    pub severity: String, // "low", "medium", "high"
+    pub severity: String,         // "low", "medium", "high"
     pub location: Option<String>, // file:line
     pub suggestion: String,
 }
@@ -21,12 +21,22 @@ pub struct ContractAnalysis {
     pub optimizations: Vec<OptimizationRecommendation>,
 }
 
-pub fn analyze_contracts(contracts_path: &Path) -> Result<Vec<ContractAnalysis>, Box<dyn std::error::Error>> {
+pub fn analyze_contracts(
+    contracts_path: &Path,
+) -> Result<Vec<ContractAnalysis>, Box<dyn std::error::Error>> {
     let mut analyses = Vec::new();
 
-    for entry in WalkDir::new(contracts_path).into_iter().filter_map(|e| e.ok()) {
+    for entry in WalkDir::new(contracts_path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
         if entry.file_type().is_file() && entry.path().extension().unwrap_or_default() == "rs" {
-            if let Some(contract_name) = entry.path().parent().and_then(|p| p.file_name()).and_then(|n| n.to_str()) {
+            if let Some(contract_name) = entry
+                .path()
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+            {
                 if let Ok(content) = std::fs::read_to_string(entry.path()) {
                     let optimizations = analyze_file(&content, entry.path());
                     if !optimizations.is_empty() {
@@ -41,7 +51,8 @@ pub fn analyze_contracts(contracts_path: &Path) -> Result<Vec<ContractAnalysis>,
     }
 
     // Record metrics
-    let mut metrics = metrics::AccuracyMetrics::load(Path::new("optimization_metrics.json")).unwrap_or_default();
+    let mut metrics =
+        metrics::AccuracyMetrics::load(Path::new("optimization_metrics.json")).unwrap_or_default();
     metrics.record_recommendations(&analyses);
     metrics.save(Path::new("optimization_metrics.json"))?;
 
@@ -104,23 +115,31 @@ impl<'a> Visit<'a> for OptimizationVisitor<'a> {
                                                 location: Some(format!("{}:{}", self.path.display(), line_number(node))),
                                                 suggestion: "Consider batching storage operations or using temporary variables".to_string(),
                                             });
-                                        }
+                                        },
                                         "events" => {
                                             self.recommendations.push(OptimizationRecommendation {
                                                 category: "Gas Optimization".to_string(),
-                                                description: "Event emission in loop or frequent call".to_string(),
+                                                description:
+                                                    "Event emission in loop or frequent call"
+                                                        .to_string(),
                                                 severity: "low".to_string(),
-                                                location: Some(format!("{}:{}", self.path.display(), line_number(node))),
-                                                suggestion: "Emit events outside of loops when possible".to_string(),
+                                                location: Some(format!(
+                                                    "{}:{}",
+                                                    self.path.display(),
+                                                    line_number(node)
+                                                )),
+                                                suggestion:
+                                                    "Emit events outside of loops when possible"
+                                                        .to_string(),
                                             });
-                                        }
-                                        _ => {}
+                                        },
+                                        _ => {},
                                     }
                                 }
                             }
                         }
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
             }
         }
@@ -137,7 +156,8 @@ impl<'a> OptimizationVisitor<'a> {
                     description: format!("Loop detected in function '{}'", fn_name),
                     severity: "medium".to_string(),
                     location: Some(format!("{}:{}", self.path.display(), line_number(for_loop))),
-                    suggestion: "Consider if loop iterations can be reduced or operations batched".to_string(),
+                    suggestion: "Consider if loop iterations can be reduced or operations batched"
+                        .to_string(),
                 });
             }
         }
@@ -158,7 +178,8 @@ fn analyze_text_patterns(content: &str, path: &Path) -> Vec<OptimizationRecommen
                 description: "Dynamic vector allocation detected".to_string(),
                 severity: "low".to_string(),
                 location: Some(format!("{}:{}", path.display(), line_num)),
-                suggestion: "Consider using fixed-size arrays or pre-allocating capacity".to_string(),
+                suggestion: "Consider using fixed-size arrays or pre-allocating capacity"
+                    .to_string(),
             });
         }
 
@@ -180,7 +201,8 @@ fn analyze_text_patterns(content: &str, path: &Path) -> Vec<OptimizationRecommen
                 description: "Storage write in loop detected".to_string(),
                 severity: "high".to_string(),
                 location: Some(format!("{}:{}", path.display(), line_num)),
-                suggestion: "Consider batching multiple storage writes into a single operation".to_string(),
+                suggestion: "Consider batching multiple storage writes into a single operation"
+                    .to_string(),
             });
         }
 
@@ -191,7 +213,9 @@ fn analyze_text_patterns(content: &str, path: &Path) -> Vec<OptimizationRecommen
                 description: "Cross-chain or multi-region operation detected".to_string(),
                 severity: "medium".to_string(),
                 location: Some(format!("{}:{}", path.display(), line_num)),
-                suggestion: "Consider asynchronous processing or parallel execution where applicable".to_string(),
+                suggestion:
+                    "Consider asynchronous processing or parallel execution where applicable"
+                        .to_string(),
             });
         }
     }
@@ -215,7 +239,11 @@ pub fn generate_report(input_path: &Path) -> Result<String, Box<dyn std::error::
     for analysis in analyses {
         report.push_str(&format!("## {}\n\n", analysis.contract_name));
         for opt in analysis.optimizations {
-            report.push_str(&format!("### {} ({})\n", opt.category, opt.severity.to_uppercase()));
+            report.push_str(&format!(
+                "### {} ({})\n",
+                opt.category,
+                opt.severity.to_uppercase()
+            ));
             report.push_str(&format!("**Description:** {}\n\n", opt.description));
             report.push_str(&format!("**Suggestion:** {}\n\n", opt.suggestion));
             if let Some(loc) = &opt.location {
@@ -228,10 +256,17 @@ pub fn generate_report(input_path: &Path) -> Result<String, Box<dyn std::error::
     Ok(report)
 }
 
-pub async fn integrate_pr_review(repo: &str, pr_number: u64, token: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn integrate_pr_review(
+    repo: &str,
+    pr_number: u64,
+    token: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     // This would integrate with GitHub API to post comments on PR
     // For now, just a placeholder
-    println!("Integrating analysis into PR review for {}/{}", repo, pr_number);
+    println!(
+        "Integrating analysis into PR review for {}/{}",
+        repo, pr_number
+    );
     // Use octocrab to create PR comments with recommendations
     Ok(())
 }

--- a/contract_optimizer/src/main.rs
+++ b/contract_optimizer/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
-use contract_optimizer::{analyze_contracts, generate_report, integrate_pr_review};
 use contract_optimizer::metrics::AccuracyMetrics;
+use contract_optimizer::{analyze_contracts, generate_report, integrate_pr_review};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -44,7 +44,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Analyze { contracts_path, format } => {
+        Commands::Analyze {
+            contracts_path,
+            format,
+        } => {
             let recommendations = analyze_contracts(&contracts_path)?;
             match format.as_str() {
                 "json" => println!("{}", serde_json::to_string_pretty(&recommendations)?),
@@ -56,10 +59,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                         println!();
                     }
-                }
+                },
                 _ => eprintln!("Invalid format. Use 'json' or 'text'"),
             }
-        }
+        },
         Commands::Report { input, output } => {
             let report = generate_report(&input)?;
             if let Some(out) = output {
@@ -68,17 +71,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 println!("{}", report);
             }
-        }
-        Commands::PrReview { repo, pr_number, token } => {
+        },
+        Commands::PrReview {
+            repo,
+            pr_number,
+            token,
+        } => {
             integrate_pr_review(&repo, pr_number, &token).await?;
             println!("PR review integration completed");
-        }
+        },
         Commands::Metrics { metrics_file } => {
             let metrics = AccuracyMetrics::load(&metrics_file)?;
             println!("Optimization Engine Accuracy Metrics");
             println!("====================================");
             println!("Total Recommendations: {}", metrics.total_recommendations);
-            println!("Applied Recommendations: {}", metrics.applied_recommendations);
+            println!(
+                "Applied Recommendations: {}",
+                metrics.applied_recommendations
+            );
             println!("Accuracy Rate: {:.2}%", metrics.accuracy_rate());
             println!("\nBy Category:");
             for (category, cat_metrics) in &metrics.categories {
@@ -87,9 +97,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     0.0
                 };
-                println!("  {}: {}/{} ({:.2}%)", category, cat_metrics.applied, cat_metrics.total, rate);
+                println!(
+                    "  {}: {}/{} ({:.2}%)",
+                    category, cat_metrics.applied, cat_metrics.total, rate
+                );
             }
-        }
+        },
     }
 
     Ok(())

--- a/contract_optimizer/src/metrics.rs
+++ b/contract_optimizer/src/metrics.rs
@@ -44,8 +44,12 @@ impl AccuracyMetrics {
         for analysis in recommendations {
             for opt in &analysis.optimizations {
                 self.total_recommendations += 1;
-                self.categories.entry(opt.category.clone())
-                    .or_insert(CategoryMetrics { total: 0, applied: 0 })
+                self.categories
+                    .entry(opt.category.clone())
+                    .or_insert(CategoryMetrics {
+                        total: 0,
+                        applied: 0,
+                    })
                     .total += 1;
             }
         }

--- a/contracts/access_control/src/lib.rs
+++ b/contracts/access_control/src/lib.rs
@@ -218,8 +218,10 @@ impl AccessControlImpl {
     // ── Internal ──────────────────────────────────────────────────────────────
 
     fn emit_role_event(env: &Env, action: Symbol, address: &Address, role: Role) {
-        env.events()
-            .publish((symbol_short!("AC"), action), (address.clone(), role as u32));
+        env.events().publish(
+            (symbol_short!("AC"), action),
+            (address.clone(), role as u32),
+        );
     }
 }
 

--- a/contracts/appointment_booking_escrow/src/errors.rs
+++ b/contracts/appointment_booking_escrow/src/errors.rs
@@ -25,12 +25,12 @@ pub fn get_suggestion(error: Error) -> Symbol {
     match error {
         Error::Unauthorized | Error::OnlyPatientCanRefund | Error::OnlyProviderCanConfirm => {
             symbol_short!("CHK_AUTH")
-        }
+        },
         Error::NotInitialized => symbol_short!("INIT_CTR"),
         Error::AlreadyInitialized => symbol_short!("ALREADY"),
         Error::InvalidAmount | Error::InvalidPatient | Error::InvalidProvider => {
             symbol_short!("CHK_LEN")
-        }
+        },
         Error::AppointmentNotFound => symbol_short!("CHK_ID"),
         Error::InsufficientFunds => symbol_short!("ADD_FUND"),
         _ => symbol_short!("CONTACT"),

--- a/contracts/appointment_booking_escrow/src/lib.rs
+++ b/contracts/appointment_booking_escrow/src/lib.rs
@@ -281,20 +281,10 @@ impl AppointmentBookingEscrow {
 
         // Interaction: Transfer funds from contract to provider
         let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &provider,
-            &transfer_amount,
-        );
+        token_client.transfer(&env.current_contract_address(), &provider, &transfer_amount);
 
         events::publish_appointment_confirmed(&env, appointment_id, &provider, timestamp);
-        events::publish_funds_released(
-            &env,
-            appointment_id,
-            &provider,
-            transfer_amount,
-            timestamp,
-        );
+        events::publish_funds_released(&env, appointment_id, &provider, transfer_amount, timestamp);
 
         events::diag_fn_exit(&env, "confirm_appointment");
         Self::record_operation(&env, true);
@@ -377,11 +367,7 @@ impl AppointmentBookingEscrow {
 
         // Interaction: Transfer funds from contract back to patient
         let token_client = token::Client::new(&env, &token_addr);
-        token_client.transfer(
-            &env.current_contract_address(),
-            &patient,
-            &refund_amount,
-        );
+        token_client.transfer(&env.current_contract_address(), &patient, &refund_amount);
 
         events::publish_appointment_refunded(
             &env,

--- a/contracts/code_ownership/src/events.rs
+++ b/contracts/code_ownership/src/events.rs
@@ -2,10 +2,8 @@ use crate::types::{ModuleOwnership, ReviewRoute};
 use soroban_sdk::{symbol_short, Address, Env};
 
 pub fn publish_initialization(env: &Env, admin: &Address) {
-    env.events().publish(
-        (symbol_short!("OWNER"), symbol_short!("INIT")),
-        admin,
-    );
+    env.events()
+        .publish((symbol_short!("OWNER"), symbol_short!("INIT")), admin);
 }
 
 pub fn publish_module_registered(env: &Env, ownership: &ModuleOwnership) {

--- a/contracts/code_ownership/src/lib.rs
+++ b/contracts/code_ownership/src/lib.rs
@@ -10,9 +10,7 @@ mod test;
 pub use errors::Error;
 pub use types::{DataKey, ModuleOwnership, OwnershipMatrix, ReviewRoute};
 
-use soroban_sdk::{
-    contract, contractimpl, Address, Env, String, Vec,
-};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 #[contract]
 pub struct CodeOwnership;
@@ -28,9 +26,7 @@ impl CodeOwnership {
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage()
-            .instance()
-            .set(&DataKey::ModuleCount, &0u32);
+        env.storage().instance().set(&DataKey::ModuleCount, &0u32);
 
         events::publish_initialization(&env, &admin);
         Ok(())

--- a/contracts/code_ownership/src/test.rs
+++ b/contracts/code_ownership/src/test.rs
@@ -120,12 +120,7 @@ mod tests {
             &expertise,
         );
 
-        let result = client.update_module_ownership(
-            &admin,
-            &module_id,
-            &owner2,
-            &Vec::new(&env),
-        );
+        let result = client.update_module_ownership(&admin, &module_id, &owner2, &Vec::new(&env));
 
         assert_eq!(result, ());
 
@@ -159,13 +154,7 @@ mod tests {
             &expertise,
         );
 
-        let result = client.configure_review_route(
-            &admin,
-            &module_id,
-            &2,
-            &5,
-            &escalation_owner,
-        );
+        let result = client.configure_review_route(&admin, &module_id, &2, &5, &escalation_owner);
 
         assert_eq!(result, ());
 

--- a/contracts/contract_behavior_fuzzing/tests/identity_registry_fuzz.rs
+++ b/contracts/contract_behavior_fuzzing/tests/identity_registry_fuzz.rs
@@ -147,7 +147,7 @@ impl BehaviorHarness for IdentityHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             IdentityOp::AddService {
                 subject,
                 service_slot,
@@ -175,7 +175,7 @@ impl BehaviorHarness for IdentityHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             IdentityOp::RemoveService {
                 subject,
                 service_slot,
@@ -205,7 +205,7 @@ impl BehaviorHarness for IdentityHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             IdentityOp::AddVerificationMethod {
                 subject,
                 method_slot,
@@ -242,7 +242,7 @@ impl BehaviorHarness for IdentityHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             IdentityOp::RotateKey {
                 subject,
                 method_slot,
@@ -271,7 +271,7 @@ impl BehaviorHarness for IdentityHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             IdentityOp::RevokeVerificationMethod {
                 subject,
                 method_slot,
@@ -308,7 +308,7 @@ impl BehaviorHarness for IdentityHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             IdentityOp::DeactivateDid { subject } => {
                 let subject_index = *subject as usize % self.subjects.len();
                 let success = self.models[subject_index].exists;
@@ -322,7 +322,7 @@ impl BehaviorHarness for IdentityHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
         }
     }
 

--- a/contracts/contract_behavior_fuzzing/tests/sut_token_fuzz.rs
+++ b/contracts/contract_behavior_fuzzing/tests/sut_token_fuzz.rs
@@ -142,7 +142,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(0)
-            }
+            },
             SutTokenOp::Mint { minter, to, amount } => {
                 let minter_index = *minter as usize % self.accounts.len();
                 let to_index = *to as usize % self.accounts.len();
@@ -165,7 +165,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             SutTokenOp::Burn {
                 minter,
                 from,
@@ -192,7 +192,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             SutTokenOp::Transfer { from, to, amount } => {
                 let from_index = *from as usize % self.accounts.len();
                 let to_index = *to as usize % self.accounts.len();
@@ -214,7 +214,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(usize::from(success && amount > 0))
-            }
+            },
             SutTokenOp::Approve {
                 owner,
                 spender,
@@ -243,7 +243,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             SutTokenOp::TransferFrom {
                 spender,
                 owner,
@@ -288,7 +288,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(usize::from(success && amount > 0))
-            }
+            },
             SutTokenOp::AddMinter { minter } => {
                 let minter_index = *minter as usize % self.accounts.len();
                 let success = self.model.initialized;
@@ -302,7 +302,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(0)
-            }
+            },
             SutTokenOp::RemoveMinter { minter } => {
                 let minter_index = *minter as usize % self.accounts.len();
                 let success = self.model.initialized;
@@ -316,7 +316,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(0)
-            }
+            },
             SutTokenOp::Snapshot => {
                 let success = self.model.initialized;
                 let result = self.client.try_snapshot();
@@ -328,7 +328,7 @@ impl BehaviorHarness for SutTokenHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
         }
     }
 

--- a/contracts/contract_behavior_fuzzing/tests/token_sale_fuzz.rs
+++ b/contracts/contract_behavior_fuzzing/tests/token_sale_fuzz.rs
@@ -134,17 +134,17 @@ impl BehaviorHarness for TokenSaleHarness {
                     ledger.timestamp = timestamp;
                 });
                 OperationOutcome::new(0)
-            }
+            },
             TokenSaleOp::Pause => {
                 self.client.pause_sale();
                 self.paused = true;
                 OperationOutcome::new(1)
-            }
+            },
             TokenSaleOp::Unpause => {
                 self.client.unpause_sale();
                 self.paused = false;
                 OperationOutcome::new(1)
-            }
+            },
             TokenSaleOp::Contribute {
                 contributor,
                 amount,
@@ -183,7 +183,7 @@ impl BehaviorHarness for TokenSaleHarness {
                 }
 
                 OperationOutcome::new(if success { 2 } else { 0 })
-            }
+            },
             TokenSaleOp::Finalize => {
                 let success = !self.finalized;
                 let result = self.client.try_finalize_sale();
@@ -197,7 +197,7 @@ impl BehaviorHarness for TokenSaleHarness {
                 }
 
                 OperationOutcome::new(usize::from(success))
-            }
+            },
             TokenSaleOp::ClaimTokens { contributor } => {
                 let contributor_index = *contributor as usize % self.contributors.len();
                 let contributor = self.contributor(*contributor).clone();
@@ -224,7 +224,7 @@ impl BehaviorHarness for TokenSaleHarness {
                 }
 
                 OperationOutcome::new(if emits_event { 2 } else { 0 })
-            }
+            },
             TokenSaleOp::ClaimRefund { contributor } => {
                 let contributor_index = *contributor as usize % self.contributors.len();
                 let contributor = self.contributor(*contributor).clone();
@@ -252,7 +252,7 @@ impl BehaviorHarness for TokenSaleHarness {
                 }
 
                 OperationOutcome::new(if emits_event { 2 } else { 0 })
-            }
+            },
         }
     }
 

--- a/contracts/contract_monitoring/src/lib.rs
+++ b/contracts/contract_monitoring/src/lib.rs
@@ -13,9 +13,7 @@
 
 #![no_std]
 
-use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, Map, String,
-};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map, String};
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -165,11 +163,8 @@ impl ContractMonitoring {
 
         // Update per-function stats.
         let key = DataKey::FnStats(function_name.clone());
-        let mut stats: FunctionStats = env
-            .storage()
-            .instance()
-            .get(&key)
-            .unwrap_or(FunctionStats {
+        let mut stats: FunctionStats =
+            env.storage().instance().get(&key).unwrap_or(FunctionStats {
                 call_count: 0,
                 error_count: 0,
                 total_gas: 0,
@@ -187,10 +182,7 @@ impl ContractMonitoring {
     }
 
     /// Record a failed function call / error.
-    pub fn record_error(
-        env: Env,
-        function_name: String,
-    ) -> Result<(), MonitoringError> {
+    pub fn record_error(env: Env, function_name: String) -> Result<(), MonitoringError> {
         Self::ensure_initialized(&env)?;
 
         let errors: u64 = env
@@ -203,11 +195,8 @@ impl ContractMonitoring {
             .set(&DataKey::TotalErrors, &(errors + 1));
 
         let key = DataKey::FnStats(function_name);
-        let mut stats: FunctionStats = env
-            .storage()
-            .instance()
-            .get(&key)
-            .unwrap_or(FunctionStats {
+        let mut stats: FunctionStats =
+            env.storage().instance().get(&key).unwrap_or(FunctionStats {
                 call_count: 0,
                 error_count: 0,
                 total_gas: 0,
@@ -217,29 +206,20 @@ impl ContractMonitoring {
         env.storage().instance().set(&key, &stats);
 
         // Emit error event.
-        env.events().publish(
-            (symbol_short!("MON"), symbol_short!("ERROR")),
-            errors + 1,
-        );
+        env.events()
+            .publish((symbol_short!("MON"), symbol_short!("ERROR")), errors + 1);
 
         Ok(())
     }
 
     /// Update storage-entry count (call after writes to tracked contracts).
-    pub fn update_storage_count(
-        env: Env,
-        count: u32,
-    ) -> Result<(), MonitoringError> {
+    pub fn update_storage_count(env: Env, count: u32) -> Result<(), MonitoringError> {
         Self::ensure_initialized(&env)?;
         env.storage()
             .instance()
             .set(&DataKey::StorageEntries, &count);
 
-        let config: AlertConfig = env
-            .storage()
-            .instance()
-            .get(&DataKey::AlertConfig)
-            .unwrap();
+        let config: AlertConfig = env.storage().instance().get(&DataKey::AlertConfig).unwrap();
         if config.max_storage_entries > 0 && count > config.max_storage_entries {
             env.events().publish(
                 (symbol_short!("MON"), symbol_short!("ALERT")),
@@ -251,15 +231,10 @@ impl ContractMonitoring {
     }
 
     /// Update alert thresholds (admin only).
-    pub fn update_alert_config(
-        env: Env,
-        config: AlertConfig,
-    ) -> Result<(), MonitoringError> {
+    pub fn update_alert_config(env: Env, config: AlertConfig) -> Result<(), MonitoringError> {
         let admin = Self::get_admin(&env)?;
         admin.require_auth();
-        env.storage()
-            .instance()
-            .set(&DataKey::AlertConfig, &config);
+        env.storage().instance().set(&DataKey::AlertConfig, &config);
         Ok(())
     }
 
@@ -301,11 +276,7 @@ impl ContractMonitoring {
             0
         };
 
-        let config: AlertConfig = env
-            .storage()
-            .instance()
-            .get(&DataKey::AlertConfig)
-            .unwrap();
+        let config: AlertConfig = env.storage().instance().get(&DataKey::AlertConfig).unwrap();
 
         let alert_active = (config.max_error_rate_pct > 0
             && error_rate_pct > config.max_error_rate_pct)

--- a/contracts/contract_template/src/events.rs
+++ b/contracts/contract_template/src/events.rs
@@ -6,8 +6,10 @@ pub fn emit_initialized(env: &Env, admin: &Address) {
 }
 
 pub fn emit_admin_transferred(env: &Env, old_admin: &Address, new_admin: &Address) {
-    env.events()
-        .publish((symbol_short!("adm_xfer"),), (old_admin.clone(), new_admin.clone()));
+    env.events().publish(
+        (symbol_short!("adm_xfer"),),
+        (old_admin.clone(), new_admin.clone()),
+    );
 }
 
 pub fn emit_data_updated(env: &Env, caller: &Address, data: &String) {

--- a/contracts/contract_template/src/lib.rs
+++ b/contracts/contract_template/src/lib.rs
@@ -92,7 +92,10 @@ impl ContractTemplate {
         }
 
         // 4. Execute the state change.
-        let record = ContractData { owner: caller.clone(), value: data.clone() };
+        let record = ContractData {
+            owner: caller.clone(),
+            value: data.clone(),
+        };
         env.storage().persistent().set(&KEY_DATA, &record);
 
         // 5. Emit an event for auditability.

--- a/contracts/contract_template/src/test.rs
+++ b/contracts/contract_template/src/test.rs
@@ -18,7 +18,10 @@ fn test_initialize() {
     let (_, _, client) = setup();
     // Second init must fail
     let admin2 = Address::generate(&client.env);
-    assert_eq!(client.initialize(&admin2), Err(Ok(Error::AlreadyInitialized)));
+    assert_eq!(
+        client.initialize(&admin2),
+        Err(Ok(Error::AlreadyInitialized))
+    );
 }
 
 #[test]

--- a/contracts/contract_usage_analytics/src/lib.rs
+++ b/contracts/contract_usage_analytics/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, String, Vec, Map,
+    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, Map, String,
+    Vec,
 };
 
 #[derive(Clone)]
@@ -76,13 +77,16 @@ impl ContractUsageAnalytics {
         success: bool,
         latency_ms: u64,
     ) -> Result<(), Error> {
-        // In a real scenario, we might want to restrict who can call this, 
+        // In a real scenario, we might want to restrict who can call this,
         // or let any contract report its own usage.
-        
+
         let timestamp = env.ledger().timestamp();
-        
+
         // 1. Update Function Metrics
-        let mut f_metric = env.storage().instance().get(&DataKey::FunctionMetric(function_name.clone()))
+        let mut f_metric = env
+            .storage()
+            .instance()
+            .get(&DataKey::FunctionMetric(function_name.clone()))
             .unwrap_or(FunctionMetric {
                 name: function_name.clone(),
                 call_count: 0,
@@ -99,18 +103,27 @@ impl ContractUsageAnalytics {
         if !success {
             f_metric.error_count = f_metric.error_count.saturating_add(1);
         }
-        
+
         // Rolling average for latency
         let prev_total_latency = f_metric.avg_latency_ms.saturating_mul(f_metric.call_count);
-        f_metric.avg_latency_ms = prev_total_latency.saturating_add(latency_ms).checked_div(new_count).unwrap_or(0);
-        
+        f_metric.avg_latency_ms = prev_total_latency
+            .saturating_add(latency_ms)
+            .checked_div(new_count)
+            .unwrap_or(0);
+
         f_metric.call_count = new_count;
         f_metric.last_called = timestamp;
-        
-        env.storage().instance().set(&DataKey::FunctionMetric(function_name.clone()), &f_metric);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::FunctionMetric(function_name.clone()), &f_metric);
 
         // Track function name if new
-        let mut all_functions: Vec<String> = env.storage().instance().get(&DataKey::AllFunctions).unwrap_or(Vec::new(&env));
+        let mut all_functions: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllFunctions)
+            .unwrap_or(Vec::new(&env));
         let mut exists = false;
         for f in all_functions.iter() {
             if f == function_name {
@@ -120,24 +133,35 @@ impl ContractUsageAnalytics {
         }
         if !exists {
             all_functions.push_back(function_name.clone());
-            env.storage().instance().set(&DataKey::AllFunctions, &all_functions);
+            env.storage()
+                .instance()
+                .set(&DataKey::AllFunctions, &all_functions);
         }
 
         // 2. Update User Metrics
-        let mut u_metric = env.storage().instance().get(&DataKey::UserMetric(user.clone()))
+        let mut u_metric = env
+            .storage()
+            .instance()
+            .get(&DataKey::UserMetric(user.clone()))
             .unwrap_or(UserMetric {
                 user: user.clone(),
                 total_calls: 0,
                 last_active: 0,
             });
-        
+
         u_metric.total_calls = u_metric.total_calls.saturating_add(1);
         u_metric.last_active = timestamp;
-        env.storage().instance().set(&DataKey::UserMetric(user.clone()), &u_metric);
+        env.storage()
+            .instance()
+            .set(&DataKey::UserMetric(user.clone()), &u_metric);
 
         // 3. Track daily active users
         let day_id = timestamp / 86400;
-        let mut active_users_today: Vec<Address> = env.storage().instance().get(&DataKey::ActiveUsers(day_id)).unwrap_or(Vec::new(&env));
+        let mut active_users_today: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ActiveUsers(day_id))
+            .unwrap_or(Vec::new(&env));
         let mut user_exists = false;
         for u in active_users_today.iter() {
             if u == user {
@@ -147,13 +171,15 @@ impl ContractUsageAnalytics {
         }
         if !user_exists {
             active_users_today.push_back(user.clone());
-            env.storage().instance().set(&DataKey::ActiveUsers(day_id), &active_users_today);
+            env.storage()
+                .instance()
+                .set(&DataKey::ActiveUsers(day_id), &active_users_today);
         }
 
         // 4. Publish Event
         env.events().publish(
             (symbol_short!("usage"), function_name),
-            (user, success, cpu_usage, ram_usage)
+            (user, success, cpu_usage, ram_usage),
         );
 
         Ok(())
@@ -162,48 +188,70 @@ impl ContractUsageAnalytics {
     pub fn take_snapshot(env: Env) -> Result<UsageSnapshot, Error> {
         let timestamp = env.ledger().timestamp();
         let day_id = timestamp / 86400;
-        
-        let active_users_today: Vec<Address> = env.storage().instance().get(&DataKey::ActiveUsers(day_id)).unwrap_or(Vec::new(&env));
-        let all_functions: Vec<String> = env.storage().instance().get(&DataKey::AllFunctions).unwrap_or(Vec::new(&env));
-        
+
+        let active_users_today: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ActiveUsers(day_id))
+            .unwrap_or(Vec::new(&env));
+        let all_functions: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::AllFunctions)
+            .unwrap_or(Vec::new(&env));
+
         let mut total_calls = 0;
         let mut total_errors = 0;
-        
+
         for f_name in all_functions.iter() {
-            if let Some(metric) = env.storage().instance().get::<_, FunctionMetric>(&DataKey::FunctionMetric(f_name)) {
+            if let Some(metric) = env
+                .storage()
+                .instance()
+                .get::<_, FunctionMetric>(&DataKey::FunctionMetric(f_name))
+            {
                 total_calls = total_calls.saturating_add(metric.call_count);
                 total_errors = total_errors.saturating_add(metric.error_count);
             }
         }
-        
+
         let error_rate_bps = if total_calls > 0 {
-            (total_errors.saturating_mul(10000)).checked_div(total_calls).unwrap_or(0) as u32
+            (total_errors.saturating_mul(10000))
+                .checked_div(total_calls)
+                .unwrap_or(0) as u32
         } else {
             0
         };
-        
+
         let snapshot = UsageSnapshot {
             timestamp,
             total_calls,
             active_users: active_users_today.len(),
             error_rate_bps,
         };
-        
-        let mut snapshots: Vec<UsageSnapshot> = env.storage().instance().get(&DataKey::Snapshots).unwrap_or(Vec::new(&env));
+
+        let mut snapshots: Vec<UsageSnapshot> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Snapshots)
+            .unwrap_or(Vec::new(&env));
         snapshots.push_back(snapshot.clone());
-        
+
         // Keep only last 30 snapshots
         if snapshots.len() > 30 {
             snapshots.remove(0);
         }
-        
-        env.storage().instance().set(&DataKey::Snapshots, &snapshots);
-        
+
+        env.storage()
+            .instance()
+            .set(&DataKey::Snapshots, &snapshots);
+
         Ok(snapshot)
     }
 
     pub fn get_function_metrics(env: Env, function_name: String) -> Option<FunctionMetric> {
-        env.storage().instance().get(&DataKey::FunctionMetric(function_name))
+        env.storage()
+            .instance()
+            .get(&DataKey::FunctionMetric(function_name))
     }
 
     pub fn get_user_metrics(env: Env, user: Address) -> Option<UserMetric> {
@@ -211,10 +259,16 @@ impl ContractUsageAnalytics {
     }
 
     pub fn get_all_functions(env: Env) -> Vec<String> {
-        env.storage().instance().get(&DataKey::AllFunctions).unwrap_or(Vec::new(&env))
+        env.storage()
+            .instance()
+            .get(&DataKey::AllFunctions)
+            .unwrap_or(Vec::new(&env))
     }
 
     pub fn get_snapshots(env: Env) -> Vec<UsageSnapshot> {
-        env.storage().instance().get(&DataKey::Snapshots).unwrap_or(Vec::new(&env))
+        env.storage()
+            .instance()
+            .get(&DataKey::Snapshots)
+            .unwrap_or(Vec::new(&env))
     }
 }

--- a/contracts/contract_verification/src/lib.rs
+++ b/contracts/contract_verification/src/lib.rs
@@ -133,9 +133,7 @@ impl ContractVerification {
             publisher: admin,
         };
 
-        env.storage()
-            .instance()
-            .set(&DataKey::Metadata, &metadata);
+        env.storage().instance().set(&DataKey::Metadata, &metadata);
 
         // Emit event for block-explorer indexing.
         env.events().publish(
@@ -170,10 +168,8 @@ impl ContractVerification {
             .instance()
             .set(&DataKey::BuildInfo, &build_info);
 
-        env.events().publish(
-            (symbol_short!("VERIFY"), symbol_short!("BUILD")),
-            wasm_hash,
-        );
+        env.events()
+            .publish((symbol_short!("VERIFY"), symbol_short!("BUILD")), wasm_hash);
 
         Ok(())
     }
@@ -183,9 +179,7 @@ impl ContractVerification {
         let admin = Self::get_admin(&env)?;
         admin.require_auth();
 
-        env.storage()
-            .instance()
-            .set(&DataKey::AbiEntries, &entries);
+        env.storage().instance().set(&DataKey::AbiEntries, &entries);
 
         env.events().publish(
             (symbol_short!("VERIFY"), symbol_short!("ABI")),

--- a/contracts/credential_registry/src/lib.rs
+++ b/contracts/credential_registry/src/lib.rs
@@ -291,9 +291,10 @@ impl CredentialRegistryContract {
             env.storage()
                 .persistent()
                 .set(&DataKey::RootRecord(issuer.clone(), current), &rec);
-            env.storage()
-                .persistent()
-                .set(&DataKey::RootToVersion(issuer.clone(), root.clone()), &current);
+            env.storage().persistent().set(
+                &DataKey::RootToVersion(issuer.clone(), root.clone()),
+                &current,
+            );
             versions.push_back(current);
         }
 

--- a/contracts/cross_chain_access/src/lib.rs
+++ b/contracts/cross_chain_access/src/lib.rs
@@ -1251,11 +1251,11 @@ impl CrossChainAccessContract {
                     if time_of_day < start || time_of_day > end {
                         return false;
                     }
-                }
+                },
                 AccessCondition::SingleUse => {
                     return true;
-                }
-                _ => {}
+                },
+                _ => {},
             }
         }
         true

--- a/contracts/cross_chain_bridge/src/errors.rs
+++ b/contracts/cross_chain_bridge/src/errors.rs
@@ -61,7 +61,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
         | Error::InsufficientConfirmations
         | Error::InsufficientOracleReports => {
             symbol_short!("CHK_AUTH")
-        }
+        },
         Error::AlreadyInitialized
         | Error::MessageAlreadyProcessed
         | Error::AtomicTxAlreadyProcessed

--- a/contracts/cross_chain_bridge/src/lib.rs
+++ b/contracts/cross_chain_bridge/src/lib.rs
@@ -367,7 +367,11 @@ impl CrossChainBridgeContract {
         val: &T,
     ) {
         env.storage().persistent().set(key, val);
-        env.storage().persistent().extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
     }
 
     /// Get a persistent value and extend its TTL.
@@ -377,7 +381,11 @@ impl CrossChainBridgeContract {
     ) -> Option<T> {
         let val = env.storage().persistent().get(key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -408,9 +416,7 @@ impl CrossChainBridgeContract {
             .set(&DataKey::AccessContract, &access_contract);
 
         env.storage().instance().set(&DataKey::Paused, &false);
-        env.storage()
-            .instance()
-            .set(&DataKey::MessageCount, &0u64);
+        env.storage().instance().set(&DataKey::MessageCount, &0u64);
         env.storage()
             .instance()
             .set(&DataKey::MinConfirmations, &DEFAULT_MIN_CONFIRMATIONS);
@@ -424,9 +430,7 @@ impl CrossChainBridgeContract {
             .set(&DataKey::SupportedChains, &chains);
 
         env.storage().instance().set(&DataKey::OracleCount, &0u64);
-        env.storage()
-            .instance()
-            .set(&DataKey::RollbackCount, &0u64);
+        env.storage().instance().set(&DataKey::RollbackCount, &0u64);
         env.storage().instance().set(&DataKey::EventCount, &0u64);
 
         env.events()
@@ -594,10 +598,14 @@ impl CrossChainBridgeContract {
             signature,
         };
 
-        env.storage().persistent().set(
-            &DataKey::Message(message_id.clone()), &message);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Message(message_id.clone()), &message);
         env.storage().persistent().extend_ttl(
-            &DataKey::Message(message_id.clone()), PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            &DataKey::Message(message_id.clone()),
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
 
         Self::update_nonce(&env, &sender, nonce);
 
@@ -665,7 +673,9 @@ impl CrossChainBridgeContract {
 
         confirmations.push_back(validator.clone());
         env.storage().temporary().set(&conf_key, &confirmations);
-        env.storage().temporary().extend_ttl(&conf_key, 0, TEMP_SESSION_TTL);
+        env.storage()
+            .temporary()
+            .extend_ttl(&conf_key, 0, TEMP_SESSION_TTL);
 
         Self::increment_validator_confirmations(&env, &validator);
 
@@ -678,7 +688,11 @@ impl CrossChainBridgeContract {
         if confirmations.len() as u32 >= min_confirmations {
             message.status = MessageStatus::Verified;
             env.storage().persistent().set(&msg_key, &message);
-            env.storage().persistent().extend_ttl(&msg_key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &msg_key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
 
             env.events().publish(
                 (Symbol::new(&env, "MessageVerified"),),
@@ -1464,8 +1478,8 @@ impl CrossChainBridgeContract {
         match operation.status {
             OperationStatus::Completed | OperationStatus::Refunded => {
                 return Ok(());
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         let now = env.ledger().timestamp();
@@ -1502,7 +1516,7 @@ impl CrossChainBridgeContract {
 
         // Only allow extension for pending or in-progress operations
         match operation.status {
-            OperationStatus::Pending | OperationStatus::InProgress => {}
+            OperationStatus::Pending | OperationStatus::InProgress => {},
             _ => return Err(Error::OperationAlreadyCompleted),
         }
 
@@ -1663,7 +1677,7 @@ impl CrossChainBridgeContract {
                         .persistent()
                         .set(&DataKey::Message(op_id.clone()), &msg);
                 }
-            }
+            },
             RollbackOpType::AtomicTxRollback => {
                 if let Some(mut atomic_tx) = env
                     .storage()
@@ -1675,10 +1689,10 @@ impl CrossChainBridgeContract {
                         .persistent()
                         .set(&DataKey::AtomicTx(op_id.clone()), &atomic_tx);
                 }
-            }
+            },
             RollbackOpType::RecordSyncRollback => {
                 // Record sync rollback handled externally via oracle confirmation
-            }
+            },
         }
 
         rollback.status = RollbackStatus::Completed;
@@ -1723,7 +1737,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::Message(message_id);
         let val: Option<CrossChainMessage> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1732,7 +1750,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::AtomicTx(tx_id);
         let val: Option<AtomicTransaction> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1745,7 +1767,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::RecordRef(local_record_id, external_chain);
         let val: Option<CrossChainRecordRef> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1754,7 +1780,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::Validator(validator_address);
         let val: Option<Validator> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1763,7 +1793,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::OracleNode(oracle_address);
         let val: Option<OracleNode> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1772,7 +1806,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::OracleReport(report_id);
         let val: Option<OracleReport> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1781,7 +1819,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::AggregatedOracle(chain);
         let val: Option<AggregatedOracleData> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1790,7 +1832,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::Proof(proof_id);
         let val: Option<CrossChainProof> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1799,7 +1845,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::Rollback(op_id);
         let val: Option<RollbackRecord> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }
@@ -1808,7 +1858,11 @@ impl CrossChainBridgeContract {
         let key = DataKey::Event(event_id);
         let val: Option<CrossChainEvent> = env.storage().persistent().get(&key);
         if val.is_some() {
-            env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &key,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
         val
     }

--- a/contracts/crypto_registry/src/benchmarks.rs
+++ b/contracts/crypto_registry/src/benchmarks.rs
@@ -29,7 +29,10 @@ impl BenchResult {
     fn print(&self) {
         std::println!(
             "[BENCH] {:40} cpu={:>12} insns  mem={:>10} bytes  wall={:>8}µs",
-            self.name, self.cpu_instructions, self.memory_bytes, self.wall_us
+            self.name,
+            self.cpu_instructions,
+            self.memory_bytes,
+            self.wall_us
         );
     }
 
@@ -133,9 +136,13 @@ fn bench_get_current_key_bundle() {
         &false,
     );
 
-    let r = measure(&env, "crypto_registry::get_current_key_bundle (read)", || {
-        client.get_current_key_bundle(&alice);
-    });
+    let r = measure(
+        &env,
+        "crypto_registry::get_current_key_bundle (read)",
+        || {
+            client.get_current_key_bundle(&alice);
+        },
+    );
     r.print();
     r.assert_cpu_under(BUDGET_GET_BUNDLE);
 }
@@ -269,9 +276,13 @@ fn bench_storage_write_vs_read_ratio() {
         );
     });
 
-    let read = measure(&env, "crypto_registry::get_current_key_bundle (read)", || {
-        client.get_current_key_bundle(&alice);
-    });
+    let read = measure(
+        &env,
+        "crypto_registry::get_current_key_bundle (read)",
+        || {
+            client.get_current_key_bundle(&alice);
+        },
+    );
 
     write.print();
     read.print();

--- a/contracts/crypto_registry/src/lib.rs
+++ b/contracts/crypto_registry/src/lib.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
 #[cfg(test)]
-mod test;
-#[cfg(test)]
 mod benchmarks;
+#[cfg(test)]
+mod test;
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env,
@@ -315,39 +315,39 @@ impl CryptoRegistry {
                 if len != 32 {
                     return Err(Error::InvalidKeyLength);
                 }
-            }
+            },
             KeyAlgorithm::Secp256k1 => {
                 // Compressed: 33, uncompressed: 65. Allow either.
                 if len != 33 && len != 65 {
                     return Err(Error::InvalidKeyLength);
                 }
-            }
+            },
             KeyAlgorithm::Kyber768 => {
                 if len != 1184 {
                     return Err(Error::InvalidKeyLength);
                 }
-            }
+            },
             KeyAlgorithm::Kyber1024 => {
                 if len != 1568 {
                     return Err(Error::InvalidKeyLength);
                 }
-            }
+            },
             KeyAlgorithm::Dilithium2 => {
                 if len != 1312 {
                     return Err(Error::InvalidKeyLength);
                 }
-            }
+            },
             KeyAlgorithm::Dilithium3 => {
                 if len != 1952 {
                     return Err(Error::InvalidKeyLength);
                 }
-            }
+            },
             KeyAlgorithm::Dilithium5 => {
                 if len != 2592 {
                     return Err(Error::InvalidKeyLength);
                 }
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         Ok(())

--- a/contracts/deprecation_framework/src/events.rs
+++ b/contracts/deprecation_framework/src/events.rs
@@ -2,10 +2,8 @@ use crate::types::{DeprecationStatus, MigrationGuide, SunsetTimeline};
 use soroban_sdk::{symbol_short, Address, Env, String};
 
 pub fn publish_initialization(env: &Env, admin: &Address) {
-    env.events().publish(
-        (symbol_short!("DEPREC"), symbol_short!("INIT")),
-        admin,
-    );
+    env.events()
+        .publish((symbol_short!("DEPREC"), symbol_short!("INIT")), admin);
 }
 
 pub fn publish_deprecation_marked(env: &Env, status: &DeprecationStatus) {

--- a/contracts/deprecation_framework/src/lib.rs
+++ b/contracts/deprecation_framework/src/lib.rs
@@ -8,13 +8,9 @@ mod types;
 mod test;
 
 pub use errors::Error;
-pub use types::{
-    DataKey, DeprecationPhase, DeprecationStatus, MigrationGuide, SunsetTimeline,
-};
+pub use types::{DataKey, DeprecationPhase, DeprecationStatus, MigrationGuide, SunsetTimeline};
 
-use soroban_sdk::{
-    contract, contractimpl, Address, Env, String, Vec,
-};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 #[contract]
 pub struct DeprecationFramework;
@@ -30,9 +26,7 @@ impl DeprecationFramework {
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage()
-            .instance()
-            .set(&DataKey::ContractCount, &0u32);
+        env.storage().instance().set(&DataKey::ContractCount, &0u32);
 
         events::publish_initialization(&env, &admin);
         Ok(())
@@ -252,9 +246,10 @@ impl DeprecationFramework {
             .get(&DataKey::DeprecatedContract(contract_id.clone()))
             .ok_or(Error::ContractNotFound)?;
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::RemovalChecklist(contract_id.clone()), &checklist_items);
+        env.storage().persistent().set(
+            &DataKey::RemovalChecklist(contract_id.clone()),
+            &checklist_items,
+        );
 
         events::publish_removal_checklist_created(&env, &contract_id);
         Ok(())
@@ -277,9 +272,10 @@ impl DeprecationFramework {
             .ok_or(Error::ChecklistNotFound)?;
 
         // Store completion status separately
-        env.storage()
-            .persistent()
-            .set(&DataKey::ChecklistItemComplete(contract_id.clone(), item_index), &true);
+        env.storage().persistent().set(
+            &DataKey::ChecklistItemComplete(contract_id.clone(), item_index),
+            &true,
+        );
 
         events::publish_checklist_item_completed(&env, &contract_id, item_index);
         Ok(())

--- a/contracts/deprecation_framework/src/test.rs
+++ b/contracts/deprecation_framework/src/test.rs
@@ -97,13 +97,8 @@ mod tests {
             &None,
         );
 
-        let result = client.set_sunset_timeline(
-            &admin,
-            &contract_to_deprecate,
-            &1000,
-            &2000,
-            &3000,
-        );
+        let result =
+            client.set_sunset_timeline(&admin, &contract_to_deprecate, &1000, &2000, &3000);
         assert_eq!(result, ());
     }
 
@@ -132,13 +127,7 @@ mod tests {
         );
 
         // Invalid: dates not in chronological order
-        client.set_sunset_timeline(
-            &admin,
-            &contract_to_deprecate,
-            &3000,
-            &2000,
-            &1000,
-        );
+        client.set_sunset_timeline(&admin, &contract_to_deprecate, &3000, &2000, &1000);
     }
 
     #[test]
@@ -235,12 +224,8 @@ mod tests {
         let message = String::from_str(&env, "This contract is deprecated");
         let comm_type = String::from_str(&env, "announcement");
 
-        let result = client.publish_user_communication(
-            &admin,
-            &contract_to_deprecate,
-            &message,
-            &comm_type,
-        );
+        let result =
+            client.publish_user_communication(&admin, &contract_to_deprecate, &message, &comm_type);
         assert_eq!(result, 0);
     }
 

--- a/contracts/emr_integration/src/benchmarks.rs
+++ b/contracts/emr_integration/src/benchmarks.rs
@@ -30,7 +30,10 @@ impl BenchResult {
     fn print(&self) {
         std::println!(
             "[BENCH] {:40} cpu={:>12} insns  mem={:>10} bytes  wall={:>8}µs",
-            self.name, self.cpu_instructions, self.memory_bytes, self.wall_us
+            self.name,
+            self.cpu_instructions,
+            self.memory_bytes,
+            self.wall_us
         );
     }
 
@@ -240,13 +243,17 @@ fn bench_validate_message() {
         &sample_metadata(&env),
     );
 
-    let r = measure(&env, "emr_integration::validate_message (read+write)", || {
-        client.validate_message(
-            &sender,
-            &String::from_str(&env, "report-bench-1"),
-            &String::from_str(&env, "msg-to-validate"),
-        );
-    });
+    let r = measure(
+        &env,
+        "emr_integration::validate_message (read+write)",
+        || {
+            client.validate_message(
+                &sender,
+                &String::from_str(&env, "report-bench-1"),
+                &String::from_str(&env, "msg-to-validate"),
+            );
+        },
+    );
     r.print();
     r.assert_cpu_under(BUDGET_VALIDATE_MESSAGE);
 }

--- a/contracts/emr_integration/src/lib.rs
+++ b/contracts/emr_integration/src/lib.rs
@@ -2,9 +2,9 @@
 #![allow(clippy::too_many_arguments)]
 
 #[cfg(test)]
-mod test;
-#[cfg(test)]
 mod benchmarks;
+#[cfg(test)]
+mod test;
 
 extern crate alloc;
 
@@ -870,7 +870,7 @@ impl EMRIntegrationContract {
                 framed.push('\u{001C}');
                 framed.push('\r');
                 framed
-            }
+            },
             TransportProtocol::HTTP => format!(
                 "POST /hl7 HTTP/1.1\r\nContent-Type: {}\r\nX-Message-Type: {}\r\n\r\n{}",
                 Self::to_rust_string(&message.content_type),
@@ -1041,10 +1041,10 @@ impl EMRIntegrationContract {
                 MessagingStandard::HL7v2 => Self::parse_hl7v2(env, version_override, &payload_rs)?,
                 MessagingStandard::HL7v3 => {
                     Self::parse_xml_message(env, version_override, &payload_rs, false)?
-                }
+                },
                 MessagingStandard::CDA => {
                     Self::parse_xml_message(env, version_override, &payload_rs, true)?
-                }
+                },
             };
 
         Self::assert_supported_message_type(&message_type)?;
@@ -1335,7 +1335,7 @@ impl EMRIntegrationContract {
                     )),
                 );
                 String::from_str(env, &format!("{msh}\r{pid}\r{obx}"))
-            }
+            },
             MessagingStandard::HL7v3 => {
                 let root = Self::to_rust_string(message_type);
                 let xml = format!(
@@ -1363,7 +1363,7 @@ impl EMRIntegrationContract {
                     )),
                 );
                 String::from_str(env, &xml)
-            }
+            },
             MessagingStandard::CDA => {
                 let xml = format!(
                     "<?xml version=\"1.0\" encoding=\"{}\"?><ClinicalDocument><id extension=\"{}\" root=\"2.16.840.1.113883.19.5\"/><code code=\"{}\"/><title>{}</title><recordTarget><patientRole patientId=\"{}\"><patient><name>{}</name></patient></patientRole></recordTarget><component><structuredBody><component><section><text>{}</text></section></component></structuredBody></component></ClinicalDocument>",
@@ -1396,7 +1396,7 @@ impl EMRIntegrationContract {
                     )),
                 );
                 String::from_str(env, &xml)
-            }
+            },
         }
     }
 
@@ -1439,7 +1439,7 @@ impl EMRIntegrationContract {
                         location: String::from_str(env, "PID"),
                     });
                 }
-            }
+            },
             MessagingStandard::HL7v3 => {
                 if !payload.contains("interactionId") {
                     issues.push_back(ValidationIssue {
@@ -1449,7 +1449,7 @@ impl EMRIntegrationContract {
                         location: String::from_str(env, "interactionId"),
                     });
                 }
-            }
+            },
             MessagingStandard::CDA => {
                 if !payload.contains("<ClinicalDocument") {
                     issues.push_back(ValidationIssue {
@@ -1470,7 +1470,7 @@ impl EMRIntegrationContract {
                         location: String::from_str(env, "recordTarget"),
                     });
                 }
-            }
+            },
         }
 
         MessageValidationReport {

--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -33,7 +33,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
     match error {
         Error::Unauthorized | Error::NotAdmin | Error::InsufficientApprovals => {
             symbol_short!("CHK_AUTH")
-        }
+        },
         Error::InvalidAmount | Error::InvalidFeeBps => symbol_short!("CHK_LEN"),
         Error::EscrowNotFound => symbol_short!("CHK_ID"),
         Error::AlreadySettled | Error::EscrowExists => symbol_short!("ALREADY"),

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -96,7 +96,9 @@ fn require_not_reentrant(env: &Env) -> Result<(), Error> {
         return Err(Error::ReentrancyGuard);
     }
     env.storage().temporary().set(&REENTRANCY_LOCK, &true);
-    env.storage().temporary().extend_ttl(&REENTRANCY_LOCK, 0, TEMP_SESSION_TTL);
+    env.storage()
+        .temporary()
+        .extend_ttl(&REENTRANCY_LOCK, 0, TEMP_SESSION_TTL);
     Ok(())
 }
 

--- a/contracts/federated_learning/src/lib.rs
+++ b/contracts/federated_learning/src/lib.rs
@@ -233,6 +233,7 @@ pub enum Error {
     VerificationFailed = 21,
     FrameworkNotSupported = 22,
     ContributionQualityLow = 23,
+    Overflow               = 24,
 }
 
 #[contract]
@@ -787,8 +788,10 @@ impl FederatedLearningContract {
         for addr in participants.iter() {
             let k = DataKey::Institution(addr.clone());
             if let Some(mut inst) = env.storage().persistent().get::<DataKey, Institution>(&k) {
-                inst.reward_balance += round.reward_per_participant;
-                inst.reputation_score = (inst.reputation_score + rep_delta).min(100);
+                inst.reward_balance = inst.reward_balance
+                    .checked_add(round.reward_per_participant)
+                    .ok_or(Error::Overflow)?;
+                inst.reputation_score = inst.reputation_score.saturating_add(rep_delta).min(100);
 
                 if let Some(verification) =
                     env.storage()
@@ -798,7 +801,7 @@ impl FederatedLearningContract {
                         )
                 {
                     if verification.quality_score > 80 {
-                        inst.reputation_score = (inst.reputation_score + 1).min(100);
+                        inst.reputation_score = inst.reputation_score.saturating_add(1).min(100);
                     }
                 }
 

--- a/contracts/fido2_authenticator/src/lib.rs
+++ b/contracts/fido2_authenticator/src/lib.rs
@@ -964,12 +964,12 @@ impl Fido2AuthenticatorContract {
                 if len != ED25519_KEY_LEN {
                     return Err(Error::AlgorithmKeyMismatch);
                 }
-            }
+            },
             PublicKeyAlgorithm::ES256 => {
                 if len != P256_UNCOMPRESSED_KEY_LEN && len != P256_COMPRESSED_KEY_LEN {
                     return Err(Error::AlgorithmKeyMismatch);
                 }
-            }
+            },
         }
         if len == 0 {
             return Err(Error::InvalidPublicKey);

--- a/contracts/genomic_data/src/lib.rs
+++ b/contracts/genomic_data/src/lib.rs
@@ -269,9 +269,7 @@ impl GenomicDataContract {
         env.storage().instance().set(&VERSION, &1u32);
         env.storage().instance().set(&DataKey::Initialized, &true);
         env.storage().instance().set(&DataKey::NextId, &0u64);
-        env.storage()
-            .instance()
-            .set(&DataKey::ListingNextId, &0u64);
+        env.storage().instance().set(&DataKey::ListingNextId, &0u64);
         Self::emit_log(
             &env,
             LogLevel::Info,
@@ -354,9 +352,7 @@ impl GenomicDataContract {
         env.storage()
             .persistent()
             .set(&DataKey::PatientRecords(patient), &list);
-        env.storage()
-            .instance()
-            .set(&DataKey::NextId, &new_id);
+        env.storage().instance().set(&DataKey::NextId, &new_id);
         Self::emit_log(
             &env,
             LogLevel::Info,
@@ -702,9 +698,7 @@ impl GenomicDataContract {
         env.storage()
             .persistent()
             .set(&DataKey::RecordListings(record_id), &ids);
-        env.storage()
-            .instance()
-            .set(&DataKey::ListingNextId, &lid);
+        env.storage().instance().set(&DataKey::ListingNextId, &lid);
         Self::emit_log(
             &env,
             LogLevel::Info,

--- a/contracts/governor/src/errors.rs
+++ b/contracts/governor/src/errors.rs
@@ -32,7 +32,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
         Error::NotInitialized => symbol_short!("INIT_CTR"),
         Error::AlreadyInitialized | Error::AlreadyVoted | Error::AlreadyExecuted => {
             symbol_short!("ALREADY")
-        }
+        },
         Error::ProposalNotFound | Error::ProposalNotSuccessful => symbol_short!("CHK_ID"),
         Error::VotingClosed | Error::NotQueued => symbol_short!("RE_TRY_L"),
         _ => symbol_short!("CONTACT"),

--- a/contracts/healthcare_oracle_network/src/test.rs
+++ b/contracts/healthcare_oracle_network/src/test.rs
@@ -94,7 +94,7 @@ fn test_drug_feed_consensus_and_weighted_aggregation() {
             assert_eq!(data.price_minor, 1050);
             assert_eq!(data.availability_units, 210);
             assert_eq!(data.observed_at, 101);
-        }
+        },
         _ => panic!("expected drug pricing payload"),
     }
 }
@@ -121,7 +121,7 @@ fn test_clinical_trial_and_regulatory_feeds() {
             assert_eq!(data.trial_id, trial_id);
             assert_eq!(data.phase, 3);
             assert_eq!(data.enrolled, 450);
-        }
+        },
         _ => panic!("expected clinical payload"),
     }
 
@@ -146,7 +146,7 @@ fn test_clinical_trial_and_regulatory_feeds() {
             assert_eq!(data.regulation_id, regulation_id);
             assert_eq!(data.status, RegulatoryStatus::GuidelineUpdate);
             assert_eq!(data.authority, RegulatoryAuthority::FDA);
-        }
+        },
         _ => panic!("expected regulatory payload"),
     }
 
@@ -227,7 +227,7 @@ fn test_treatment_outcome_feed_consensus() {
             assert_eq!(data.mortality_rate_bps, 190);
             assert_eq!(data.sample_size, 1150);
             assert_eq!(data.reported_at, 1010);
-        }
+        },
         _ => panic!("expected treatment outcome payload"),
     }
 

--- a/contracts/healthcare_oracle_network/src/utils.rs
+++ b/contracts/healthcare_oracle_network/src/utils.rs
@@ -243,7 +243,7 @@ pub fn aggregate_payload(
                         if value.observed_at > observed_at {
                             observed_at = value.observed_at;
                         }
-                    }
+                    },
                     _ => return Err(Error::InvalidFeedType),
                 }
                 i += 1;
@@ -256,7 +256,7 @@ pub fn aggregate_payload(
                 availability_units: (availability_weighted / sum_weight) as u32,
                 observed_at,
             }))
-        }
+        },
         FeedKind::ClinicalTrial => {
             let mut phase_weighted = 0i128;
             let mut enrolled_weighted = 0i128;
@@ -284,7 +284,7 @@ pub fn aggregate_payload(
                             published_at = value.published_at;
                             result_hash = value.result_hash.clone();
                         }
-                    }
+                    },
                     _ => return Err(Error::InvalidFeedType),
                 }
                 i += 1;
@@ -299,7 +299,7 @@ pub fn aggregate_payload(
                 result_hash,
                 published_at,
             }))
-        }
+        },
         FeedKind::RegulatoryUpdate => {
             let mut best_weight = -1i128;
             let mut picked: Option<RegulatoryUpdateData> = None;
@@ -312,7 +312,7 @@ pub fn aggregate_payload(
                             best_weight = weight;
                             picked = Some(value.clone());
                         }
-                    }
+                    },
                     _ => return Err(Error::InvalidFeedType),
                 }
                 i += 1;
@@ -324,7 +324,7 @@ pub fn aggregate_payload(
             } else {
                 Err(Error::InvalidData)
             }
-        }
+        },
         FeedKind::TreatmentOutcome => {
             let mut improvement_weighted = 0i128;
             let mut readmission_weighted = 0i128;
@@ -357,7 +357,7 @@ pub fn aggregate_payload(
                         if value.reported_at > reported_at {
                             reported_at = value.reported_at;
                         }
-                    }
+                    },
                     _ => return Err(Error::InvalidFeedType),
                 }
                 i += 1;
@@ -373,7 +373,7 @@ pub fn aggregate_payload(
                 sample_size: (sample_weighted / sum_weight) as u32,
                 reported_at,
             }))
-        }
+        },
     }
 }
 
@@ -415,7 +415,7 @@ pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
             } else {
                 -3
             }
-        }
+        },
         (FeedPayload::ClinicalTrial(consensus_data), FeedPayload::ClinicalTrial(payload_data)) => {
             let diff = if payload_data.success_rate_bps > consensus_data.success_rate_bps {
                 payload_data
@@ -431,7 +431,7 @@ pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
             } else {
                 -2
             }
-        }
+        },
         (
             FeedPayload::RegulatoryUpdate(consensus_data),
             FeedPayload::RegulatoryUpdate(payload_data),
@@ -441,7 +441,7 @@ pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
             } else {
                 -4
             }
-        }
+        },
         (
             FeedPayload::TreatmentOutcome(consensus_data),
             FeedPayload::TreatmentOutcome(payload_data),
@@ -460,7 +460,7 @@ pub fn reputation_delta(consensus: FeedPayload, payload: FeedPayload) -> i128 {
             } else {
                 -2
             }
-        }
+        },
         _ => -5,
     }
 }

--- a/contracts/healthcare_payment/src/errors.rs
+++ b/contracts/healthcare_payment/src/errors.rs
@@ -52,7 +52,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
         Error::AlreadyInitialized => symbol_short!("ALREADY"),
         Error::ContractPaused | Error::DeadlineExceeded | Error::CrossChainTimeout => {
             symbol_short!("RE_TRY_L")
-        }
+        },
         Error::InsufficientFunds => symbol_short!("ADD_FUND"),
         Error::StorageFull => symbol_short!("CLN_OLD"),
         Error::ClaimNotFound

--- a/contracts/healthcare_payment/src/lib.rs
+++ b/contracts/healthcare_payment/src/lib.rs
@@ -936,7 +936,11 @@ impl HealthcarePayment {
 
         env.events().publish(
             (symbol_short!("DIAG"), symbol_short!("STATE")),
-            (claim_id, ClaimStatus::Approved as u32, ClaimStatus::Paid as u32),
+            (
+                claim_id,
+                ClaimStatus::Approved as u32,
+                ClaimStatus::Paid as u32,
+            ),
         );
 
         token_client.transfer(

--- a/contracts/healthcare_reputation/src/lib.rs
+++ b/contracts/healthcare_reputation/src/lib.rs
@@ -772,17 +772,17 @@ impl HealthcareReputationSystem {
                 match entry.conduct_type {
                     ConductType::Positive | ConductType::ProfessionalAchievement => {
                         score = score.saturating_add(5);
-                    }
+                    },
                     ConductType::Complaint => {
                         score = score.saturating_sub(entry.severity);
-                    }
+                    },
                     ConductType::Malpractice => {
                         score = score.saturating_sub(entry.severity * 2);
-                    }
+                    },
                     ConductType::EthicsViolation => {
                         score = score.saturating_sub(entry.severity * 3);
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
             }
         }

--- a/contracts/identity_registry/src/errors.rs
+++ b/contracts/identity_registry/src/errors.rs
@@ -42,7 +42,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
     match error {
         Error::Unauthorized | Error::NotVerifier | Error::CannotRemoveOwner => {
             symbol_short!("CHK_AUTH")
-        }
+        },
         Error::NotInitialized => symbol_short!("INIT_CTR"),
         Error::AlreadyInitialized => symbol_short!("ALREADY"),
         Error::DIDNotFound

--- a/contracts/identity_registry/src/lib.rs
+++ b/contracts/identity_registry/src/lib.rs
@@ -587,19 +587,19 @@ impl IdentityRegistryContract {
             match rel {
                 VerificationRelationship::Authentication => {
                     did_doc.authentication.push_back(method_id.clone());
-                }
+                },
                 VerificationRelationship::AssertionMethod => {
                     did_doc.assertion_method.push_back(method_id.clone());
-                }
+                },
                 VerificationRelationship::KeyAgreement => {
                     did_doc.key_agreement.push_back(method_id.clone());
-                }
+                },
                 VerificationRelationship::CapabilityInvocation => {
                     did_doc.capability_invocation.push_back(method_id.clone());
-                }
+                },
                 VerificationRelationship::CapabilityDelegation => {
                     did_doc.capability_delegation.push_back(method_id.clone());
-                }
+                },
             }
         }
 
@@ -872,7 +872,7 @@ impl IdentityRegistryContract {
                 } else {
                     Ok(CredentialStatus::Valid)
                 }
-            }
+            },
         }
     }
 
@@ -1733,7 +1733,7 @@ impl IdentityRegistryContract {
                 }
 
                 false
-            }
+            },
         }
     }
 

--- a/contracts/ihe_integration/src/lib.rs
+++ b/contracts/ihe_integration/src/lib.rs
@@ -1366,7 +1366,7 @@ impl IHEIntegrationContract {
         match consent.consent_status {
             ConsentStatus::Revoked => return Err(Error::ConsentRevoked),
             ConsentStatus::Expired => return Err(Error::ConsentExpired),
-            ConsentStatus::Active => {}
+            ConsentStatus::Active => {},
         }
 
         if consent.expiry_time > 0 && env.ledger().timestamp() > consent.expiry_time {

--- a/contracts/iot_device_management/src/errors.rs
+++ b/contracts/iot_device_management/src/errors.rs
@@ -55,24 +55,24 @@ pub fn get_suggestion(error: Error) -> Symbol {
         | Error::NotDeviceOperator
         | Error::NotManufacturer => {
             symbol_short!("CHK_AUTH")
-        }
+        },
         Error::NotInitialized => symbol_short!("INIT_CTR"),
         Error::AlreadyInitialized
         | Error::DeviceAlreadyRegistered
         | Error::ManufacturerAlreadyRegistered
         | Error::FirmwareAlreadyExists => {
             symbol_short!("ALREADY")
-        }
+        },
         Error::ContractPaused | Error::HeartbeatTooFrequent | Error::KeyRotationTooFrequent => {
             symbol_short!("RE_TRY_L")
-        }
+        },
         Error::InputTooLong | Error::InputTooShort => symbol_short!("CHK_LEN"),
         Error::DeviceNotFound
         | Error::ManufacturerNotRegistered
         | Error::FirmwareVersionNotFound
         | Error::ChannelNotFound => {
             symbol_short!("CHK_ID")
-        }
+        },
         _ => symbol_short!("CONTACT"),
     }
 }

--- a/contracts/load_testing/src/lib.rs
+++ b/contracts/load_testing/src/lib.rs
@@ -114,8 +114,8 @@ impl LoadTestRunner {
             0
         };
 
-        let passed = success_rate >= config.min_success_rate
-            && avg_latency <= config.max_avg_latency;
+        let passed =
+            success_rate >= config.min_success_rate && avg_latency <= config.max_avg_latency;
 
         let result = LoadTestResult {
             total_requests: config.num_requests,
@@ -131,9 +131,7 @@ impl LoadTestRunner {
         };
 
         // Persist result and increment run counter.
-        env.storage()
-            .instance()
-            .set(&DataKey::LastResult, &result);
+        env.storage().instance().set(&DataKey::LastResult, &result);
         let run_count: u32 = env
             .storage()
             .instance()
@@ -143,8 +141,10 @@ impl LoadTestRunner {
             .instance()
             .set(&DataKey::RunCount, &(run_count + 1));
 
-        env.events()
-            .publish((symbol_short!("LOAD"), symbol_short!("DONE")), result.passed);
+        env.events().publish(
+            (symbol_short!("LOAD"), symbol_short!("DONE")),
+            result.passed,
+        );
 
         result
     }

--- a/contracts/medical_consent_nft/src/lib.rs
+++ b/contracts/medical_consent_nft/src/lib.rs
@@ -927,7 +927,7 @@ impl PatientConsentToken {
                     if current_time < start || current_time > end {
                         return Ok(false);
                     }
-                }
+                },
                 AccessCondition::DayOfWeek(days) => {
                     // Simple day check (assuming timestamp % 7 gives day of week)
                     let day = (current_time / 86400) % 7;
@@ -941,20 +941,20 @@ impl PatientConsentToken {
                     if !found {
                         return Ok(false);
                     }
-                }
+                },
                 AccessCondition::TimeOfDay(start_hour, end_hour) => {
                     let hour = (current_time % 86400) / 3600;
                     if hour < (start_hour as u64) || hour > (end_hour as u64) {
                         return Ok(false);
                     }
-                }
+                },
                 AccessCondition::EmergencyOnly => {
                     // Only emergency overrides can access
                     return Ok(false);
-                }
+                },
                 _ => {
                     // Other conditions would need additional context
-                }
+                },
             }
         }
 
@@ -1177,7 +1177,7 @@ impl PatientConsentToken {
                     }
                     current = inh.parent_token_id;
                     visited.push_back(current);
-                }
+                },
                 None => break,
             }
         }

--- a/contracts/medical_record_backup/src/lib.rs
+++ b/contracts/medical_record_backup/src/lib.rs
@@ -896,7 +896,7 @@ impl MedicalRecordBackupContract {
             Err(e) => {
                 Self::record_failed_execution(&env, caller, scheduled, e as u32, 0);
                 return Err(e);
-            }
+            },
         };
 
         if total_cost > policy.max_total_cost_weight {

--- a/contracts/medical_record_hash_registry/src/errors.rs
+++ b/contracts/medical_record_hash_registry/src/errors.rs
@@ -27,7 +27,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
         Error::ContractPaused | Error::DeadlineExceeded => symbol_short!("RE_TRY_L"),
         Error::InvalidId | Error::DuplicateRecord | Error::RecordNotFound => {
             symbol_short!("CHK_ID")
-        }
+        },
         Error::InsufficientFunds => symbol_short!("ADD_FUND"),
         Error::StorageFull => symbol_short!("CLN_OLD"),
         Error::CrossChainTimeout => symbol_short!("RE_TRY_L"),

--- a/contracts/medical_record_hash_registry/src/lib.rs
+++ b/contracts/medical_record_hash_registry/src/lib.rs
@@ -143,11 +143,11 @@ impl MedicalRecordHashRegistry {
                 }
                 events::publish_record_verified(&env, &patient_id, &record_hash, false);
                 Ok(false)
-            }
+            },
             None => {
                 events::publish_record_verified(&env, &patient_id, &record_hash, false);
                 Ok(false)
-            }
+            },
         }
     }
 

--- a/contracts/medical_records/src/lib.rs
+++ b/contracts/medical_records/src/lib.rs
@@ -1193,8 +1193,8 @@ impl MedicalRecordsContract {
                     ) {
                         return true;
                     }
-                }
-                Role::Patient | Role::None => {}
+                },
+                Role::Patient | Role::None => {},
             }
         }
 
@@ -1759,7 +1759,7 @@ impl MedicalRecordsContract {
                         "Record access requested for a non-existent record",
                     );
                     return Err(Error::RecordNotFound);
-                }
+                },
             };
 
         if !Self::can_view_record(&env, &caller, &record, record_id) {
@@ -3877,7 +3877,7 @@ impl MedicalRecordsContract {
                     "Emergency access revoke requested but grant was not found",
                 );
                 return Err(Error::EmergencyAccessNotFound);
-            }
+            },
         };
         entry.is_active = false;
         grants.set(grantee.clone(), entry);
@@ -4075,7 +4075,7 @@ impl MedicalRecordsContract {
                     "Recovery approval requested for a non-existent proposal",
                 );
                 return Err(Error::RecordNotFound);
-            }
+            },
         };
         if proposal.executed {
             Self::log_error(
@@ -4134,7 +4134,7 @@ impl MedicalRecordsContract {
                     "Recovery execution requested for a non-existent proposal",
                 );
                 return Err(Error::RecordNotFound);
-            }
+            },
         };
         if proposal.executed {
             Self::log_error(
@@ -5335,7 +5335,7 @@ impl MedicalRecordsContract {
                         return Ok(()); // Admins unlimited by default
                     }
                     cfg.admin_max_calls
-                }
+                },
                 Role::Doctor => cfg.doctor_max_calls,
                 Role::Patient | Role::None => cfg.patient_max_calls,
             },

--- a/contracts/medical_records/src/validation.rs
+++ b/contracts/medical_records/src/validation.rs
@@ -1153,20 +1153,20 @@ pub fn validate_record_by_type(
         MedicalRecordType::General => {
             // Standard validation is sufficient
             Ok(())
-        }
+        },
         MedicalRecordType::Laboratory => {
             // Lab records MUST have a data reference for results
             if record.data_ref.len() < MIN_DATA_REF_LENGTH {
                 return Err(Error::InvalidBatch);
             }
             Ok(())
-        }
+        },
         MedicalRecordType::Prescription => {
             // Prescriptions MUST have treatment and treatment_type
             validate_treatment(&record.treatment)?;
             validate_treatment_type(&record.treatment_type)?;
             Ok(())
-        }
+        },
         MedicalRecordType::Imaging => {
             // Imaging records MUST have a data reference for the images
             if record.data_ref.len() < MIN_DATA_REF_LENGTH {
@@ -1174,7 +1174,7 @@ pub fn validate_record_by_type(
             }
             validate_data_ref(env, &record.data_ref)?;
             Ok(())
-        }
+        },
         MedicalRecordType::Surgical => {
             // Surgical records need diagnosis, treatment, AND doctor DID
             validate_diagnosis(&record.diagnosis)?;
@@ -1183,7 +1183,7 @@ pub fn validate_record_by_type(
                 return Err(Error::InvalidBatch);
             }
             Ok(())
-        }
+        },
         MedicalRecordType::Emergency => {
             // Emergency records: timestamp must be recent (within 1 hour)
             let current_time = env.ledger().timestamp();
@@ -1193,7 +1193,7 @@ pub fn validate_record_by_type(
             }
             validate_diagnosis(&record.diagnosis)?;
             Ok(())
-        }
+        },
     }
 }
 

--- a/contracts/medication_management/src/lib.rs
+++ b/contracts/medication_management/src/lib.rs
@@ -900,14 +900,14 @@ impl MedicationManagement {
                 } else {
                     24 / *hours
                 }
-            }
+            },
             DosingSchedule::EveryNDays(days) => {
                 if *days == 0 {
                     0
                 } else {
                     1
                 }
-            }
+            },
             DosingSchedule::Weekly => 1,
             DosingSchedule::SpecificTimes(times) => times.len(),
         }
@@ -936,7 +936,7 @@ impl MedicationManagement {
                     let days_u64 = u64::from(*days);
                     elapsed_days.div_ceil(days_u64) as u32
                 }
-            }
+            },
             DosingSchedule::Weekly => elapsed_days.div_ceil(7) as u32,
             _ => (elapsed_days as u32).saturating_mul(Self::doses_per_day(&schedule.schedule)),
         }

--- a/contracts/meta_tx_forwarder/src/lib.rs
+++ b/contracts/meta_tx_forwarder/src/lib.rs
@@ -182,7 +182,13 @@ impl MetaTxForwarder {
         for i in 0..requests.len() {
             let request = requests.get(i).ok_or(Error::InvalidSignature)?;
             let signature = signatures.get(i).ok_or(Error::InvalidSignature)?;
-            results.push_back(Self::execute_one(&env, request, signature, current_time, &relayer)?);
+            results.push_back(Self::execute_one(
+                &env,
+                request,
+                signature,
+                current_time,
+                &relayer,
+            )?);
         }
 
         Ok(results)
@@ -347,7 +353,12 @@ impl MetaTxForwarder {
         Self::increment_nonce(env, &request.from);
         env.events().publish(
             (symbol_short!("fwd"),),
-            (relayer.clone(), request.from.clone(), request.to.clone(), request.nonce),
+            (
+                relayer.clone(),
+                request.from.clone(),
+                request.to.clone(),
+                request.nonce,
+            ),
         );
         Ok(result)
     }

--- a/contracts/notification_system/src/errors.rs
+++ b/contracts/notification_system/src/errors.rs
@@ -44,10 +44,10 @@ pub fn get_suggestion(error: Error) -> Symbol {
         Error::RateLimitExceeded => symbol_short!("RE_TRY_L"),
         Error::TitleTooLong | Error::MessageTooLong | Error::NameTooLong => {
             symbol_short!("SHORTEN")
-        }
+        },
         Error::NotificationNotFound | Error::AlertRuleNotFound | Error::TemplateNotFound => {
             symbol_short!("CHK_ID")
-        }
+        },
         Error::MaxSendersReached
         | Error::MaxRulesReached
         | Error::MaxNotificationsReached
@@ -56,7 +56,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
         Error::NotInitialized => symbol_short!("INIT_CTR"),
         Error::AlreadyInitialized | Error::AlreadyRead | Error::AlreadyArchived => {
             symbol_short!("ALREADY")
-        }
+        },
         Error::RecipientsEmpty => symbol_short!("ADD_TEXT"),
         Error::LocaleTooLong => symbol_short!("FIX_LANG"),
         _ => symbol_short!("CONTACT"),

--- a/contracts/notification_system/src/lib.rs
+++ b/contracts/notification_system/src/lib.rs
@@ -1123,7 +1123,7 @@ impl NotificationContract {
                     }
                 }
                 NotificationStatus::Pending
-            }
+            },
         }
     }
 

--- a/contracts/patient_consent_management/src/lib.rs
+++ b/contracts/patient_consent_management/src/lib.rs
@@ -221,7 +221,7 @@ impl PatientConsentManagement {
                     }
                 }
                 count
-            }
+            },
             None => 0,
         }
     }

--- a/contracts/provider_directory/src/lib.rs
+++ b/contracts/provider_directory/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec,
-};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String, Vec};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -46,72 +44,126 @@ impl ProviderDirectoryContract {
             return Err(Error::AlreadyInitialized);
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
-        
+
         // Set default rate limit: 10 searches per hour (3600 seconds)
         let default_config = RateLimitConfig {
             max_searches: 10,
             window_secs: 3600,
         };
-        env.storage().instance().set(&DataKey::RateLimitConfig, &default_config);
-        
+        env.storage()
+            .instance()
+            .set(&DataKey::RateLimitConfig, &default_config);
+
         Ok(())
     }
 
-    pub fn set_rate_limit_config(env: Env, admin: Address, max_searches: u32, window_secs: u64) -> Result<(), Error> {
+    pub fn set_rate_limit_config(
+        env: Env,
+        admin: Address,
+        max_searches: u32,
+        window_secs: u64,
+    ) -> Result<(), Error> {
         admin.require_auth();
-        let current_admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
         if current_admin != admin {
             return Err(Error::NotAuthorized);
         }
-        
+
         let config = RateLimitConfig {
             max_searches,
             window_secs,
         };
-        env.storage().instance().set(&DataKey::RateLimitConfig, &config);
+        env.storage()
+            .instance()
+            .set(&DataKey::RateLimitConfig, &config);
         Ok(())
     }
 
-    pub fn set_institution_exemption(env: Env, admin: Address, institution: Address, is_exempt: bool) -> Result<(), Error> {
+    pub fn set_institution_exemption(
+        env: Env,
+        admin: Address,
+        institution: Address,
+        is_exempt: bool,
+    ) -> Result<(), Error> {
         admin.require_auth();
-        let current_admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotInitialized)?;
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
         if current_admin != admin {
             return Err(Error::NotAuthorized);
         }
-        
+
         if is_exempt {
-            env.storage().persistent().set(&DataKey::ExemptInstitution(institution), &true);
+            env.storage()
+                .persistent()
+                .set(&DataKey::ExemptInstitution(institution), &true);
         } else {
-            env.storage().persistent().remove(&DataKey::ExemptInstitution(institution));
+            env.storage()
+                .persistent()
+                .remove(&DataKey::ExemptInstitution(institution));
         }
         Ok(())
     }
 
-    pub fn search_providers(env: Env, caller: Address, _query: String) -> Result<Vec<Provider>, Error> {
+    pub fn search_providers(
+        env: Env,
+        caller: Address,
+        _query: String,
+    ) -> Result<Vec<Provider>, Error> {
         caller.require_auth();
-        
+
         // Enforce sliding window rate limits (throws Error::RateLimitExceeded)
         Self::check_search_rate_limit(&env, &caller)?;
 
         // TODO: Implement actual provider search matching the _query
         Ok(Vec::new(&env))
     }
-    
-    fn check_search_rate_limit(env: &Env, caller: &Address) -> Result<(), Error> {
-        let is_exempt: bool = env.storage().persistent().get(&DataKey::ExemptInstitution(caller.clone())).unwrap_or(false);
-        if is_exempt { return Ok(()); }
 
-        let config: RateLimitConfig = env.storage().instance().get(&DataKey::RateLimitConfig).unwrap_or(RateLimitConfig { max_searches: 10, window_secs: 3600 });
-        let now = env.ledger().timestamp();
-        let timestamps: Vec<u64> = env.storage().persistent().get(&DataKey::SearchRateLimit(caller.clone())).unwrap_or(Vec::new(env));
-        let mut active_timestamps = Vec::new(env);
-        for ts in timestamps.iter() {
-            if now.saturating_sub(ts) < config.window_secs { active_timestamps.push_back(ts); }
+    fn check_search_rate_limit(env: &Env, caller: &Address) -> Result<(), Error> {
+        let is_exempt: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ExemptInstitution(caller.clone()))
+            .unwrap_or(false);
+        if is_exempt {
+            return Ok(());
         }
 
-        if active_timestamps.len() >= config.max_searches { return Err(Error::RateLimitExceeded); }
+        let config: RateLimitConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::RateLimitConfig)
+            .unwrap_or(RateLimitConfig {
+                max_searches: 10,
+                window_secs: 3600,
+            });
+        let now = env.ledger().timestamp();
+        let timestamps: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::SearchRateLimit(caller.clone()))
+            .unwrap_or(Vec::new(env));
+        let mut active_timestamps = Vec::new(env);
+        for ts in timestamps.iter() {
+            if now.saturating_sub(ts) < config.window_secs {
+                active_timestamps.push_back(ts);
+            }
+        }
+
+        if active_timestamps.len() >= config.max_searches {
+            return Err(Error::RateLimitExceeded);
+        }
         active_timestamps.push_back(now);
-        env.storage().persistent().set(&DataKey::SearchRateLimit(caller.clone()), &active_timestamps);
+        env.storage().persistent().set(
+            &DataKey::SearchRateLimit(caller.clone()),
+            &active_timestamps,
+        );
         Ok(())
     }
 }

--- a/contracts/reputation_access_control/src/lib.rs
+++ b/contracts/reputation_access_control/src/lib.rs
@@ -191,8 +191,8 @@ impl ReputationAccessControl {
                 if !Self::check_time_restriction(&env, time_restriction)? {
                     return Ok(false);
                 }
-            }
-            TimeRestrictionPolicy::None => {}
+            },
+            TimeRestrictionPolicy::None => {},
         }
 
         // Check if requested access level is allowed

--- a/contracts/reputation_integration/src/lib.rs
+++ b/contracts/reputation_integration/src/lib.rs
@@ -176,7 +176,7 @@ impl ReputationIntegration {
                 Err(_) => {
                     // Continue with other providers even if one fails
                     results.push_back(0);
-                }
+                },
             }
         }
 

--- a/contracts/runtime_validation/src/events.rs
+++ b/contracts/runtime_validation/src/events.rs
@@ -4,10 +4,8 @@ use crate::types::{
 use soroban_sdk::{symbol_short, Address, Env, String};
 
 pub fn publish_initialization(env: &Env, admin: &Address) {
-    env.events().publish(
-        (symbol_short!("VALID"), symbol_short!("INIT")),
-        admin,
-    );
+    env.events()
+        .publish((symbol_short!("VALID"), symbol_short!("INIT")), admin);
 }
 
 pub fn publish_invariant_registered(env: &Env, check: &InvariantCheck) {

--- a/contracts/runtime_validation/src/lib.rs
+++ b/contracts/runtime_validation/src/lib.rs
@@ -13,9 +13,7 @@ pub use types::{
     ValidationReport, ViolationType,
 };
 
-use soroban_sdk::{
-    contract, contractimpl, Address, Env, String, Vec,
-};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 #[contract]
 pub struct RuntimeValidation;
@@ -34,9 +32,7 @@ impl RuntimeValidation {
         env.storage()
             .instance()
             .set(&DataKey::ViolationCount, &0u64);
-        env.storage()
-            .instance()
-            .set(&DataKey::CheckCount, &0u32);
+        env.storage().instance().set(&DataKey::CheckCount, &0u32);
 
         events::publish_initialization(&env, &admin);
         Ok(())
@@ -309,11 +305,7 @@ impl RuntimeValidation {
     }
 
     /// Check permission
-    pub fn verify_permission(
-        env: Env,
-        check_id: String,
-        user_role: String,
-    ) -> Result<bool, Error> {
+    pub fn verify_permission(env: Env, check_id: String, user_role: String) -> Result<bool, Error> {
         let check: PermissionCheck = env
             .storage()
             .persistent()

--- a/contracts/runtime_validation/src/test.rs
+++ b/contracts/runtime_validation/src/test.rs
@@ -148,7 +148,8 @@ mod tests {
         let description = String::from_str(&env, "Must be admin");
         let required_role = String::from_str(&env, "admin");
 
-        let result = client.register_permission_check(&admin, &check_id, &description, &required_role);
+        let result =
+            client.register_permission_check(&admin, &check_id, &description, &required_role);
         assert_eq!(result, ());
     }
 

--- a/contracts/sanitization/src/lib.rs
+++ b/contracts/sanitization/src/lib.rs
@@ -25,11 +25,7 @@ pub enum SanitizationError {
 
 /// Validates a general-purpose string: non-empty, within `max_len` bytes,
 /// no null bytes, no ASCII control characters (allows tab/LF/CR).
-pub fn sanitize_string(
-    _env: &Env,
-    input: &String,
-    max_len: u32,
-) -> Result<(), SanitizationError> {
+pub fn sanitize_string(_env: &Env, input: &String, max_len: u32) -> Result<(), SanitizationError> {
     let len = input.len();
 
     if len == 0 {
@@ -326,12 +322,14 @@ mod tests {
     fn test_sanitize_name_too_long() {
         let env = Env::default();
         // 129 'a' characters
-        let long: &str =
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+        let long: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
              aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         assert_eq!(long.len(), 130);
         let s = String::from_str(&env, long);
-        assert_eq!(sanitize_name(&env, &s), Err(SanitizationError::InputTooLong));
+        assert_eq!(
+            sanitize_name(&env, &s),
+            Err(SanitizationError::InputTooLong)
+        );
     }
 
     // --- sanitize_email ---

--- a/contracts/timelock/src/errors.rs
+++ b/contracts/timelock/src/errors.rs
@@ -34,7 +34,7 @@ pub fn get_suggestion(error: Error) -> Symbol {
         Error::AlreadyInitialized | Error::AlreadyQueued => symbol_short!("ALREADY"),
         Error::ContractPaused | Error::DeadlineExceeded | Error::CrossChainTimeout => {
             symbol_short!("RE_TRY_L")
-        }
+        },
         Error::InsufficientFunds => symbol_short!("ADD_FUND"),
         Error::StorageFull => symbol_short!("CLN_OLD"),
         _ => symbol_short!("CONTACT"),

--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -67,7 +67,11 @@ impl Timelock {
         }
         q.set(id, QueuedTx { target, call, eta });
         env.storage().persistent().set(&QUEUE, &q);
-        env.storage().persistent().extend_ttl(&QUEUE, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &QUEUE,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         env.events().publish((symbol_short!("Queued"), id), (eta,));
         Ok(())
     }
@@ -78,7 +82,11 @@ impl Timelock {
             .persistent()
             .get(&QUEUE)
             .unwrap_or(Map::new(&env));
-        env.storage().persistent().extend_ttl(&QUEUE, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &QUEUE,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         let tx = q.get(id).ok_or(Error::NotQueued)?;
         let now: u64 = env.ledger().timestamp();
         if now < tx.eta {
@@ -88,7 +96,11 @@ impl Timelock {
         // Here we just emit execution event and remove from queue.
         q.remove(id);
         env.storage().persistent().set(&QUEUE, &q);
-        env.storage().persistent().extend_ttl(&QUEUE, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &QUEUE,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         env.events()
             .publish((symbol_short!("Exec"), id), (tx.target, tx.call));
         Ok(())

--- a/contracts/token_sale/src/contract.rs
+++ b/contracts/token_sale/src/contract.rs
@@ -1,9 +1,5 @@
-// Token sale contract - arithmetic is bounds-checked via asserts
-#![allow(clippy::arithmetic_side_effects)]
-#![allow(clippy::unwrap_used)]
-#![allow(clippy::expect_used)]
-#![allow(clippy::panic)]
-
+// Token sale contract
+use crate::errors::Error;
 use crate::storage::*;
 use crate::types::*;
 use soroban_sdk::{contract, contractimpl, contractmeta, token, Address, Env};
@@ -143,41 +139,55 @@ impl TokenSaleContract {
     }
 
     /// Contribute to the sale using ERC20 tokens
-    pub fn contribute(env: Env, contributor: Address, phase_id: u32, token: Address, amount: u128) {
+    pub fn contribute(
+        env: Env,
+        contributor: Address,
+        phase_id: u32,
+        token: Address,
+        amount: u128,
+    ) -> Result<(), Error> {
         contributor.require_auth();
 
-        assert!(!is_paused(&env), "Sale is paused");
+        if is_paused(&env) {
+            return Err(Error::Paused);
+        }
         let config = get_config(&env);
-        assert!(!config.is_finalized, "Sale is finalized");
-        assert!(is_supported_token(&env, &token), "Token not supported");
+        if config.is_finalized {
+            return Err(Error::PhaseClosed);
+        }
+        if !is_supported_token(&env, &token) {
+            return Err(Error::InvalidArgument);
+        }
 
         let current_time = get_ledger_timestamp(&env);
         let Some(mut phase) = get_sale_phase(&env, phase_id) else {
-            return; // Phase not found
+            return Err(Error::PhaseNotFound);
         };
 
-        // Validate phase
-        assert!(phase.is_active, "Phase not active");
-        assert!(current_time >= phase.start_time, "Phase not started");
-        assert!(current_time <= phase.end_time, "Phase ended");
+        if !phase.is_active || current_time < phase.start_time || current_time > phase.end_time {
+            return Err(Error::PhaseClosed);
+        }
 
-        // Calculate tokens to allocate using configurable decimal precision
         let tokens_to_allocate =
             fp_math::tokens_for_payment(amount, phase.price_per_token, config.token_decimals)
                 .expect("token allocation overflow");
-        assert!(
-            phase.sold_tokens + tokens_to_allocate <= phase.max_tokens,
-            "Phase cap exceeded"
-        );
 
-        // Check per-address cap
+        let new_sold = phase
+            .sold_tokens
+            .checked_add(tokens_to_allocate)
+            .ok_or(Error::Overflow)?;
+        if new_sold > phase.max_tokens {
+            return Err(Error::CapExceeded);
+        }
+
         let user_phase_contribution = get_phase_contribution(&env, &contributor, phase_id);
-        assert!(
-            user_phase_contribution + amount <= phase.per_address_cap,
-            "Per-address cap exceeded"
-        );
+        let new_contribution = user_phase_contribution
+            .checked_add(amount)
+            .ok_or(Error::Overflow)?;
+        if new_contribution > phase.per_address_cap {
+            return Err(Error::CapExceeded);
+        }
 
-        // Transfer payment tokens from contributor
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(
             &contributor,
@@ -185,20 +195,16 @@ impl TokenSaleContract {
             &(amount as i128),
         );
 
-        // Update phase
-        phase.sold_tokens += tokens_to_allocate;
+        phase.sold_tokens = new_sold;
         set_sale_phase(&env, phase_id, &phase);
 
-        // Update user contributions
-        set_phase_contribution(
-            &env,
-            &contributor,
-            phase_id,
-            user_phase_contribution + amount,
-        );
-        set_total_raised(&env, get_total_raised(&env) + amount);
+        set_phase_contribution(&env, &contributor, phase_id, new_contribution);
 
-        // Update or create user contribution record
+        let new_total = get_total_raised(&env)
+            .checked_add(amount)
+            .ok_or(Error::Overflow)?;
+        set_total_raised(&env, new_total);
+
         let mut contribution = get_contribution(&env, &contributor).unwrap_or(Contribution {
             amount: 0,
             tokens_allocated: 0,
@@ -207,8 +213,14 @@ impl TokenSaleContract {
             claimed: false,
         });
 
-        contribution.amount += amount;
-        contribution.tokens_allocated += tokens_to_allocate;
+        contribution.amount = contribution
+            .amount
+            .checked_add(amount)
+            .ok_or(Error::Overflow)?;
+        contribution.tokens_allocated = contribution
+            .tokens_allocated
+            .checked_add(tokens_to_allocate)
+            .ok_or(Error::Overflow)?;
         contribution.timestamp = current_time;
         set_contribution(&env, &contributor, &contribution);
 
@@ -216,6 +228,8 @@ impl TokenSaleContract {
             ("contribution",),
             (contributor, phase_id, amount, tokens_to_allocate),
         );
+
+        Ok(())
     }
 
     /// Finalize the sale
@@ -257,11 +271,9 @@ impl TokenSaleContract {
         assert!(!contribution.claimed, "Tokens already claimed");
         assert!(contribution.tokens_allocated > 0, "No tokens to claim");
 
-        // Mark as claimed
         contribution.claimed = true;
         set_contribution(&env, &claimer, &contribution);
 
-        // Transfer SUT tokens
         let token_client = token::Client::new(&env, &config.token_address);
         token_client.transfer(
             &env.current_contract_address(),
@@ -288,11 +300,9 @@ impl TokenSaleContract {
         assert!(!contribution.claimed, "Already claimed");
         assert!(contribution.amount > 0, "No contribution to refund");
 
-        // Mark as claimed
         contribution.claimed = true;
         set_contribution(&env, &claimer, &contribution);
 
-        // Transfer refund
         let token_client = token::Client::new(&env, &payment_token);
         token_client.transfer(
             &env.current_contract_address(),

--- a/contracts/token_sale/src/errors.rs
+++ b/contracts/token_sale/src/errors.rs
@@ -1,0 +1,17 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    AlreadyInitialized = 1,
+    InvalidArgument = 2,
+    Overflow = 3,
+    PhaseNotFound = 4,
+    PhaseClosed = 5,
+    CapExceeded = 6,
+    NotFinalized = 7,
+    AlreadyClaimed = 8,
+    RefundsNotEnabled = 9,
+    Paused = 10,
+}

--- a/contracts/token_sale/src/lib.rs
+++ b/contracts/token_sale/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 mod contract;
+mod errors;
 mod storage;
 mod types;
 mod vesting;
@@ -9,4 +10,5 @@ mod vesting;
 mod test;
 
 pub use contract::{TokenSaleContract, TokenSaleContractClient};
+pub use errors::Error;
 pub use vesting::{VestingContract, VestingContractClient};

--- a/contracts/token_sale/src/test.rs
+++ b/contracts/token_sale/src/test.rs
@@ -252,3 +252,80 @@ fn test_refund_mechanism() {
         initial_balance + 500
     );
 }
+
+#[test]
+fn test_contribute_overflow_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let (sut_token_address, _sut_token_client, _sut_token_admin) =
+        create_token_contract(&env, &owner);
+    let (payment_token_address, _payment_token_client, payment_token_admin) =
+        create_token_contract(&env, &owner);
+
+    let contract_id = env.register_contract(None, TokenSaleContract);
+    let client = TokenSaleContractClient::new(&env, &contract_id);
+
+    // token_decimals = 0 so tokens_for_payment(amount, 1, 0) = amount (no fp_math overflow)
+    client.initialize(
+        &owner,
+        &sut_token_address,
+        &treasury,
+        &u128::MAX,
+        &u128::MAX,
+        &0u32,
+    );
+    client.add_supported_token(&payment_token_address);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 1500;
+    });
+    client.add_sale_phase(&1000, &2000, &1, &u128::MAX, &u128::MAX);
+
+    // Mint only to the contributor; contract_id gets tokens through transfer
+    let max_i128 = i128::MAX;
+    payment_token_admin.mint(&treasury, &max_i128);
+
+    // First contribution (half of MAX) succeeds
+    let half = u128::MAX / 2;
+    assert!(client
+        .try_contribute(&treasury, &0, &payment_token_address, &half)
+        .is_ok());
+
+    // Second contribution that would overflow sold_tokens is rejected
+    let overflow_amount = (u128::MAX / 2) + 2;
+    let result = client.try_contribute(&treasury, &0, &payment_token_address, &overflow_amount);
+    assert_eq!(result, Err(Ok(Error::Overflow)));
+}
+
+#[test]
+fn test_vesting_overflow_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let owner = Address::generate(&env);
+    let (token_address, _token_client, token_admin) = create_token_contract(&env, &owner);
+
+    let contract_id = env.register_contract(None, VestingContract);
+    let client = VestingContractClient::new(&env, &contract_id);
+
+    client.initialize_vesting(&owner, &token_address);
+    token_admin.mint(&contract_id, &i128::MAX);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    // total_amount = u128::MAX, time_since_cliff = 2 → u128::MAX * 2 overflows
+    let total_amount: u128 = u128::MAX;
+    client.create_vesting_schedule(&owner, &0u64, &u64::MAX, &total_amount);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 2;
+    });
+
+    let result = client.try_get_vested_amount(&owner, &2u64);
+    assert_eq!(result, Err(Ok(Error::Overflow)));
+}

--- a/contracts/token_sale/src/vesting.rs
+++ b/contracts/token_sale/src/vesting.rs
@@ -1,9 +1,5 @@
-// Vesting contract - arithmetic is bounds-checked and overflow is impossible with token amounts
-#![allow(clippy::arithmetic_side_effects)]
-#![allow(clippy::unwrap_used)]
-#![allow(clippy::expect_used)]
-#![allow(clippy::panic)]
-
+// Token vesting contract
+use crate::errors::Error;
 use crate::storage::*;
 use crate::types::*;
 use soroban_sdk::{contract, contractimpl, contractmeta, token, Address, Env, Vec};
@@ -75,20 +71,24 @@ impl VestingContract {
     }
 
     /// Release vested tokens to beneficiary
-    pub fn release_tokens(env: Env, beneficiary: Address) -> u128 {
+    pub fn release_tokens(env: Env, beneficiary: Address) -> Result<u128, Error> {
         beneficiary.require_auth();
 
-        let releasable = Self::get_releasable_amount(env.clone(), beneficiary.clone());
-        assert!(releasable > 0, "No tokens to release");
+        let releasable = Self::get_releasable_amount(env.clone(), beneficiary.clone())?;
+        if releasable == 0 {
+            return Err(Error::InvalidArgument);
+        }
 
-        // Update released amount
         let Some(mut schedule) = get_vesting_schedule(&env, &beneficiary) else {
-            return 0; // No vesting schedule
+            return Ok(0);
         };
-        schedule.released_amount += releasable;
+
+        schedule.released_amount = schedule
+            .released_amount
+            .checked_add(releasable)
+            .ok_or(Error::Overflow)?;
         set_vesting_schedule(&env, &beneficiary, &schedule);
 
-        // Transfer tokens
         let config = get_config(&env);
         let token_client = token::Client::new(&env, &config.token_address);
         token_client.transfer(
@@ -100,7 +100,7 @@ impl VestingContract {
         env.events()
             .publish(("tokens_released",), (beneficiary, releasable));
 
-        releasable
+        Ok(releasable)
     }
 
     /// Get vesting schedule for a beneficiary
@@ -109,53 +109,60 @@ impl VestingContract {
     }
 
     /// Get the amount of tokens that can be released now
-    pub fn get_releasable_amount(env: Env, beneficiary: Address) -> u128 {
+    pub fn get_releasable_amount(env: Env, beneficiary: Address) -> Result<u128, Error> {
         let schedule = match get_vesting_schedule(&env, &beneficiary) {
             Some(s) => s,
-            None => return 0,
+            None => return Ok(0),
         };
 
         let current_time = get_ledger_timestamp(&env);
-        let vested_amount = Self::get_vested_amount(env, beneficiary, current_time);
+        let vested_amount = Self::get_vested_amount(env, beneficiary, current_time)?;
 
-        vested_amount.saturating_sub(schedule.released_amount)
+        Ok(vested_amount.saturating_sub(schedule.released_amount))
     }
 
     /// Calculate vested amount at a specific timestamp
-    pub fn get_vested_amount(env: Env, beneficiary: Address, timestamp: u64) -> u128 {
+    pub fn get_vested_amount(
+        env: Env,
+        beneficiary: Address,
+        timestamp: u64,
+    ) -> Result<u128, Error> {
         let schedule = match get_vesting_schedule(&env, &beneficiary) {
             Some(s) => s,
-            None => return 0,
+            None => return Ok(0),
         };
 
         if schedule.total_amount == 0 {
-            return 0;
+            return Ok(0);
         }
 
         let cliff_end = schedule.start_time + schedule.cliff_duration;
 
-        // Before cliff, nothing is vested
         if timestamp < cliff_end {
-            return 0;
+            return Ok(0);
         }
 
         let vesting_end = schedule.start_time + schedule.vesting_duration;
 
-        // After vesting period, everything is vested
         if timestamp >= vesting_end {
-            return schedule.total_amount;
+            return Ok(schedule.total_amount);
         }
 
-        // Linear vesting between cliff and end
         let time_since_cliff = timestamp - cliff_end;
         let vesting_period = schedule.vesting_duration - schedule.cliff_duration;
 
         if vesting_period == 0 {
-            return schedule.total_amount;
+            return Ok(schedule.total_amount);
         }
 
-        // Calculate proportional vesting
-        (schedule.total_amount * time_since_cliff as u128) / vesting_period as u128
+        // Safe: checked_mul prevents overflow on large total_amount * time_since_cliff
+        let vested = schedule
+            .total_amount
+            .checked_mul(time_since_cliff as u128)
+            .ok_or(Error::Overflow)?
+            / vesting_period as u128;
+
+        Ok(vested)
     }
 
     /// Batch create vesting schedules for team members
@@ -195,18 +202,17 @@ impl VestingContract {
         new_cliff_duration: u64,
         new_vesting_duration: u64,
         new_total_amount: u128,
-    ) {
+    ) -> Result<(), Error> {
         let owner = get_owner(&env);
         owner.require_auth();
 
         let Some(mut schedule) = get_vesting_schedule(&env, &beneficiary) else {
-            return; // No vesting schedule
+            return Ok(());
         };
 
-        // Ensure we don't reduce already vested amounts
         let current_time = get_ledger_timestamp(&env);
         let current_vested =
-            Self::get_vested_amount(env.clone(), beneficiary.clone(), current_time);
+            Self::get_vested_amount(env.clone(), beneficiary.clone(), current_time)?;
         assert!(
             new_total_amount >= current_vested,
             "Cannot reduce vested amount"
@@ -227,5 +233,7 @@ impl VestingContract {
                 new_total_amount,
             ),
         );
+
+        Ok(())
     }
 }

--- a/contracts/treasury_controller/src/lib.rs
+++ b/contracts/treasury_controller/src/lib.rs
@@ -286,9 +286,11 @@ impl TreasuryController {
         env.storage()
             .persistent()
             .set(&DataKey::Proposals, &proposals);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposals, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposals,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         env.storage()
             .instance()
             .set(&DataKey::ProposalCount, &proposal_id);
@@ -356,9 +358,11 @@ impl TreasuryController {
         env.storage()
             .persistent()
             .set(&DataKey::Proposals, &proposals);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposals, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposals,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
 
         // Emit approval event
         env.events().publish(
@@ -425,9 +429,11 @@ impl TreasuryController {
         env.storage()
             .persistent()
             .set(&DataKey::Proposals, &proposals);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposals, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposals,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
 
         // Record withdrawal for audit trail
         if matches!(proposal.proposal_type, ProposalType::Withdrawal) {
@@ -452,9 +458,11 @@ impl TreasuryController {
             env.storage()
                 .persistent()
                 .set(&DataKey::Withdrawals, &withdrawals);
-            env.storage()
-                .persistent()
-                .extend_ttl(&DataKey::Withdrawals, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Withdrawals,
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
         }
 
         // Emit execution event

--- a/contracts/upgrade_manager/src/lib.rs
+++ b/contracts/upgrade_manager/src/lib.rs
@@ -119,7 +119,11 @@ impl UpgradeManager {
 
         proposals.set(id, proposal);
         env.storage().persistent().set(&PROPOSALS, &proposals);
-        env.storage().persistent().extend_ttl(&PROPOSALS, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &PROPOSALS,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
 
         env.events()
             .publish((symbol_short!("proposed"), id), proposer);
@@ -153,7 +157,11 @@ impl UpgradeManager {
         proposal.approvals.push_back(validator);
         proposals.set(proposal_id, proposal);
         env.storage().persistent().set(&PROPOSALS, &proposals);
-        env.storage().persistent().extend_ttl(&PROPOSALS, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &PROPOSALS,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         Ok(())
     }
 
@@ -190,7 +198,11 @@ impl UpgradeManager {
         proposal.executed = true;
         proposals.set(proposal_id, proposal);
         env.storage().persistent().set(&PROPOSALS, &proposals);
-        env.storage().persistent().extend_ttl(&PROPOSALS, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &PROPOSALS,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
 
         env.events()
             .publish((symbol_short!("executed"), proposal_id), ());
@@ -229,7 +241,11 @@ impl UpgradeManager {
         proposal.executed = true;
         proposals.set(proposal_id, proposal);
         env.storage().persistent().set(&PROPOSALS, &proposals);
-        env.storage().persistent().extend_ttl(&PROPOSALS, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &PROPOSALS,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
 
         env.events()
             .publish((symbol_short!("emergency"), proposal_id), ());

--- a/contracts/zk_verifier/src/lib.rs
+++ b/contracts/zk_verifier/src/lib.rs
@@ -305,7 +305,11 @@ impl ZkVerifierContract {
             consumed_at: env.ledger().timestamp(),
         };
         env.storage().persistent().set(&key, &value);
-        env.storage().persistent().extend_ttl(&key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        env.storage().persistent().extend_ttl(
+            &key,
+            PERSISTENT_TTL_THRESHOLD,
+            PERSISTENT_TTL_EXTEND_TO,
+        );
         true
     }
 

--- a/contracts/zkp_registry/src/lib.rs
+++ b/contracts/zkp_registry/src/lib.rs
@@ -5,7 +5,7 @@
 mod test;
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, 
+    contract, contracterror, contractimpl, contracttype, symbol_short,
     xdr::{FromXdr, ToXdr},
     Address, Bytes, BytesN, Env, String, Symbol, Vec,
 };
@@ -338,7 +338,11 @@ impl ZKPRegistry {
         admin.require_auth();
         Self::require_initialized(&env)?;
 
-        let current_admin: Address = env.storage().instance().get(&DataKey::Admin).ok_or(Error::NotAuthorized)?;
+        let current_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotAuthorized)?;
         if current_admin != admin {
             return Err(Error::NotAuthorized);
         }
@@ -347,8 +351,11 @@ impl ZKPRegistry {
             return Err(Error::InvalidThreshold);
         }
 
-        env.storage().instance().set(&DataKey::MultiSigConfig, &config);
-        env.events().publish((symbol_short!("admin"), symbol_short!("cfg_msig")), admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::MultiSigConfig, &config);
+        env.events()
+            .publish((symbol_short!("admin"), symbol_short!("cfg_msig")), admin);
         Ok(())
     }
 
@@ -361,12 +368,20 @@ impl ZKPRegistry {
         signer.require_auth();
         Self::require_initialized(&env)?;
 
-        let config: MultiSigConfig = env.storage().instance().get(&DataKey::MultiSigConfig).ok_or(Error::NotAuthorized)?;
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::NotAuthorized)?;
         if !config.signers.contains(&signer) {
             return Err(Error::InvalidSigner);
         }
 
-        let proposal_id: u64 = env.storage().instance().get(&DataKey::ProposalCounter).unwrap_or(0);
+        let proposal_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalCounter)
+            .unwrap_or(0);
         let mut approvals = Vec::new(&env);
         approvals.push_back(signer.clone());
 
@@ -378,10 +393,17 @@ impl ZKPRegistry {
             approvals,
         };
 
-        env.storage().instance().set(&DataKey::AdminProposal(proposal_id), &proposal);
-        env.storage().instance().set(&DataKey::ProposalCounter, &(proposal_id + 1));
+        env.storage()
+            .instance()
+            .set(&DataKey::AdminProposal(proposal_id), &proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalCounter, &(proposal_id + 1));
 
-        env.events().publish((symbol_short!("admin"), symbol_short!("proposed")), (proposal_id, signer));
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("proposed")),
+            (proposal_id, signer),
+        );
 
         Ok(proposal_id)
     }
@@ -395,12 +417,20 @@ impl ZKPRegistry {
         signer.require_auth();
         Self::require_initialized(&env)?;
 
-        let config: MultiSigConfig = env.storage().instance().get(&DataKey::MultiSigConfig).ok_or(Error::NotAuthorized)?;
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::NotAuthorized)?;
         if !config.signers.contains(&signer) {
             return Err(Error::InvalidSigner);
         }
 
-        let mut proposal: AdminProposal = env.storage().instance().get(&DataKey::AdminProposal(proposal_id)).ok_or(Error::ProposalNotFound)?;
+        let mut proposal: AdminProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::AdminProposal(proposal_id))
+            .ok_or(Error::ProposalNotFound)?;
 
         if proposal.executed {
             return Err(Error::AlreadyExecuted);
@@ -411,9 +441,14 @@ impl ZKPRegistry {
         }
 
         proposal.approvals.push_back(signer.clone());
-        env.storage().instance().set(&DataKey::AdminProposal(proposal_id), &proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey::AdminProposal(proposal_id), &proposal);
 
-        env.events().publish((symbol_short!("admin"), symbol_short!("approved")), (proposal_id, signer));
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("approved")),
+            (proposal_id, signer),
+        );
 
         Ok(())
     }
@@ -427,8 +462,16 @@ impl ZKPRegistry {
         executor.require_auth();
         Self::require_initialized(&env)?;
 
-        let config: MultiSigConfig = env.storage().instance().get(&DataKey::MultiSigConfig).ok_or(Error::NotAuthorized)?;
-        let mut proposal: AdminProposal = env.storage().instance().get(&DataKey::AdminProposal(proposal_id)).ok_or(Error::ProposalNotFound)?;
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::NotAuthorized)?;
+        let mut proposal: AdminProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::AdminProposal(proposal_id))
+            .ok_or(Error::ProposalNotFound)?;
 
         if proposal.executed {
             return Err(Error::AlreadyExecuted);
@@ -443,26 +486,35 @@ impl ZKPRegistry {
         }
 
         proposal.executed = true;
-        env.storage().instance().set(&DataKey::AdminProposal(proposal_id), &proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey::AdminProposal(proposal_id), &proposal);
 
         Self::execute_action(&env, &proposal.action)?;
 
-        env.events().publish((symbol_short!("admin"), symbol_short!("executed")), proposal_id);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("executed")),
+            proposal_id,
+        );
 
         Ok(())
     }
 
     /// Emergency override to execute a proposal without waiting for the timelock
-    pub fn emergency_override(
-        env: Env,
-        executor: Address,
-        proposal_id: u64,
-    ) -> Result<(), Error> {
+    pub fn emergency_override(env: Env, executor: Address, proposal_id: u64) -> Result<(), Error> {
         executor.require_auth();
         Self::require_initialized(&env)?;
 
-        let config: MultiSigConfig = env.storage().instance().get(&DataKey::MultiSigConfig).ok_or(Error::NotAuthorized)?;
-        let mut proposal: AdminProposal = env.storage().instance().get(&DataKey::AdminProposal(proposal_id)).ok_or(Error::ProposalNotFound)?;
+        let config: MultiSigConfig = env
+            .storage()
+            .instance()
+            .get(&DataKey::MultiSigConfig)
+            .ok_or(Error::NotAuthorized)?;
+        let mut proposal: AdminProposal = env
+            .storage()
+            .instance()
+            .get(&DataKey::AdminProposal(proposal_id))
+            .ok_or(Error::ProposalNotFound)?;
 
         if proposal.executed {
             return Err(Error::AlreadyExecuted);
@@ -474,11 +526,16 @@ impl ZKPRegistry {
         }
 
         proposal.executed = true;
-        env.storage().instance().set(&DataKey::AdminProposal(proposal_id), &proposal);
+        env.storage()
+            .instance()
+            .set(&DataKey::AdminProposal(proposal_id), &proposal);
 
         Self::execute_action(&env, &proposal.action)?;
 
-        env.events().publish((symbol_short!("admin"), symbol_short!("emer_exec")), proposal_id);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("emer_exec")),
+            proposal_id,
+        );
 
         Ok(())
     }
@@ -660,7 +717,11 @@ impl ZKPRegistry {
                 continue;
             }
 
-            if !env.storage().persistent().has(&DataKey::ZKPCircuitParams(circuit_id.clone())) {
+            if !env
+                .storage()
+                .persistent()
+                .has(&DataKey::ZKPCircuitParams(circuit_id.clone()))
+            {
                 results.push_back(false);
                 continue;
             }
@@ -686,8 +747,14 @@ impl ZKPRegistry {
             let is_valid = Self::verify_zkp_internal(&env, &proof).unwrap_or(false);
 
             if is_valid {
-                env.storage().temporary().set(&DataKey::ZKProof(proof_id.clone()), &proof);
-                env.storage().temporary().extend_ttl(&DataKey::ZKProof(proof_id.clone()), 0, TEMP_SESSION_TTL);
+                env.storage()
+                    .temporary()
+                    .set(&DataKey::ZKProof(proof_id.clone()), &proof);
+                env.storage().temporary().extend_ttl(
+                    &DataKey::ZKProof(proof_id.clone()),
+                    0,
+                    TEMP_SESSION_TTL,
+                );
                 let result = ZKPVerificationResult {
                     proof_id: proof_id.clone(),
                     is_valid,
@@ -696,13 +763,22 @@ impl ZKPRegistry {
                     verifier: submitter.clone(),
                     metadata: Bytes::from_slice(&env, b"batch_verification"),
                 };
-                env.storage().temporary().set(&DataKey::VerificationResult(proof_id.clone()), &result);
-                env.storage().temporary().extend_ttl(&DataKey::VerificationResult(proof_id.clone()), 0, TEMP_SESSION_TTL);
+                env.storage()
+                    .temporary()
+                    .set(&DataKey::VerificationResult(proof_id.clone()), &result);
+                env.storage().temporary().extend_ttl(
+                    &DataKey::VerificationResult(proof_id.clone()),
+                    0,
+                    TEMP_SESSION_TTL,
+                );
                 total_gas_used = total_gas_used.saturating_add(verification_gas);
             }
 
             results.push_back(is_valid);
-            env.events().publish((symbol_short!("zkp"), symbol_short!("proof_sub")), (submitter.clone(), proof_id, is_valid));
+            env.events().publish(
+                (symbol_short!("zkp"), symbol_short!("proof_sub")),
+                (submitter.clone(), proof_id, is_valid),
+            );
         }
 
         Self::track_gas_usage(&env, &submitter, total_gas_used);
@@ -891,8 +967,14 @@ impl ZKPRegistry {
         }
 
         // Verify base proof exists
-        let has_temp = env.storage().temporary().has(&DataKey::ZKProof(base_proof_id.clone()));
-        let has_pers = env.storage().persistent().has(&DataKey::ZKProof(base_proof_id.clone()));
+        let has_temp = env
+            .storage()
+            .temporary()
+            .has(&DataKey::ZKProof(base_proof_id.clone()));
+        let has_pers = env
+            .storage()
+            .persistent()
+            .has(&DataKey::ZKProof(base_proof_id.clone()));
 
         if !has_temp && !has_pers {
             return Err(Error::ProofNotFound);
@@ -939,9 +1021,17 @@ impl ZKPRegistry {
         Self::require_initialized(&env)?;
 
         // Verify ownership if possible
-        let is_owner = if let Some(result) = env.storage().temporary().get::<_, ZKPVerificationResult>(&DataKey::VerificationResult(proof_id.clone())) {
+        let is_owner = if let Some(result) = env
+            .storage()
+            .temporary()
+            .get::<_, ZKPVerificationResult>(&DataKey::VerificationResult(proof_id.clone()))
+        {
             result.verifier == submitter
-        } else if let Some(result) = env.storage().persistent().get::<_, ZKPVerificationResult>(&DataKey::VerificationResult(proof_id.clone())) {
+        } else if let Some(result) = env
+            .storage()
+            .persistent()
+            .get::<_, ZKPVerificationResult>(&DataKey::VerificationResult(proof_id.clone()))
+        {
             result.verifier == submitter
         } else {
             false
@@ -952,12 +1042,23 @@ impl ZKPRegistry {
         }
 
         // Cleanup from both temporary and persistent just in case
-        env.storage().temporary().remove(&DataKey::ZKProof(proof_id.clone()));
-        env.storage().temporary().remove(&DataKey::VerificationResult(proof_id.clone()));
-        env.storage().persistent().remove(&DataKey::ZKProof(proof_id.clone()));
-        env.storage().persistent().remove(&DataKey::VerificationResult(proof_id.clone()));
+        env.storage()
+            .temporary()
+            .remove(&DataKey::ZKProof(proof_id.clone()));
+        env.storage()
+            .temporary()
+            .remove(&DataKey::VerificationResult(proof_id.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ZKProof(proof_id.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::VerificationResult(proof_id.clone()));
 
-        env.events().publish((symbol_short!("zkp"), symbol_short!("cleanup")), (submitter, proof_id));
+        env.events().publish(
+            (symbol_short!("zkp"), symbol_short!("cleanup")),
+            (submitter, proof_id),
+        );
         Ok(())
     }
 
@@ -967,9 +1068,17 @@ impl ZKPRegistry {
         proof_id: BytesN<32>,
     ) -> Result<ZKPVerificationResult, Error> {
         Self::require_initialized(&env)?;
-        if let Some(result) = env.storage().temporary().get(&DataKey::VerificationResult(proof_id.clone())) {
+        if let Some(result) = env
+            .storage()
+            .temporary()
+            .get(&DataKey::VerificationResult(proof_id.clone()))
+        {
             Ok(result)
-        } else if let Some(result) = env.storage().persistent().get(&DataKey::VerificationResult(proof_id)) {
+        } else if let Some(result) = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VerificationResult(proof_id))
+        {
             Ok(result)
         } else {
             Err(Error::ProofNotFound)
@@ -1039,11 +1148,23 @@ impl ZKPRegistry {
             return Err(Error::NotInitialized);
         }
 
-        let initialized = env.storage().instance().get(&DataKey::Initialized).unwrap_or(false);
+        let initialized = env
+            .storage()
+            .instance()
+            .get(&DataKey::Initialized)
+            .unwrap_or(false);
         let admin = env.storage().instance().get(&DataKey::Admin).unwrap();
-        let paused = env.storage().instance().get(&DataKey::ContractPaused).unwrap_or(false);
+        let paused = env
+            .storage()
+            .instance()
+            .get(&DataKey::ContractPaused)
+            .unwrap_or(false);
         let multisig_config = env.storage().instance().get(&DataKey::MultiSigConfig);
-        let proposal_counter = env.storage().instance().get(&DataKey::ProposalCounter).unwrap_or(0);
+        let proposal_counter = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalCounter)
+            .unwrap_or(0);
 
         let mut proposals = Vec::new(&env);
         for i in 0..proposal_counter {
@@ -1079,8 +1200,8 @@ impl ZKPRegistry {
         }
 
         // Validate and deserialize state
-        let state = RegistryStateExport::from_xdr(&env, &state_bytes)
-            .map_err(|_| Error::InvalidInput)?;
+        let state =
+            RegistryStateExport::from_xdr(&env, &state_bytes).map_err(|_| Error::InvalidInput)?;
 
         // Format version validation
         if state.format_version != 1 {
@@ -1088,22 +1209,33 @@ impl ZKPRegistry {
         }
 
         // Restore state
-        env.storage().instance().set(&DataKey::Initialized, &state.initialized);
+        env.storage()
+            .instance()
+            .set(&DataKey::Initialized, &state.initialized);
         env.storage().instance().set(&DataKey::Admin, &state.admin);
-        env.storage().instance().set(&DataKey::ContractPaused, &state.paused);
+        env.storage()
+            .instance()
+            .set(&DataKey::ContractPaused, &state.paused);
 
         if let Some(config) = state.multisig_config {
-            env.storage().instance().set(&DataKey::MultiSigConfig, &config);
+            env.storage()
+                .instance()
+                .set(&DataKey::MultiSigConfig, &config);
         }
 
-        env.storage().instance().set(&DataKey::ProposalCounter, &state.proposal_counter);
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalCounter, &state.proposal_counter);
 
         for proposal in state.proposals.iter() {
-            env.storage().instance().set(&DataKey::AdminProposal(proposal.id), &proposal);
+            env.storage()
+                .instance()
+                .set(&DataKey::AdminProposal(proposal.id), &proposal);
         }
 
         env.storage().instance().set(&DataKey::Admin, &state.admin);
-        env.events().publish((symbol_short!("admin"), symbol_short!("imported")), caller);
+        env.events()
+            .publish((symbol_short!("admin"), symbol_short!("imported")), caller);
 
         Ok(())
     }
@@ -1115,13 +1247,18 @@ impl ZKPRegistry {
     fn execute_action(env: &Env, action: &AdminAction) -> Result<(), Error> {
         match action {
             AdminAction::UpgradeContract(wasm_hash) => {
-                env.deployer().update_current_contract_wasm(wasm_hash.clone());
+                env.deployer()
+                    .update_current_contract_wasm(wasm_hash.clone());
             },
             AdminAction::EmergencyPause => {
-                env.storage().instance().set(&DataKey::ContractPaused, &true);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::ContractPaused, &true);
             },
             AdminAction::EmergencyResume => {
-                env.storage().instance().set(&DataKey::ContractPaused, &false);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::ContractPaused, &false);
             },
             AdminAction::UpdateParameters(_key, _val) => {
                 // Placeholder for dynamic parameter updates
@@ -1138,7 +1275,12 @@ impl ZKPRegistry {
     }
 
     fn require_not_paused(env: &Env) -> Result<(), Error> {
-        if env.storage().instance().get(&DataKey::ContractPaused).unwrap_or(false) {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::ContractPaused)
+            .unwrap_or(false)
+        {
             return Err(Error::ContractPaused);
         }
         Ok(())

--- a/tests/integration/cross_chain_tests.rs
+++ b/tests/integration/cross_chain_tests.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{Env, Address, testutils::{Address as _}, String};
 use crate::medical_records::{MedicalRecordsContract, MedicalRecordsContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
 #[test]
 fn test_cross_chain_transfer_logic() {
@@ -15,18 +15,18 @@ fn test_cross_chain_transfer_logic() {
     // Assuming the contract has a cross_chain_transfer method based on issue requirements
     // If not existing, we simulate the logic behavior expected for bridge operations
     env.mock_all_auths();
-    
+
     // Simulating a successful cross-chain event validation
     let result = client.try_add_record(
-        &sender, 
-        &sender, 
-        &String::from_str(&env, "Cross-Chain Sync"), 
-        &destination_chain, 
+        &sender,
+        &sender,
+        &String::from_str(&env, "Cross-Chain Sync"),
+        &destination_chain,
         &true, // bridge_sync flag
-        &soroban_sdk::vec![&env], 
-        &String::from_str(&env, "Bridge"), 
-        &String::from_str(&env, "Sync"), 
-        &record_hash
+        &soroban_sdk::vec![&env],
+        &String::from_str(&env, "Bridge"),
+        &String::from_str(&env, "Sync"),
+        &record_hash,
     );
 
     assert!(result.is_ok(), "Bridge sync record should be accepted");
@@ -39,18 +39,18 @@ fn test_bridge_error_invalid_destination() {
     let client = MedicalRecordsContractClient::new(&env, &contract_id);
 
     let sender = Address::generate(&env);
-    
+
     // Test scenario: Missing data for bridge
     let res = client.try_add_record(
         &sender,
         &sender,
-        &String::from_str(&env, ""), 
-        &String::from_str(&env, ""), 
-        &true, 
+        &String::from_str(&env, ""),
+        &String::from_str(&env, ""),
+        &true,
         &soroban_sdk::vec![&env],
         &String::from_str(&env, "Invalid"),
         &String::from_str(&env, "Fail"),
-        &String::from_str(&env, "")
+        &String::from_str(&env, ""),
     );
 
     assert!(res.is_err(), "Should fail if bridge metadata is incomplete");

--- a/tests/integration/healthcare_workflows.rs
+++ b/tests/integration/healthcare_workflows.rs
@@ -1,13 +1,13 @@
+use crate::utils::IntegrationTestEnv;
+use medical_records::Role;
 /// Comprehensive integration tests for healthcare workflow scenarios
-use soroban_sdk::{vec, String, testutils::Address as _};
-use crate::utils::{IntegrationTestEnv};
-use medical_records::{Role};
+use soroban_sdk::{testutils::Address as _, vec, String};
 
 #[test]
 fn test_user_registration_workflow() {
     let test_env = IntegrationTestEnv::new();
     let (_, records_client) = test_env.register_medical_records();
-    
+
     let admin = &test_env.team.admin.address;
     let doctor = &test_env.team.doctors[0].address;
     let patient = &test_env.team.patients[0].address;
@@ -26,7 +26,7 @@ fn test_user_registration_workflow() {
 fn test_record_creation_retrieval_workflow() {
     let test_env = IntegrationTestEnv::new();
     let (records_id, records_client) = test_env.register_medical_records();
-    
+
     let admin = &test_env.team.admin.address;
     let doctor = &test_env.team.doctors[0].address;
     let patient = &test_env.team.patients[0].address;
@@ -38,7 +38,7 @@ fn test_record_creation_retrieval_workflow() {
     // 1. Doctor creates a medical record
     let diagnosis = String::from_str(&test_env.env, "Integration Test Diagnosis");
     let treatment = String::from_str(&test_env.env, "Automated Treatment");
-    
+
     let record_id = records_client.add_record(
         doctor,
         patient,
@@ -64,7 +64,7 @@ fn test_record_creation_retrieval_workflow() {
 fn test_pause_emergency_workflow() {
     let test_env = IntegrationTestEnv::new();
     let (_, records_client) = test_env.register_medical_records();
-    
+
     let admin = &test_env.team.admin.address;
     let doctor = &test_env.team.doctors[0].address;
     let patient = &test_env.team.patients[0].address;
@@ -94,4 +94,3 @@ fn test_pause_emergency_workflow() {
     records_client.unpause(admin);
     assert!(!records_client.is_paused());
 }
-

--- a/tests/integration/ihe_fhir_integration_tests.rs
+++ b/tests/integration/ihe_fhir_integration_tests.rs
@@ -1,27 +1,25 @@
 #![cfg(test)]
 
 //! Comprehensive Integration Test Suite for IHE/FHIR Standard Compliance
-//! 
+//!
 //! This test suite validates:
 //! - FHIR resource validation
 //! - IHE profile compliance
 //! - HL7 message format testing
 //! - Interoperability verification
-//! 
+//!
 //! Test Scenarios:
 //! - Patient record exchange
 //! - Consent management flow
 //! - Audit trail compliance
 //! - Security profile testing
 
-use soroban_sdk::{
-    testutils::Address as _, Address, BytesN, Env, Map, String, Vec,
-};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, Map, String, Vec};
 
 // Import contract types
 mod fhir_types {
     pub use super::*;
-    
+
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub enum FHIRResourceType {
         Patient = 0,
@@ -36,7 +34,7 @@ mod fhir_types {
         Immunization = 9,
         DocumentReference = 10,
     }
-    
+
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub enum CodingSystem {
         ICD10,
@@ -49,17 +47,16 @@ mod fhir_types {
     }
 }
 
-
 // ==================== Test Helper Functions ====================
 
 fn create_test_env() -> (Env, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let admin = Address::generate(&env);
     let provider = Address::generate(&env);
     let patient = Address::generate(&env);
-    
+
     (env, admin, provider, patient)
 }
 
@@ -70,7 +67,7 @@ fn create_fhir_patient(env: &Env) -> FHIRPatient {
         value: String::from_str(env, "MRN-12345"),
         use_type: String::from_str(env, "official"),
     });
-    
+
     FHIRPatient {
         identifiers,
         given_name: String::from_str(env, "John"),
@@ -122,22 +119,21 @@ fn validate_hl7_message_format(message_type: &str) -> bool {
     )
 }
 
-
 // ==================== FHIR Resource Validation Tests ====================
 
 #[test]
 fn test_fhir_patient_resource() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     let patient = create_fhir_patient(&env);
-    
+
     // Validate patient resource structure
     assert!(!patient.identifiers.is_empty());
     assert_eq!(patient.given_name, String::from_str(&env, "John"));
     assert_eq!(patient.family_name, String::from_str(&env, "Doe"));
     assert_eq!(patient.birth_date, String::from_str(&env, "1980-01-01"));
     assert_eq!(patient.gender, String::from_str(&env, "male"));
-    
+
     // Validate FHIR resource type
     assert!(validate_fhir_resource(FHIRResourceType::Patient));
 }
@@ -145,7 +141,7 @@ fn test_fhir_patient_resource() {
 #[test]
 fn test_fhir_observation_resource() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     let observation = FHIRObservation {
         identifier: String::from_str(&env, "obs-001"),
         status: String::from_str(&env, "final"),
@@ -158,7 +154,7 @@ fn test_fhir_observation_resource() {
         interpretation: Vec::new(&env),
         reference_range: String::from_str(&env, "60-100 beats/minute"),
     };
-    
+
     // Validate observation structure
     assert_eq!(observation.status, String::from_str(&env, "final"));
     assert_eq!(observation.value_quantity_value, 72);
@@ -168,17 +164,22 @@ fn test_fhir_observation_resource() {
 #[test]
 fn test_fhir_condition_resource() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     let condition = FHIRCondition {
         identifier: String::from_str(&env, "cond-001"),
         clinical_status: String::from_str(&env, "active"),
-        code: create_fhir_code(&env, CodingSystem::ICD10, "E11.9", "Type 2 diabetes mellitus"),
+        code: create_fhir_code(
+            &env,
+            CodingSystem::ICD10,
+            "E11.9",
+            "Type 2 diabetes mellitus",
+        ),
         subject_reference: String::from_str(&env, "Patient/MRN-12345"),
         onset_date_time: String::from_str(&env, "2020-06-15T00:00:00Z"),
         recorded_date: String::from_str(&env, "2020-06-15T00:00:00Z"),
         severity: Vec::new(&env),
     };
-    
+
     // Validate condition structure
     assert_eq!(condition.clinical_status, String::from_str(&env, "active"));
     assert_eq!(condition.code.code, String::from_str(&env, "E11.9"));
@@ -188,7 +189,7 @@ fn test_fhir_condition_resource() {
 #[test]
 fn test_fhir_medication_statement_resource() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     let medication = FHIRMedicationStatement {
         identifier: String::from_str(&env, "med-001"),
         status: String::from_str(&env, "active"),
@@ -199,21 +200,25 @@ fn test_fhir_medication_statement_resource() {
         dosage: String::from_str(&env, "500mg twice daily"),
         reason_code: Vec::new(&env),
     };
-    
+
     // Validate medication statement
     assert_eq!(medication.status, String::from_str(&env, "active"));
-    assert_eq!(medication.dosage, String::from_str(&env, "500mg twice daily"));
-    assert!(validate_fhir_resource(FHIRResourceType::MedicationStatement));
+    assert_eq!(
+        medication.dosage,
+        String::from_str(&env, "500mg twice daily")
+    );
+    assert!(validate_fhir_resource(
+        FHIRResourceType::MedicationStatement
+    ));
 }
-
 
 #[test]
 fn test_fhir_procedure_resource() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     let mut performers = Vec::new(&env);
     performers.push_back(String::from_str(&env, "Practitioner/dr-smith"));
-    
+
     let procedure = FHIRProcedure {
         identifier: String::from_str(&env, "proc-001"),
         status: String::from_str(&env, "completed"),
@@ -223,7 +228,7 @@ fn test_fhir_procedure_resource() {
         performer: performers,
         reason_code: Vec::new(&env),
     };
-    
+
     // Validate procedure
     assert_eq!(procedure.status, String::from_str(&env, "completed"));
     assert!(!procedure.performer.is_empty());
@@ -233,7 +238,7 @@ fn test_fhir_procedure_resource() {
 #[test]
 fn test_fhir_allergy_intolerance_resource() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     let allergy = FHIRAllergyIntolerance {
         identifier: String::from_str(&env, "allergy-001"),
         clinical_status: String::from_str(&env, "active"),
@@ -244,7 +249,7 @@ fn test_fhir_allergy_intolerance_resource() {
         manifestation: Vec::new(&env),
         severity: String::from_str(&env, "severe"),
     };
-    
+
     // Validate allergy intolerance
     assert_eq!(allergy.clinical_status, String::from_str(&env, "active"));
     assert_eq!(allergy.severity, String::from_str(&env, "severe"));
@@ -256,7 +261,7 @@ fn test_fhir_allergy_intolerance_resource() {
 #[test]
 fn test_ihe_xds_profile_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test XDS (Cross-Enterprise Document Sharing) profile
     let document_entry = XDSDocumentEntry {
         document_id: String::from_str(&env, "doc-001"),
@@ -277,32 +282,34 @@ fn test_ihe_xds_profile_compliance() {
         submission_set_id: String::from_str(&env, "ss-001"),
         mime_type: String::from_str(&env, "application/pdf"),
     };
-    
+
     // Validate XDS document entry
-    assert_eq!(document_entry.document_id, String::from_str(&env, "doc-001"));
+    assert_eq!(
+        document_entry.document_id,
+        String::from_str(&env, "doc-001")
+    );
     assert_eq!(document_entry.status, DocumentStatus::Approved);
     assert!(!document_entry.format_code.is_empty());
 }
 
-
 #[test]
 fn test_ihe_pix_profile_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test PIX (Patient Identifier Cross-referencing) profile
     let local_id = PatientIdentifier {
         id_value: String::from_str(&env, "MRN-12345"),
         assigning_authority: String::from_str(&env, "Hospital-A"),
         identifier_type_code: String::from_str(&env, "MR"),
     };
-    
+
     let mut cross_ids = Vec::new(&env);
     cross_ids.push_back(PatientIdentifier {
         id_value: String::from_str(&env, "PID-67890"),
         assigning_authority: String::from_str(&env, "Hospital-B"),
         identifier_type_code: String::from_str(&env, "PI"),
     });
-    
+
     let pix_cross_ref = PIXCrossReference {
         reference_id: 1,
         local_id: local_id.clone(),
@@ -311,9 +318,12 @@ fn test_ihe_pix_profile_compliance() {
         updated_at: env.ledger().timestamp(),
         is_merged: false,
     };
-    
+
     // Validate PIX cross-reference
-    assert_eq!(pix_cross_ref.local_id.id_value, String::from_str(&env, "MRN-12345"));
+    assert_eq!(
+        pix_cross_ref.local_id.id_value,
+        String::from_str(&env, "MRN-12345")
+    );
     assert!(!pix_cross_ref.cross_referenced_ids.is_empty());
     assert!(!pix_cross_ref.is_merged);
 }
@@ -321,7 +331,7 @@ fn test_ihe_pix_profile_compliance() {
 #[test]
 fn test_ihe_pdq_profile_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test PDQ (Patient Demographics Query) profile
     let demographics = PatientDemographics {
         patient_id: String::from_str(&env, "MRN-12345"),
@@ -344,17 +354,20 @@ fn test_ihe_pdq_profile_compliance() {
         last_updated: env.ledger().timestamp(),
         assigning_authority: String::from_str(&env, "Hospital-A"),
     };
-    
+
     // Validate PDQ demographics
     assert_eq!(demographics.given_name, String::from_str(&env, "John"));
     assert_eq!(demographics.family_name, String::from_str(&env, "Doe"));
-    assert_eq!(demographics.administrative_gender, String::from_str(&env, "M"));
+    assert_eq!(
+        demographics.administrative_gender,
+        String::from_str(&env, "M")
+    );
 }
 
 #[test]
 fn test_ihe_atna_profile_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test ATNA (Audit Trail and Node Authentication) profile
     let mut participants = Vec::new(&env);
     participants.push_back(ATNAParticipant {
@@ -364,7 +377,7 @@ fn test_ihe_atna_profile_compliance() {
         is_requestor: true,
         network_access_point: String::from_str(&env, "192.168.1.100"),
     });
-    
+
     let audit_event = ATNAAuditEvent {
         event_id: 1,
         event_type: ATNAEventType::PatientRecordAccess,
@@ -378,13 +391,12 @@ fn test_ihe_atna_profile_compliance() {
         hl7_message_id: String::from_str(&env, "MSG-001"),
         profile: IHEProfile::ATNA,
     };
-    
+
     // Validate ATNA audit event
     assert_eq!(audit_event.event_type, ATNAEventType::PatientRecordAccess);
     assert_eq!(audit_event.event_outcome, ATNAEventOutcome::Success);
     assert!(!audit_event.active_participants.is_empty());
 }
-
 
 // ==================== HL7 Message Format Tests ====================
 
@@ -419,7 +431,7 @@ fn test_hl7_v2_qbp_message_format() {
 #[test]
 fn test_hl7_message_type_enum() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test all HL7 message types
     let message_types = vec![
         HL7MessageType::V2ADT,
@@ -434,7 +446,7 @@ fn test_hl7_message_type_enum() {
         HL7MessageType::V3PatientResponse,
         HL7MessageType::V3DeviceQuery,
     ];
-    
+
     // Validate all message types are distinct
     assert_eq!(message_types.len(), 11);
 }
@@ -444,10 +456,10 @@ fn test_hl7_message_type_enum() {
 #[test]
 fn test_patient_record_exchange_interoperability() {
     let (env, admin, provider, patient) = create_test_env();
-    
+
     // Simulate patient record exchange between systems
     let fhir_patient = create_fhir_patient(&env);
-    
+
     // Convert to IHE PDQ demographics
     let demographics = PatientDemographics {
         patient_id: fhir_patient.identifiers.get(0).unwrap().value.clone(),
@@ -470,22 +482,21 @@ fn test_patient_record_exchange_interoperability() {
         last_updated: env.ledger().timestamp(),
         assigning_authority: String::from_str(&env, "Hospital-A"),
     };
-    
+
     // Validate interoperability
     assert_eq!(demographics.given_name, fhir_patient.given_name);
     assert_eq!(demographics.family_name, fhir_patient.family_name);
     assert_eq!(demographics.date_of_birth, fhir_patient.birth_date);
 }
 
-
 #[test]
 fn test_fhir_to_xds_document_conversion() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Create FHIR DocumentReference
     let fhir_doc_ref_id = String::from_str(&env, "doc-ref-001");
     let patient_id = String::from_str(&env, "MRN-12345");
-    
+
     // Convert to IHE XDS Document Entry
     let xds_entry = XDSDocumentEntry {
         document_id: fhir_doc_ref_id.clone(),
@@ -506,7 +517,7 @@ fn test_fhir_to_xds_document_conversion() {
         submission_set_id: String::from_str(&env, "ss-001"),
         mime_type: String::from_str(&env, "application/pdf"),
     };
-    
+
     // Validate conversion
     assert_eq!(xds_entry.document_id, fhir_doc_ref_id);
     assert_eq!(xds_entry.patient_id, patient_id);
@@ -516,30 +527,30 @@ fn test_fhir_to_xds_document_conversion() {
 #[test]
 fn test_cross_system_patient_identifier_mapping() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test PIX cross-referencing for interoperability
     let system_a_id = PatientIdentifier {
         id_value: String::from_str(&env, "MRN-12345"),
         assigning_authority: String::from_str(&env, "Hospital-A"),
         identifier_type_code: String::from_str(&env, "MR"),
     };
-    
+
     let system_b_id = PatientIdentifier {
         id_value: String::from_str(&env, "PID-67890"),
         assigning_authority: String::from_str(&env, "Hospital-B"),
         identifier_type_code: String::from_str(&env, "PI"),
     };
-    
+
     let system_c_id = PatientIdentifier {
         id_value: String::from_str(&env, "EID-ABCDE"),
         assigning_authority: String::from_str(&env, "Clinic-C"),
         identifier_type_code: String::from_str(&env, "EI"),
     };
-    
+
     let mut cross_ids = Vec::new(&env);
     cross_ids.push_back(system_b_id);
     cross_ids.push_back(system_c_id);
-    
+
     let pix_mapping = PIXCrossReference {
         reference_id: 1,
         local_id: system_a_id,
@@ -548,7 +559,7 @@ fn test_cross_system_patient_identifier_mapping() {
         updated_at: env.ledger().timestamp(),
         is_merged: false,
     };
-    
+
     // Validate cross-system mapping
     assert_eq!(pix_mapping.cross_referenced_ids.len(), 2);
     assert_eq!(
@@ -562,20 +573,20 @@ fn test_cross_system_patient_identifier_mapping() {
 #[test]
 fn test_scenario_patient_record_exchange() {
     let (env, admin, provider, patient) = create_test_env();
-    
+
     // Scenario: Complete patient record exchange workflow
-    
+
     // Step 1: Create FHIR patient
     let fhir_patient = create_fhir_patient(&env);
     assert!(!fhir_patient.identifiers.is_empty());
-    
+
     // Step 2: Register patient in PIX
     let local_id = PatientIdentifier {
         id_value: fhir_patient.identifiers.get(0).unwrap().value.clone(),
         assigning_authority: String::from_str(&env, "Hospital-A"),
         identifier_type_code: String::from_str(&env, "MR"),
     };
-    
+
     let pix_ref = PIXCrossReference {
         reference_id: 1,
         local_id,
@@ -584,9 +595,9 @@ fn test_scenario_patient_record_exchange() {
         updated_at: env.ledger().timestamp(),
         is_merged: false,
     };
-    
+
     assert_eq!(pix_ref.reference_id, 1);
-    
+
     // Step 3: Store demographics in PDQ
     let demographics = PatientDemographics {
         patient_id: fhir_patient.identifiers.get(0).unwrap().value.clone(),
@@ -609,9 +620,9 @@ fn test_scenario_patient_record_exchange() {
         last_updated: env.ledger().timestamp(),
         assigning_authority: String::from_str(&env, "Hospital-A"),
     };
-    
+
     assert_eq!(demographics.given_name, fhir_patient.given_name);
-    
+
     // Step 4: Create XDS document entry
     let xds_entry = XDSDocumentEntry {
         document_id: String::from_str(&env, "doc-001"),
@@ -632,20 +643,19 @@ fn test_scenario_patient_record_exchange() {
         submission_set_id: String::from_str(&env, "ss-001"),
         mime_type: String::from_str(&env, "application/pdf"),
     };
-    
+
     assert_eq!(xds_entry.status, DocumentStatus::Approved);
 }
-
 
 #[test]
 fn test_scenario_consent_management_flow() {
     let (env, admin, provider, patient) = create_test_env();
-    
+
     // Scenario: Complete consent management workflow
-    
+
     // Step 1: Create FHIR patient
     let fhir_patient = create_fhir_patient(&env);
-    
+
     // Step 2: Grant consent (BPPC profile)
     let consent = BPPCConsent {
         consent_id: 1,
@@ -663,10 +673,10 @@ fn test_scenario_consent_management_flow() {
         author: patient.clone(),
         document_ref: String::from_str(&env, "consent-doc-001"),
     };
-    
+
     assert_eq!(consent.consent_status, ConsentStatus::Active);
     assert_eq!(consent.access_consent_list.len(), 2);
-    
+
     // Step 3: Log ATNA audit event for consent
     let mut participants = Vec::new(&env);
     participants.push_back(ATNAParticipant {
@@ -676,7 +686,7 @@ fn test_scenario_consent_management_flow() {
         is_requestor: true,
         network_access_point: String::from_str(&env, "192.168.1.100"),
     });
-    
+
     let audit_event = ATNAAuditEvent {
         event_id: 1,
         event_type: ATNAEventType::PatientRecordAccess,
@@ -690,10 +700,10 @@ fn test_scenario_consent_management_flow() {
         hl7_message_id: String::from_str(&env, "MSG-CONSENT-001"),
         profile: IHEProfile::BPPC,
     };
-    
+
     assert_eq!(audit_event.event_outcome, ATNAEventOutcome::Success);
     assert_eq!(audit_event.profile, IHEProfile::BPPC);
-    
+
     // Step 4: Verify consent is active
     assert_eq!(consent.consent_status, ConsentStatus::Active);
     assert!(consent.expiry_time > env.ledger().timestamp());
@@ -702,9 +712,9 @@ fn test_scenario_consent_management_flow() {
 #[test]
 fn test_scenario_audit_trail_compliance() {
     let (env, admin, provider, patient) = create_test_env();
-    
+
     // Scenario: Complete audit trail compliance workflow
-    
+
     // Step 1: Patient record access
     let mut participants = Vec::new(&env);
     participants.push_back(ATNAParticipant {
@@ -714,7 +724,7 @@ fn test_scenario_audit_trail_compliance() {
         is_requestor: true,
         network_access_point: String::from_str(&env, "192.168.1.50"),
     });
-    
+
     let mut participant_objects = Vec::new(&env);
     participant_objects.push_back(ATNAParticipantObject {
         object_id_type_code: String::from_str(&env, "2"),
@@ -723,7 +733,7 @@ fn test_scenario_audit_trail_compliance() {
         object_sensitivity: String::from_str(&env, "N"),
         object_query: String::from_str(&env, ""),
     });
-    
+
     let access_event = ATNAAuditEvent {
         event_id: 1,
         event_type: ATNAEventType::PatientRecordAccess,
@@ -737,10 +747,10 @@ fn test_scenario_audit_trail_compliance() {
         hl7_message_id: String::from_str(&env, "MSG-001"),
         profile: IHEProfile::ATNA,
     };
-    
+
     assert_eq!(access_event.event_type, ATNAEventType::PatientRecordAccess);
     assert_eq!(access_event.event_outcome, ATNAEventOutcome::Success);
-    
+
     // Step 2: Patient record update
     let update_event = ATNAAuditEvent {
         event_id: 2,
@@ -755,9 +765,9 @@ fn test_scenario_audit_trail_compliance() {
         hl7_message_id: String::from_str(&env, "MSG-002"),
         profile: IHEProfile::ATNA,
     };
-    
+
     assert_eq!(update_event.event_type, ATNAEventType::PatientRecordUpdate);
-    
+
     // Step 3: Document export
     let export_event = ATNAAuditEvent {
         event_id: 3,
@@ -772,22 +782,21 @@ fn test_scenario_audit_trail_compliance() {
         hl7_message_id: String::from_str(&env, "MSG-003"),
         profile: IHEProfile::XDS,
     };
-    
+
     assert_eq!(export_event.event_type, ATNAEventType::DocumentExport);
-    
+
     // Validate audit trail completeness
     assert_eq!(access_event.event_id, 1);
     assert_eq!(update_event.event_id, 2);
     assert_eq!(export_event.event_id, 3);
 }
 
-
 #[test]
 fn test_scenario_security_profile_testing() {
     let (env, admin, provider, patient) = create_test_env();
-    
+
     // Scenario: Security profile testing with ATNA and DSG
-    
+
     // Step 1: User authentication audit
     let mut auth_participants = Vec::new(&env);
     auth_participants.push_back(ATNAParticipant {
@@ -797,7 +806,7 @@ fn test_scenario_security_profile_testing() {
         is_requestor: true,
         network_access_point: String::from_str(&env, "192.168.1.100"),
     });
-    
+
     let auth_event = ATNAAuditEvent {
         event_id: 1,
         event_type: ATNAEventType::UserAuthentication,
@@ -811,10 +820,10 @@ fn test_scenario_security_profile_testing() {
         hl7_message_id: String::from_str(&env, "AUTH-001"),
         profile: IHEProfile::ATNA,
     };
-    
+
     assert_eq!(auth_event.event_type, ATNAEventType::UserAuthentication);
     assert_eq!(auth_event.event_outcome, ATNAEventOutcome::Success);
-    
+
     // Step 2: Document digital signature (DSG profile)
     let signature = DSGSignature {
         signature_id: 1,
@@ -827,10 +836,13 @@ fn test_scenario_security_profile_testing() {
         signature_purpose: String::from_str(&env, "author"),
         is_valid: true,
     };
-    
+
     assert!(signature.is_valid);
-    assert_eq!(signature.signature_algorithm, String::from_str(&env, "RS256"));
-    
+    assert_eq!(
+        signature.signature_algorithm,
+        String::from_str(&env, "RS256")
+    );
+
     // Step 3: Security alert audit
     let mut alert_participants = Vec::new(&env);
     alert_participants.push_back(ATNAParticipant {
@@ -840,7 +852,7 @@ fn test_scenario_security_profile_testing() {
         is_requestor: false,
         network_access_point: String::from_str(&env, "192.168.1.1"),
     });
-    
+
     let alert_event = ATNAAuditEvent {
         event_id: 2,
         event_type: ATNAEventType::SecurityAlert,
@@ -854,7 +866,7 @@ fn test_scenario_security_profile_testing() {
         hl7_message_id: String::from_str(&env, "ALERT-001"),
         profile: IHEProfile::ATNA,
     };
-    
+
     assert_eq!(alert_event.event_type, ATNAEventType::SecurityAlert);
     assert_eq!(alert_event.event_outcome, ATNAEventOutcome::MinorFailure);
 }
@@ -864,24 +876,34 @@ fn test_scenario_security_profile_testing() {
 #[test]
 fn test_fhir_coding_systems() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test ICD-10 coding
-    let icd10_code = create_fhir_code(&env, CodingSystem::ICD10, "E11.9", "Type 2 diabetes mellitus");
+    let icd10_code = create_fhir_code(
+        &env,
+        CodingSystem::ICD10,
+        "E11.9",
+        "Type 2 diabetes mellitus",
+    );
     assert_eq!(icd10_code.system, CodingSystem::ICD10);
     assert_eq!(icd10_code.code, String::from_str(&env, "E11.9"));
-    
+
     // Test SNOMED CT coding
-    let snomed_code = create_fhir_code(&env, CodingSystem::SNOMEDCT, "73211009", "Diabetes mellitus");
+    let snomed_code = create_fhir_code(
+        &env,
+        CodingSystem::SNOMEDCT,
+        "73211009",
+        "Diabetes mellitus",
+    );
     assert_eq!(snomed_code.system, CodingSystem::SNOMEDCT);
-    
+
     // Test LOINC coding
     let loinc_code = create_fhir_code(&env, CodingSystem::LOINC, "8867-4", "Heart rate");
     assert_eq!(loinc_code.system, CodingSystem::LOINC);
-    
+
     // Test RxNorm coding
     let rxnorm_code = create_fhir_code(&env, CodingSystem::RxNorm, "860975", "Metformin 500mg");
     assert_eq!(rxnorm_code.system, CodingSystem::RxNorm);
-    
+
     // Test CPT coding
     let cpt_code = create_fhir_code(&env, CodingSystem::CPT, "99213", "Office visit");
     assert_eq!(cpt_code.system, CodingSystem::CPT);
@@ -890,7 +912,7 @@ fn test_fhir_coding_systems() {
 #[test]
 fn test_fhir_bundle_operations() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test FHIR bundle creation
     let bundle = FHIRBundle {
         bundle_id: String::from_str(&env, "bundle-001"),
@@ -898,18 +920,17 @@ fn test_fhir_bundle_operations() {
         bundle_type: String::from_str(&env, "transaction"),
         total: 5,
     };
-    
+
     assert_eq!(bundle.bundle_type, String::from_str(&env, "transaction"));
     assert_eq!(bundle.total, 5);
 }
-
 
 // ==================== IHE Connectathon Compliance Tests ====================
 
 #[test]
 fn test_ihe_connectathon_xds_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test Connectathon compliance for XDS profile
     let test_result = ConnectathonTestResult {
         test_id: 1,
@@ -921,7 +942,7 @@ fn test_ihe_connectathon_xds_compliance() {
         tested_by: Address::generate(&env),
         notes: String::from_str(&env, "All tests passed"),
     };
-    
+
     assert!(test_result.passed);
     assert_eq!(test_result.profile, IHEProfile::XDS);
 }
@@ -929,7 +950,7 @@ fn test_ihe_connectathon_xds_compliance() {
 #[test]
 fn test_ihe_connectathon_pix_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test Connectathon compliance for PIX profile
     let test_result = ConnectathonTestResult {
         test_id: 2,
@@ -941,7 +962,7 @@ fn test_ihe_connectathon_pix_compliance() {
         tested_by: Address::generate(&env),
         notes: String::from_str(&env, "Identity cross-referencing validated"),
     };
-    
+
     assert!(test_result.passed);
     assert_eq!(test_result.profile, IHEProfile::PIX);
 }
@@ -949,7 +970,7 @@ fn test_ihe_connectathon_pix_compliance() {
 #[test]
 fn test_ihe_connectathon_pdq_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test Connectathon compliance for PDQ profile
     let test_result = ConnectathonTestResult {
         test_id: 3,
@@ -961,7 +982,7 @@ fn test_ihe_connectathon_pdq_compliance() {
         tested_by: Address::generate(&env),
         notes: String::from_str(&env, "Demographics query successful"),
     };
-    
+
     assert!(test_result.passed);
     assert_eq!(test_result.profile, IHEProfile::PDQ);
 }
@@ -969,7 +990,7 @@ fn test_ihe_connectathon_pdq_compliance() {
 #[test]
 fn test_ihe_connectathon_atna_compliance() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test Connectathon compliance for ATNA profile
     let test_result = ConnectathonTestResult {
         test_id: 4,
@@ -981,7 +1002,7 @@ fn test_ihe_connectathon_atna_compliance() {
         tested_by: Address::generate(&env),
         notes: String::from_str(&env, "Audit logging compliant"),
     };
-    
+
     assert!(test_result.passed);
     assert_eq!(test_result.profile, IHEProfile::ATNA);
 }
@@ -991,7 +1012,7 @@ fn test_ihe_connectathon_atna_compliance() {
 #[test]
 fn test_ihe_hpd_provider_registration() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test HPD (Healthcare Provider Directory) profile
     let hpd_provider = HPDProvider {
         provider_id: 1,
@@ -1008,7 +1029,7 @@ fn test_ihe_hpd_provider_registration() {
         registration_time: env.ledger().timestamp(),
         is_active: true,
     };
-    
+
     assert_eq!(hpd_provider.provider_type, ProviderType::Individual);
     assert!(hpd_provider.is_active);
     assert_eq!(hpd_provider.npi, String::from_str(&env, "1234567890"));
@@ -1019,7 +1040,7 @@ fn test_ihe_hpd_provider_registration() {
 #[test]
 fn test_ihe_svs_value_set_sharing() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test SVS (Sharing Value Sets) profile
     let mut concepts = Vec::new(&env);
     concepts.push_back(SVSConcept {
@@ -1030,7 +1051,7 @@ fn test_ihe_svs_value_set_sharing() {
         level: 0,
         type_code: String::from_str(&env, "L"),
     });
-    
+
     let value_set = SVSValueSet {
         value_set_id: 1,
         oid: String::from_str(&env, "2.16.840.1.113883.3.464.1003.103.12.1001"),
@@ -1043,24 +1064,23 @@ fn test_ihe_svs_value_set_sharing() {
         source_url: String::from_str(&env, "https://vsac.nlm.nih.gov/"),
         registered_by: Address::generate(&env),
     };
-    
+
     assert_eq!(value_set.status, String::from_str(&env, "active"));
     assert!(!value_set.concepts.is_empty());
 }
-
 
 // ==================== Cross-Community Access Tests ====================
 
 #[test]
 fn test_ihe_xca_gateway_registration() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test XCA (Cross-Community Access) profile
     let mut supported_profiles = Vec::new(&env);
     supported_profiles.push_back(IHEProfile::XDS);
     supported_profiles.push_back(IHEProfile::PIX);
     supported_profiles.push_back(IHEProfile::PDQ);
-    
+
     let xca_gateway = XCAGateway {
         gateway_id: String::from_str(&env, "gateway-001"),
         community_id: String::from_str(&env, "community-a"),
@@ -1070,10 +1090,13 @@ fn test_ihe_xca_gateway_registration() {
         registration_time: env.ledger().timestamp(),
         is_active: true,
     };
-    
+
     assert!(xca_gateway.is_active);
     assert_eq!(xca_gateway.supported_profiles.len(), 3);
-    assert_eq!(xca_gateway.community_id, String::from_str(&env, "community-a"));
+    assert_eq!(
+        xca_gateway.community_id,
+        String::from_str(&env, "community-a")
+    );
 }
 
 // ==================== Master Patient Index Tests ====================
@@ -1081,7 +1104,7 @@ fn test_ihe_xca_gateway_registration() {
 #[test]
 fn test_ihe_mpi_master_patient_record() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test MPI (Master Patient Index) profile
     let mut linked_identifiers = Vec::new(&env);
     linked_identifiers.push_back(PatientIdentifier {
@@ -1094,7 +1117,7 @@ fn test_ihe_mpi_master_patient_record() {
         assigning_authority: String::from_str(&env, "Hospital-B"),
         identifier_type_code: String::from_str(&env, "PI"),
     });
-    
+
     let demographics = PatientDemographics {
         patient_id: String::from_str(&env, "MASTER-001"),
         given_name: String::from_str(&env, "John"),
@@ -1116,7 +1139,7 @@ fn test_ihe_mpi_master_patient_record() {
         last_updated: env.ledger().timestamp(),
         assigning_authority: String::from_str(&env, "MPI-SYSTEM"),
     };
-    
+
     let mpi_master = MPIMasterPatient {
         master_id: 1,
         global_patient_id: String::from_str(&env, "GLOBAL-001"),
@@ -1126,10 +1149,13 @@ fn test_ihe_mpi_master_patient_record() {
         updated_at: env.ledger().timestamp(),
         confidence_score: 95,
     };
-    
+
     assert_eq!(mpi_master.linked_identifiers.len(), 2);
     assert_eq!(mpi_master.confidence_score, 95);
-    assert_eq!(mpi_master.global_patient_id, String::from_str(&env, "GLOBAL-001"));
+    assert_eq!(
+        mpi_master.global_patient_id,
+        String::from_str(&env, "GLOBAL-001")
+    );
 }
 
 // ==================== Document Submission Set Tests ====================
@@ -1137,13 +1163,13 @@ fn test_ihe_mpi_master_patient_record() {
 #[test]
 fn test_xds_submission_set() {
     let (env, _admin, _provider, _patient) = create_test_env();
-    
+
     // Test XDS submission set
     let mut document_ids = Vec::new(&env);
     document_ids.push_back(String::from_str(&env, "doc-001"));
     document_ids.push_back(String::from_str(&env, "doc-002"));
     document_ids.push_back(String::from_str(&env, "doc-003"));
-    
+
     let submission_set = XDSSubmissionSet {
         submission_set_id: String::from_str(&env, "ss-001"),
         patient_id: String::from_str(&env, "MRN-12345"),
@@ -1154,9 +1180,12 @@ fn test_xds_submission_set() {
         document_ids,
         intended_recipient: String::from_str(&env, "Hospital-B"),
     };
-    
+
     assert_eq!(submission_set.document_ids.len(), 3);
-    assert_eq!(submission_set.patient_id, String::from_str(&env, "MRN-12345"));
+    assert_eq!(
+        submission_set.patient_id,
+        String::from_str(&env, "MRN-12345")
+    );
 }
 
 // ==================== Comprehensive Integration Test ====================
@@ -1164,27 +1193,27 @@ fn test_xds_submission_set() {
 #[test]
 fn test_comprehensive_ihe_fhir_integration() {
     let (env, admin, provider, patient) = create_test_env();
-    
+
     // Comprehensive integration test covering multiple profiles
-    
+
     // 1. Create FHIR patient
     let fhir_patient = create_fhir_patient(&env);
     assert!(!fhir_patient.identifiers.is_empty());
-    
+
     // 2. Register in PIX
     let local_id = PatientIdentifier {
         id_value: fhir_patient.identifiers.get(0).unwrap().value.clone(),
         assigning_authority: String::from_str(&env, "Hospital-A"),
         identifier_type_code: String::from_str(&env, "MR"),
     };
-    
+
     let mut cross_ids = Vec::new(&env);
     cross_ids.push_back(PatientIdentifier {
         id_value: String::from_str(&env, "PID-67890"),
         assigning_authority: String::from_str(&env, "Hospital-B"),
         identifier_type_code: String::from_str(&env, "PI"),
     });
-    
+
     let pix_ref = PIXCrossReference {
         reference_id: 1,
         local_id,
@@ -1193,9 +1222,9 @@ fn test_comprehensive_ihe_fhir_integration() {
         updated_at: env.ledger().timestamp(),
         is_merged: false,
     };
-    
+
     assert_eq!(pix_ref.reference_id, 1);
-    
+
     // 3. Store demographics in PDQ
     let demographics = PatientDemographics {
         patient_id: fhir_patient.identifiers.get(0).unwrap().value.clone(),
@@ -1218,7 +1247,7 @@ fn test_comprehensive_ihe_fhir_integration() {
         last_updated: env.ledger().timestamp(),
         assigning_authority: String::from_str(&env, "Hospital-A"),
     };
-    
+
     // 4. Create clinical observations
     let observation = FHIRObservation {
         identifier: String::from_str(&env, "obs-001"),
@@ -1232,7 +1261,7 @@ fn test_comprehensive_ihe_fhir_integration() {
         interpretation: Vec::new(&env),
         reference_range: String::from_str(&env, "60-100 beats/minute"),
     };
-    
+
     // 5. Create XDS document entry
     let xds_entry = XDSDocumentEntry {
         document_id: String::from_str(&env, "doc-001"),
@@ -1253,7 +1282,7 @@ fn test_comprehensive_ihe_fhir_integration() {
         submission_set_id: String::from_str(&env, "ss-001"),
         mime_type: String::from_str(&env, "application/pdf"),
     };
-    
+
     // 6. Grant consent (BPPC)
     let consent = BPPCConsent {
         consent_id: 1,
@@ -1270,7 +1299,7 @@ fn test_comprehensive_ihe_fhir_integration() {
         author: patient.clone(),
         document_ref: String::from_str(&env, "consent-doc-001"),
     };
-    
+
     // 7. Log ATNA audit events
     let mut participants = Vec::new(&env);
     participants.push_back(ATNAParticipant {
@@ -1280,7 +1309,7 @@ fn test_comprehensive_ihe_fhir_integration() {
         is_requestor: true,
         network_access_point: String::from_str(&env, "192.168.1.100"),
     });
-    
+
     let audit_event = ATNAAuditEvent {
         event_id: 1,
         event_type: ATNAEventType::PatientRecordAccess,
@@ -1294,7 +1323,7 @@ fn test_comprehensive_ihe_fhir_integration() {
         hl7_message_id: String::from_str(&env, "MSG-001"),
         profile: IHEProfile::ATNA,
     };
-    
+
     // Validate complete workflow
     assert_eq!(fhir_patient.given_name, demographics.given_name);
     assert_eq!(observation.status, String::from_str(&env, "final"));

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -29,9 +29,7 @@ pub mod ihe_fhir_integration_tests;
 pub mod medical_records_tests {
     use super::*;
     use medical_records::{MedicalRecordsContract, MedicalRecordsContractClient, Role};
-    use soroban_sdk::{
-        testutils::{Address as _, MockAuth, MockAuthInvoke},
-    };
+    use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
 
     #[test]
     fn test_full_medical_record_workflow() {
@@ -48,8 +46,12 @@ pub mod medical_records_tests {
 
         // Initialize contract and roles
         client.mock_all_auths().initialize(&admin);
-        client.mock_all_auths().manage_user(&admin, &doctor, &Role::Doctor);
-        client.mock_all_auths().manage_user(&admin, &patient, &Role::Patient);
+        client
+            .mock_all_auths()
+            .manage_user(&admin, &doctor, &Role::Doctor);
+        client
+            .mock_all_auths()
+            .manage_user(&admin, &patient, &Role::Patient);
 
         // Add a medical record
         let record_id = client
@@ -83,7 +85,10 @@ pub mod medical_records_tests {
         assert_eq!(record.patient_id, patient);
         assert_eq!(record.diagnosis, diagnosis);
         assert_eq!(record.category, String::from_str(&env, "Traditional"));
-        assert_eq!(record.treatment_type, String::from_str(&env, "Herbal Therapy"));
+        assert_eq!(
+            record.treatment_type,
+            String::from_str(&env, "Herbal Therapy")
+        );
         assert_eq!(record.tags.len(), 2);
     }
 
@@ -98,13 +103,25 @@ pub mod medical_records_tests {
         let patient = Address::generate(&env);
 
         client.mock_all_auths().initialize(&admin);
-        client.mock_all_auths().manage_user(&admin, &doctor, &Role::Doctor);
-        client.mock_all_auths().manage_user(&admin, &patient, &Role::Patient);
+        client
+            .mock_all_auths()
+            .manage_user(&admin, &doctor, &Role::Doctor);
+        client
+            .mock_all_auths()
+            .manage_user(&admin, &patient, &Role::Patient);
 
         assert!(client.mock_all_auths().pause(&admin));
 
         let res = client
-            .mock_auths(&[MockAuth { address: &doctor, invoke: &MockAuthInvoke { contract: &contract_id, fn_name: "add_record", args: (), sub_invokes: &[] } }])
+            .mock_auths(&[MockAuth {
+                address: &doctor,
+                invoke: &MockAuthInvoke {
+                    contract: &contract_id,
+                    fn_name: "add_record",
+                    args: (),
+                    sub_invokes: &[],
+                },
+            }])
             .try_add_record(
                 &doctor,
                 &patient,
@@ -131,21 +148,31 @@ pub mod medical_records_tests {
         let recipient = Address::generate(&env);
 
         client.mock_all_auths().initialize(&admin1);
-        client.mock_all_auths().manage_user(&admin1, &admin2, &Role::Admin);
+        client
+            .mock_all_auths()
+            .manage_user(&admin1, &admin2, &Role::Admin);
 
-        let proposal_id = client.mock_all_auths().propose_recovery(&admin1, &token, &recipient, &100i128);
+        let proposal_id = client
+            .mock_all_auths()
+            .propose_recovery(&admin1, &token, &recipient, &100i128);
         assert!(proposal_id > 0);
 
-        assert!(client.mock_all_auths().approve_recovery(&admin2, &proposal_id));
+        assert!(client
+            .mock_all_auths()
+            .approve_recovery(&admin2, &proposal_id));
 
         // Fail before timelock
-        let res = client.mock_all_auths().try_execute_recovery(&admin1, &proposal_id);
+        let res = client
+            .mock_all_auths()
+            .try_execute_recovery(&admin1, &proposal_id);
         assert!(res.is_err());
 
         let now = env.ledger().timestamp();
         env.ledger().with_mut(|l| l.timestamp = now + 86_401);
 
-        assert!(client.mock_all_auths().execute_recovery(&admin1, &proposal_id));
+        assert!(client
+            .mock_all_auths()
+            .execute_recovery(&admin1, &proposal_id));
     }
 }
 

--- a/tests/integration/multi_region_dr_integration.rs
+++ b/tests/integration/multi_region_dr_integration.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod multi_region_dr_tests {
     use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::{Env, Address, Symbol, symbol_short};
+    use soroban_sdk::{symbol_short, Address, Env, Symbol};
 
     // Mock RTO and uptime constants
     const RTO_TARGET_MS: u64 = 15 * 60 * 1000; // 15 minutes
@@ -16,19 +16,19 @@ mod multi_region_dr_tests {
 
         // This test verifies that all 4 DR contracts can be deployed
         // In a real scenario, these would be deployed to the blockchain
-        
+
         println!("✓ Multi-Region Orchestrator contract ready");
         println!("✓ Regional Node Manager contract ready");
         println!("✓ Failover Detector contract ready");
         println!("✓ Sync Manager contract ready");
-        
+
         assert!(true, "All contracts deployed successfully");
     }
 
     #[test]
     fn test_region_registration_5_regions() {
         // Test requirement: Support for 5+ geographic regions
-        
+
         let regions = vec![
             ("us-east-1", 1, true),
             ("us-west-1", 2, false),
@@ -39,7 +39,10 @@ mod multi_region_dr_tests {
 
         println!("\n=== Testing 5+ Region Registration ===");
         for (name, id, is_primary) in &regions {
-            println!("✓ Registered region: {} (ID: {}, Primary: {})", name, id, is_primary);
+            println!(
+                "✓ Registered region: {} (ID: {}, Primary: {})",
+                name, id, is_primary
+            );
         }
 
         assert_eq!(regions.len(), 5, "All 5 regions registered successfully");
@@ -49,14 +52,23 @@ mod multi_region_dr_tests {
     #[test]
     fn test_automatic_failover_detection() {
         // Test requirement: Support for automatic failover detection
-        
+
         println!("\n=== Testing Automatic Failover Detection ===");
-        
+
         let failure_scenarios = vec![
-            ("Node heartbeat timeout", "Failed to receive heartbeat within 30 seconds"),
-            ("High latency detected", "Replication lag exceeded 5000ms threshold"),
+            (
+                "Node heartbeat timeout",
+                "Failed to receive heartbeat within 30 seconds",
+            ),
+            (
+                "High latency detected",
+                "Replication lag exceeded 5000ms threshold",
+            ),
             ("Resource exhaustion", "CPU usage exceeded 85% threshold"),
-            ("Data inconsistency", "Checksum mismatch detected across replicas"),
+            (
+                "Data inconsistency",
+                "Checksum mismatch detected across replicas",
+            ),
             ("Manual trigger", "Failover triggered manually by operator"),
         ];
 
@@ -72,25 +84,28 @@ mod multi_region_dr_tests {
     #[test]
     fn test_rto_less_than_15_minutes() {
         // Test requirement: Recovery time objective (RTO) < 15 minutes
-        
+
         println!("\n=== Testing RTO < 15 Minutes ===");
-        
+
         let rto_scenarios = vec![
-            ("us-east-1 to us-west-1", 280000),   // 4.67 minutes
-            ("us-east-1 to eu-central-1", 450000), // 7.5 minutes
-            ("us-west-1 to ap-south-1", 520000),  // 8.67 minutes
+            ("us-east-1 to us-west-1", 280000),     // 4.67 minutes
+            ("us-east-1 to eu-central-1", 450000),  // 7.5 minutes
+            ("us-west-1 to ap-south-1", 520000),    // 8.67 minutes
             ("eu-central-1 to ap-north-1", 600000), // 10 minutes
-            ("ap-south-1 to us-east-1", 780000),  // 13 minutes
+            ("ap-south-1 to us-east-1", 780000),    // 13 minutes
         ];
 
         println!("RTO Target: {} minutes", RTO_TARGET_MS / 60000);
-        
+
         for (failover_path, rto_ms) in rto_scenarios {
             let rto_minutes = rto_ms / 60000;
             let meets_target = rto_ms <= RTO_TARGET_MS;
             let status = if meets_target { "✓ PASS" } else { "✗ FAIL" };
-            
-            println!("  {} Failover: {} -> RTO: {} minutes", status, failover_path, rto_minutes);
+
+            println!(
+                "  {} Failover: {} -> RTO: {} minutes",
+                status, failover_path, rto_minutes
+            );
             assert!(meets_target, "{} exceeds RTO target", failover_path);
         }
 
@@ -100,9 +115,9 @@ mod multi_region_dr_tests {
     #[test]
     fn test_99_99_percent_uptime_sla() {
         // Test requirement: Achieve 99.99% uptime SLA
-        
+
         println!("\n=== Testing 99.99% Uptime SLA ===");
-        
+
         // Simulated uptime metrics over 30 days
         let uptime_samples = vec![
             ("Day 1-7", 9999),   // 99.99%
@@ -113,7 +128,7 @@ mod multi_region_dr_tests {
         ];
 
         println!("SLA Target: {:.2}%", UPTIME_TARGET as f64 / 100.0);
-        
+
         let mut total_uptime: u64 = 0;
         for (period, uptime_bp) in uptime_samples {
             let uptime_pct = uptime_bp as f64 / 100.0;
@@ -123,22 +138,34 @@ mod multi_region_dr_tests {
 
         let avg_uptime_bp = total_uptime / 5;
         let avg_uptime_pct = avg_uptime_bp as f64 / 100.0;
-        
+
         println!("\n  Average Uptime: {:.2}%", avg_uptime_pct);
-        assert!(avg_uptime_bp >= UPTIME_TARGET as u64 - 10, "Uptime SLA maintained");
+        assert!(
+            avg_uptime_bp >= UPTIME_TARGET as u64 - 10,
+            "Uptime SLA maintained"
+        );
         println!("✓ 99.99% Uptime SLA maintained\n");
     }
 
     #[test]
     fn test_data_synchronization_across_regions() {
         // Test requirement: Create data synchronization across regions
-        
+
         println!("\n=== Testing Data Synchronization Across Regions ===");
-        
+
         let sync_operations = vec![
-            ("us-east-1 → all regions", vec!["us-west-1", "eu-central-1", "eu-west-1", "ap-south-1"]),
-            ("eu-central-1 → all regions", vec!["us-east-1", "us-west-1", "eu-west-1", "ap-south-1"]),
-            ("ap-south-1 → cluster", vec!["ap-north-1", "eu-central-1", "us-west-1"]),
+            (
+                "us-east-1 → all regions",
+                vec!["us-west-1", "eu-central-1", "eu-west-1", "ap-south-1"],
+            ),
+            (
+                "eu-central-1 → all regions",
+                vec!["us-east-1", "us-west-1", "eu-west-1", "ap-south-1"],
+            ),
+            (
+                "ap-south-1 → cluster",
+                vec!["ap-north-1", "eu-central-1", "us-west-1"],
+            ),
         ];
 
         for (source, targets) in sync_operations {
@@ -155,32 +182,32 @@ mod multi_region_dr_tests {
     #[test]
     fn test_multi_region_failover_workflow() {
         // Complete failover workflow test
-        
+
         println!("\n=== Testing Multi-Region Failover Workflow ===");
-        
+
         println!("Step 1: Detecting failure in primary region (us-east-1)");
         println!("  └─ Consecutive failures detected: 3/3 threshold reached ✓");
-        
+
         println!("\nStep 2: Evaluating failover candidates");
         println!("  ├─ us-west-1: Healthy ✓");
         println!("  ├─ eu-central-1: Healthy ✓");
         println!("  └─ ap-south-1: Degraded ⚠");
-        
+
         println!("\nStep 3: Executing failover to us-west-1");
         println!("  ├─ Data sync: Writing to backup region...");
         println!("  ├─ Promoting to primary: us-west-1...");
         println!("  └─ Execution time: 8743ms ✓");
-        
+
         println!("\nStep 4: Verifying failover success");
         println!("  ├─ RTO: 8.743 seconds (< 15 minutes target) ✓");
         println!("  ├─ Data consistency: Verified ✓");
         println!("  └─ Traffic routed to new primary ✓");
-        
+
         println!("\nStep 5: Initiating recovery of failed region");
         println!("  ├─ Starting diagnostics on us-east-1...");
         println!("  ├─ Syncing data from backup...");
         println!("  └─ Restoring to standby state ✓");
-        
+
         println!("✓ Complete failover workflow executed successfully\n");
         assert!(true);
     }
@@ -188,21 +215,21 @@ mod multi_region_dr_tests {
     #[test]
     fn test_conflict_detection_and_resolution() {
         // Test data conflict detection during concurrent writes
-        
+
         println!("\n=== Testing Conflict Detection and Resolution ===");
-        
+
         println!("Scenario: Concurrent writes to eu-central-1 and eu-west-1");
         println!("  ├─ Write 1: us-east-1 → data_v1");
         println!("  ├─ Write 2: us-west-1 → data_v1 (conflicting)");
         println!("  └─ Conflict detected at: 2026-03-28T10:30:45Z ✓");
-        
+
         println!("\nResolution Strategy: Last-Write-Wins");
         println!("  ├─ Comparing timestamps:");
         println!("  │  ├─ us-east-1 write: 10:30:40Z");
         println!("  │  └─ us-west-1 write: 10:30:35Z (older - rejected)");
         println!("  ├─ Applying resolution...");
         println!("  └─ Consistency restored ✓");
-        
+
         println!("✓ Conflict detection and resolution working\n");
         assert!(true);
     }
@@ -210,21 +237,21 @@ mod multi_region_dr_tests {
     #[test]
     fn test_health_monitoring_and_alerting() {
         // Test health monitoring and alert generation
-        
+
         println!("\n=== Testing Health Monitoring and Alerting ===");
-        
+
         println!("Regional Health Status:");
         println!("  ├─ us-east-1: HEALTHY (CPU: 45%, Mem: 62%, Disk: 58%)");
         println!("  ├─ us-west-1: HEALTHY (CPU: 38%, Mem: 58%, Disk: 51%)");
-        println!("  ├─ eu-central-1: DEGRADED ⚠ (CPU: 89% - high)", );
+        println!("  ├─ eu-central-1: DEGRADED ⚠ (CPU: 89% - high)",);
         println!("  ├─ eu-west-1: HEALTHY (CPU: 52%, Mem: 71%, Disk: 64%)");
         println!("  └─ ap-south-1: HEALTHY (CPU: 41%, Mem: 55%, Disk: 48%)");
-        
+
         println!("\nGenerated Alerts:");
         println!("  ├─ [MEDIUM] High CPU in eu-central-1 (89%)");
         println!("  ├─ [MEDIUM] Replication lag in us-west-1 (4200ms)");
         println!("  └─ [LOW] Memory usage approaching threshold (71%)");
-        
+
         println!("✓ Health monitoring and alerting active\n");
         assert!(true);
     }
@@ -232,23 +259,23 @@ mod multi_region_dr_tests {
     #[test]
     fn test_backup_and_recovery_drills() {
         // Test recovery drills without actual data restoration
-        
+
         println!("\n=== Testing Backup and Recovery Drills ===");
-        
+
         println!("Recovery Drill #1: Full Region Recovery");
         println!("  ├─ Target: Restore us-east-1 from backup");
         println!("  ├─ Backup timestamp: 2026-03-28T10:00:00Z");
         println!("  ├─ Data integrity check: PASSED ✓");
         println!("  ├─ Recovery simulation: 3245ms");
         println!("  └─ Result: SUCCESSFUL ✓");
-        
+
         println!("\nRecovery Drill #2: Cross-Region Data Recovery");
         println!("  ├─ Source: eu-central-1 backup");
         println!("  ├─ Target: eu-west-1 (simulate restore)");
         println!("  ├─ Data validation: PASSED ✓");
         println!("  ├─ Simulation time: 5123ms");
         println!("  └─ Result: SUCCESSFUL ✓");
-        
+
         println!("✓ All recovery drills successful\n");
         assert!(true);
     }
@@ -256,15 +283,15 @@ mod multi_region_dr_tests {
     #[test]
     fn test_integration_with_medical_record_backup() {
         // Test integration with existing medical_record_backup contract
-        
+
         println!("\n=== Testing Integration with Medical Record Backup ===");
-        
+
         println!("Verifying medical_record_backup contract integration:");
         println!("  ├─ Multi-region orchestrator controlling backups...");
         println!("  ├─ Automatic failover triggering backup restore...");
         println!("  ├─ Sync manager coordinating medical data across regions...");
         println!("  └─ Failover detector monitoring backup health... ✓");
-        
+
         println!("\nMedical Data Backup Status:");
         println!("  ├─ Primary: us-east-1 - Active");
         println!("  ├─ Replicas:");
@@ -272,7 +299,7 @@ mod multi_region_dr_tests {
         println!("  │  ├─ eu-central-1: In sync (lag: 340ms) ✓");
         println!("  │  └─ ap-south-1: In sync (lag: 580ms) ✓");
         println!("  └─ Archive: 97 encrypted backups stored");
-        
+
         println!("✓ Integration with medical_record_backup verified\n");
         assert!(true);
     }
@@ -280,21 +307,21 @@ mod multi_region_dr_tests {
     #[test]
     fn test_security_and_rbac() {
         // Test role-based access control
-        
+
         println!("\n=== Testing Security and RBAC ===");
-        
+
         println!("Roles Defined:");
         println!("  ├─ Admin: Full system control");
         println!("  ├─ Operator: Failover, sync, region management");
         println!("  ├─ Monitor: Health checks and metric collection");
         println!("  └─ Auditor: Compliance and audit logging");
-        
+
         println!("\nAccess Control Tests:");
         println!("  ├─ Admin can initialize contracts: ✓");
         println!("  ├─ Operator cannot assign roles: ✓");
         println!("  ├─ Monitor cannot trigger failover: ✓");
         println!("  └─ Unauthorized access denied: ✓");
-        
+
         println!("✓ RBAC security verified\n");
         assert!(true);
     }
@@ -306,12 +333,12 @@ mod performance_tests {
     #[test]
     fn test_failover_performance_metrics() {
         println!("\n=== Failover Performance Metrics ===");
-        
+
         let metrics = vec![
             ("Detection time", 1245, "ms"),
             ("Planning time", 420, "ms"),
             ("Execution time", 8743, "ms"),
-            ("Total RTO", 10408, "ms"),  // ~10.4 seconds
+            ("Total RTO", 10408, "ms"),   // ~10.4 seconds
             ("SLA target", 900000, "ms"), // 15 minutes
         ];
 
@@ -319,7 +346,7 @@ mod performance_tests {
         for (metric, value, unit) in metrics {
             println!("  ├─ {}: {} {}", metric, value, unit);
         }
-        
+
         println!("\n  ✓ All failover operations under SLA target");
         assert!(10408 < 900000, "Failover RTO within SLA");
     }
@@ -327,13 +354,13 @@ mod performance_tests {
     #[test]
     fn test_sync_throughput() {
         println!("\n=== Data Sync Throughput ===");
-        
+
         println!("Throughput metrics:");
         println!("  ├─ Medical records sync: 1250 ops/sec");
         println!("  ├─ Multi-region replication: 4850 MB/sec");
         println!("  ├─ Heartbeat checks: 500 nodes/sec");
         println!("  └─ Health monitoring: 1000 metrics/sec");
-        
+
         println!("\n  ✓ Throughput acceptable for healthcare workloads");
         assert!(true);
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,2 +1,2 @@
-pub mod utils;
 pub mod integration;
+pub mod utils;

--- a/tests/utils/assertions.rs
+++ b/tests/utils/assertions.rs
@@ -170,8 +170,7 @@ pub fn assert_state_transition(from: &str, to: &str, allowed: &[(&str, &str)]) {
     assert!(
         transition_allowed,
         "Invalid state transition from '{}' to '{}'",
-        from,
-        to
+        from, to
     );
 }
 

--- a/tests/utils/contract_fixtures.rs
+++ b/tests/utils/contract_fixtures.rs
@@ -1,10 +1,9 @@
-/// Library of complex contract fixtures for integration testing
-use soroban_sdk::{Address, Env, String, Vec, vec};
 use crate::utils::{
-    IntegrationTestEnv, UserRole, MedicalRecordGenerator, 
-    MedicalEntry, RecordMetadata, UserFixture
+    IntegrationTestEnv, MedicalEntry, MedicalRecordGenerator, RecordMetadata, UserFixture, UserRole,
 };
 use medical_records::{MedicalRecordsContractClient, Role};
+/// Library of complex contract fixtures for integration testing
+use soroban_sdk::{vec, Address, Env, String, Vec};
 use sut_token::SutTokenClient;
 
 /// Fixture for a fully configured MedicalRecords contract
@@ -19,17 +18,21 @@ impl MedicalRecordsFixture {
     pub fn new(test_env: &IntegrationTestEnv) -> Self {
         let (contract_id, client) = test_env.register_medical_records();
         let admin = &test_env.team.admin.address;
-        
+
         client.initialize(admin);
-        
+
         // Configure standard roles for the team
         for doctor in &test_env.team.doctors {
-            client.manage_user(admin, &doctor.address, &Role::Doctor).expect("Failed to manage user");
+            client
+                .manage_user(admin, &doctor.address, &Role::Doctor)
+                .expect("Failed to manage user");
         }
         for patient in &test_env.team.patients {
-            client.manage_user(admin, &patient.address, &Role::Patient).expect("Failed to manage user");
+            client
+                .manage_user(admin, &patient.address, &Role::Patient)
+                .expect("Failed to manage user");
         }
-        
+
         Self {
             contract_id,
             client,
@@ -41,27 +44,29 @@ impl MedicalRecordsFixture {
     pub fn with_sample_data(self, test_env: &IntegrationTestEnv) -> Self {
         let env = &test_env.env;
         let mut gen = MedicalRecordGenerator::new();
-        
+
         let doctor = &test_env.team.doctors[0].address;
         let patient = &test_env.team.patients[0].address;
-        
+
         for i in 0..5 {
             let diagnosis = String::from_str(env, &format!("Sample Diagnosis {}", i));
             let treatment = String::from_str(env, &format!("Sample Treatment {}", i));
-            
-            self.client.add_record(
-                doctor,
-                patient,
-                &diagnosis,
-                &treatment,
-                &false,
-                &vec![env, String::from_str(env, "sample")],
-                &String::from_str(env, "General"),
-                &String::from_str(env, "Routine"),
-                &String::from_str(env, &format!("QmHash{}", i)),
-            ).expect("Failed to add record");
+
+            self.client
+                .add_record(
+                    doctor,
+                    patient,
+                    &diagnosis,
+                    &treatment,
+                    &false,
+                    &vec![env, String::from_str(env, "sample")],
+                    &String::from_str(env, "General"),
+                    &String::from_str(env, "Routine"),
+                    &String::from_str(env, &format!("QmHash{}", i)),
+                )
+                .expect("Failed to add record");
         }
-        
+
         self
     }
 }
@@ -77,7 +82,7 @@ impl SutTokenFixture {
     /// Create a new SUT Token fixture
     pub fn new(test_env: &IntegrationTestEnv) -> Self {
         let (contract_id, client) = test_env.register_token(&test_env.admin);
-        
+
         Self {
             contract_id,
             client,
@@ -88,7 +93,9 @@ impl SutTokenFixture {
     /// Distribute tokens to all team members
     pub fn distribute_tokens(self, test_env: &IntegrationTestEnv, amount: i128) -> Self {
         for user in test_env.team.all_users() {
-            self.client.mint(&self.admin, &user.address, &amount).expect("Failed to mint tokens");
+            self.client
+                .mint(&self.admin, &user.address, &amount)
+                .expect("Failed to mint tokens");
         }
         self
     }
@@ -105,7 +112,7 @@ impl SystemFixture {
     pub fn new(test_env: &IntegrationTestEnv) -> Self {
         let medical_records = MedicalRecordsFixture::new(test_env).with_sample_data(test_env);
         let token = SutTokenFixture::new(test_env).distribute_tokens(test_env, 10_000_000);
-        
+
         Self {
             medical_records,
             token,
@@ -123,7 +130,7 @@ mod tests {
         let test_env = IntegrationTestEnv::new();
         let fixture = MedicalRecordsFixture::new(&test_env);
         assert_eq!(fixture.admin, test_env.admin);
-        
+
         let doctor = &test_env.team.doctors[0].address;
         assert_eq!(fixture.client.get_user_role(doctor), Role::Doctor);
     }
@@ -132,7 +139,7 @@ mod tests {
     fn test_token_fixture() {
         let test_env = IntegrationTestEnv::new();
         let fixture = SutTokenFixture::new(&test_env).distribute_tokens(&test_env, 1000);
-        
+
         let patient = &test_env.team.patients[0].address;
         assert_eq!(fixture.client.balance_of(patient), 1000);
     }
@@ -141,8 +148,20 @@ mod tests {
     fn test_system_fixture() {
         let test_env = IntegrationTestEnv::new();
         let system = SystemFixture::new(&test_env);
-        
-        assert!(system.medical_records.client.get_patient_record_count(&test_env.team.patients[0].address) > 0);
-        assert!(system.token.client.balance_of(&test_env.team.patients[0].address) > 0);
+
+        assert!(
+            system
+                .medical_records
+                .client
+                .get_patient_record_count(&test_env.team.patients[0].address)
+                > 0
+        );
+        assert!(
+            system
+                .token
+                .client
+                .balance_of(&test_env.team.patients[0].address)
+                > 0
+        );
     }
 }

--- a/tests/utils/contract_utils.rs
+++ b/tests/utils/contract_utils.rs
@@ -19,7 +19,7 @@ impl ContractSetup {
     pub fn new() -> Self {
         let env = Env::default();
         let admin = Address::generate(&env);
-        
+
         Self {
             env,
             admin,

--- a/tests/utils/integration_framework.rs
+++ b/tests/utils/integration_framework.rs
@@ -1,10 +1,9 @@
+use crate::utils::{HealthcareTeam, UserFixture, UserFixtureFactory};
 /// Integration testing framework for Uzima Contracts
 use soroban_sdk::{
-    Address, BytesN, Env, IntoVal, String as SorobanString, Val, Vec,
     testutils::{Address as _, Events, Ledger},
-    vec,
+    vec, Address, BytesN, Env, IntoVal, String as SorobanString, Val, Vec,
 };
-use crate::utils::{UserFixture, UserFixtureFactory, HealthcareTeam};
 
 // Import contract types for registration helpers
 // Note: In a real multi-crate workspace, these might need to be imported via crate features or separate dev-dependencies
@@ -22,15 +21,11 @@ impl IntegrationTestEnv {
         let env = Env::default();
         // Enable mock auths by default for integration tests to focus on logic
         env.mock_all_auths();
-        
+
         let team = UserFixtureFactory::create_healthcare_team(&env);
         let admin = team.admin.address.clone();
 
-        Self {
-            env,
-            admin,
-            team,
-        }
+        Self { env, admin, team }
     }
 
     /// Advance the ledger time by a specific number of seconds
@@ -61,19 +56,27 @@ impl IntegrationTestEnv {
     /// Assert that a specific event was emitted
     pub fn assert_event_emitted(&self, contract_id: &Address, topics: Vec<Val>, data: Val) {
         let events = self.env.events().all();
-        let found = events.iter().any(|(id, t, d)| {
-            id == *contract_id && t == topics && d == data
-        });
-        assert!(found, "Expected event not found for contract {:?}", contract_id);
+        let found = events
+            .iter()
+            .any(|(id, t, d)| id == *contract_id && t == topics && d == data);
+        assert!(
+            found,
+            "Expected event not found for contract {:?}",
+            contract_id
+        );
     }
 
     /// Assert that an event with specific topics was emitted (ignoring data)
     pub fn assert_event_topics(&self, contract_id: &Address, topics: Vec<Val>) {
         let events = self.env.events().all();
-        let found = events.iter().any(|(id, t, _)| {
-            id == *contract_id && t == topics
-        });
-        assert!(found, "Expected event topics not found for contract {:?}", contract_id);
+        let found = events
+            .iter()
+            .any(|(id, t, _)| id == *contract_id && t == topics);
+        assert!(
+            found,
+            "Expected event topics not found for contract {:?}",
+            contract_id
+        );
     }
 
     /// Generate a new random address in the test environment
@@ -103,8 +106,15 @@ impl IntegrationTestEnv {
     }
 
     /// Register and initialize the MedicalRecords contract
-    pub fn register_medical_records(&self) -> (Address, medical_records::MedicalRecordsContractClient<'static>) {
-        let contract_id = self.env.register_contract(None, medical_records::MedicalRecordsContract);
+    pub fn register_medical_records(
+        &self,
+    ) -> (
+        Address,
+        medical_records::MedicalRecordsContractClient<'static>,
+    ) {
+        let contract_id = self
+            .env
+            .register_contract(None, medical_records::MedicalRecordsContract);
         let client = medical_records::MedicalRecordsContractClient::new(&self.env, &contract_id);
         (contract_id, client)
     }
@@ -113,25 +123,37 @@ impl IntegrationTestEnv {
     pub fn register_token(&self, admin: &Address) -> (Address, sut_token::SutTokenClient<'static>) {
         let contract_id = self.env.register_contract(None, sut_token::SutToken);
         let client = sut_token::SutTokenClient::new(&self.env, &contract_id);
-        
+
         let name = SorobanString::from_str(&self.env, "Stellar Utility Token");
         let symbol = SorobanString::from_str(&self.env, "SUT");
         let decimals = 7;
         let supply_cap = 100_000_000_000_000_i128; // 10M with 7 decimals
-        
-        client.initialize(admin, &name, &symbol, &decimals, &supply_cap).expect("Failed to initialize token");
-        
+
+        client
+            .initialize(admin, &name, &symbol, &decimals, &supply_cap)
+            .expect("Failed to initialize token");
+
         (contract_id, client)
     }
 }
 
 /// Helper to mock a contract call with a specific result
 pub trait MockService {
-    fn setup_mock_response<T: IntoVal<Env, Val>>(&self, contract_id: &Address, fn_name: &str, response: T);
+    fn setup_mock_response<T: IntoVal<Env, Val>>(
+        &self,
+        contract_id: &Address,
+        fn_name: &str,
+        response: T,
+    );
 }
 
 impl MockService for IntegrationTestEnv {
-    fn setup_mock_response<T: IntoVal<Env, Val>>(&self, _contract_id: &Address, _fn_name: &str, _response: T) {
+    fn setup_mock_response<T: IntoVal<Env, Val>>(
+        &self,
+        _contract_id: &Address,
+        _fn_name: &str,
+        _response: T,
+    ) {
         // Implementation for mocking external contract calls
         // In Soroban, this is usually done by registering a mock contract implementation.
         // This is a placeholder for more complex logic.
@@ -164,4 +186,3 @@ mod tests {
         assert!(token_id.to_string().len() > 0);
     }
 }
-

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,21 +1,20 @@
+pub mod assertions;
+pub mod contract_fixtures;
 /// Testing utilities module for contract testing
 /// This module provides helper functions and utilities for testing Soroban contracts
-
 pub mod contract_utils;
-pub mod test_fixtures;
-pub mod test_data;
-pub mod assertions;
-pub mod performance;
-pub mod contract_fixtures;
 pub mod integration_framework;
+pub mod performance;
+pub mod test_data;
+pub mod test_fixtures;
 
-pub use contract_utils::*;
-pub use test_fixtures::*;
-pub use test_data::*;
 pub use assertions::*;
-pub use performance::*;
 pub use contract_fixtures::*;
+pub use contract_utils::*;
 pub use integration_framework::*;
+pub use performance::*;
+pub use test_data::*;
+pub use test_fixtures::*;
 
 /// Common test constants
 pub mod constants {

--- a/tests/utils/performance.rs
+++ b/tests/utils/performance.rs
@@ -1,10 +1,10 @@
+use std::collections::HashMap;
 /// Performance testing utilities for contracts.
 ///
 /// For Soroban-specific benchmarks see the per-contract `benchmarks.rs` test
 /// modules, which use `env.budget().cpu_instruction_cost()` /
 /// `env.budget().memory_bytes_cost()` from `soroban_sdk::testutils::budget`.
 use std::time::Instant;
-use std::collections::HashMap;
 
 // ── Soroban budget result ────────────────────────────────────────────────────
 
@@ -44,7 +44,9 @@ pub struct SorobanBenchmarkSuite {
 
 impl SorobanBenchmarkSuite {
     pub fn new() -> Self {
-        Self { results: Vec::new() }
+        Self {
+            results: Vec::new(),
+        }
     }
 
     pub fn add(&mut self, result: SorobanBenchmarkResult) {

--- a/tests/utils/test_data.rs
+++ b/tests/utils/test_data.rs
@@ -46,13 +46,23 @@ impl MedicalRecordGenerator {
     pub fn generate_medical_entries(env: &Env, count: usize) -> Vec<MedicalEntry> {
         let mut entries = Vec::new();
         let diagnoses = vec!["Diabetes", "Hypertension", "Asthma", "Migraine", "GERD"];
-        let medications = vec!["Metformin", "Lisinopril", "Albuterol", "Sumatriptan", "Omeprazole"];
+        let medications = vec![
+            "Metformin",
+            "Lisinopril",
+            "Albuterol",
+            "Sumatriptan",
+            "Omeprazole",
+        ];
 
         for i in 0..count {
             entries.push(MedicalEntry {
                 entry_type: SorobanString::from_str(
                     env,
-                    if i % 2 == 0 { "diagnosis" } else { "medication" },
+                    if i % 2 == 0 {
+                        "diagnosis"
+                    } else {
+                        "medication"
+                    },
                 ),
                 description: SorobanString::from_str(
                     env,
@@ -154,7 +164,12 @@ impl TransactionDataGenerator {
     }
 
     /// Generate transaction record
-    pub fn generate_transaction(env: &Env, from: &Address, to: &Address, amount: u128) -> Transaction {
+    pub fn generate_transaction(
+        env: &Env,
+        from: &Address,
+        to: &Address,
+        amount: u128,
+    ) -> Transaction {
         Transaction {
             tx_id: Self::generate_tx_id(env),
             from: from.clone(),
@@ -236,11 +251,11 @@ impl PropertyTestDataGenerator {
     /// Generate edge case amounts
     pub fn generate_edge_case_amounts() -> Vec<u128> {
         vec![
-            0,                                   // Zero
-            1,                                   // Minimum
-            u128::MAX,                           // Maximum
-            u128::MAX / 2,                       // Half max
-            1_000_000_000_000_000_000,          // Large amount
+            0,                         // Zero
+            1,                         // Minimum
+            u128::MAX,                 // Maximum
+            u128::MAX / 2,             // Half max
+            1_000_000_000_000_000_000, // Large amount
         ]
     }
 
@@ -252,23 +267,17 @@ impl PropertyTestDataGenerator {
             .as_secs();
 
         vec![
-            0,              // Unix epoch
-            now,            // Current time
-            now + 86400,    // Tomorrow
-            now - 86400,    // Yesterday
-            u64::MAX / 2,   // Far future
+            0,            // Unix epoch
+            now,          // Current time
+            now + 86400,  // Tomorrow
+            now - 86400,  // Yesterday
+            u64::MAX / 2, // Far future
         ]
     }
 
     /// Generate boundary test values
     pub fn generate_boundary_values(min: u32, max: u32) -> Vec<u32> {
-        vec![
-            min,
-            max,
-            min + 1,
-            max - 1,
-            (min + max) / 2,
-        ]
+        vec![min, max, min + 1, max - 1, (min + max) / 2]
     }
 }
 

--- a/tests/utils/test_fixtures.rs
+++ b/tests/utils/test_fixtures.rs
@@ -50,13 +50,27 @@ impl UserFixtureFactory {
     /// Create admin fixture
     pub fn create_admin(env: &Env) -> UserFixture {
         let address = Address::generate(env);
-        UserFixture::new(env, address, UserRole::Admin, "Admin User", "admin@hospital.com").verified()
+        UserFixture::new(
+            env,
+            address,
+            UserRole::Admin,
+            "Admin User",
+            "admin@hospital.com",
+        )
+        .verified()
     }
 
     /// Create doctor fixture
     pub fn create_doctor(env: &Env) -> UserFixture {
         let address = Address::generate(env);
-        UserFixture::new(env, address, UserRole::Doctor, "Dr. Smith", "smith@hospital.com").verified()
+        UserFixture::new(
+            env,
+            address,
+            UserRole::Doctor,
+            "Dr. Smith",
+            "smith@hospital.com",
+        )
+        .verified()
     }
 
     /// Create multiple doctors
@@ -79,8 +93,14 @@ impl UserFixtureFactory {
     /// Create patient fixture
     pub fn create_patient(env: &Env) -> UserFixture {
         let address = Address::generate(env);
-        UserFixture::new(env, address, UserRole::Patient, "John Patient", "patient@example.com")
-            .verified()
+        UserFixture::new(
+            env,
+            address,
+            UserRole::Patient,
+            "John Patient",
+            "patient@example.com",
+        )
+        .verified()
     }
 
     /// Create multiple patients
@@ -103,8 +123,14 @@ impl UserFixtureFactory {
     /// Create nurse fixture
     pub fn create_nurse(env: &Env) -> UserFixture {
         let address = Address::generate(env);
-        UserFixture::new(env, address, UserRole::Nurse, "Nurse Jane", "nurse@hospital.com")
-            .verified()
+        UserFixture::new(
+            env,
+            address,
+            UserRole::Nurse,
+            "Nurse Jane",
+            "nurse@hospital.com",
+        )
+        .verified()
     }
 
     /// Create pharmacist fixture
@@ -252,7 +278,13 @@ mod tests {
     fn test_user_fixture_creation() {
         let env = soroban_sdk::Env::default();
         let addr = Address::generate(&env);
-        let user = UserFixture::new(&env, addr.clone(), UserRole::Doctor, "Test", "test@test.com");
+        let user = UserFixture::new(
+            &env,
+            addr.clone(),
+            UserRole::Doctor,
+            "Test",
+            "test@test.com",
+        );
         assert_eq!(user.role, UserRole::Doctor);
         assert!(!user.verified);
     }
@@ -261,7 +293,8 @@ mod tests {
     fn test_user_fixture_verified() {
         let env = soroban_sdk::Env::default();
         let addr = Address::generate(&env);
-        let user = UserFixture::new(&env, addr, UserRole::Patient, "Test", "test@test.com").verified();
+        let user =
+            UserFixture::new(&env, addr, UserRole::Patient, "Test", "test@test.com").verified();
         assert!(user.verified);
     }
 


### PR DESCRIPTION
# Closes #417 

## Fix: Integer Overflow in Token Calculations ([#417](#))

### Goal

Replace all unguarded arithmetic (`+`, `+=`, `*`) on `u128`/`i128` values in the `token_sale` and `federated_learning` contracts with overflow-safe operations, so overflow conditions return typed errors instead of causing unrecoverable panics or silent wrapping.

---

### 🆕 Files Created

| File | Purpose |
|------|---------|
| `contracts/token_sale/src/errors.rs` | New `Error` enum with 10 typed variants including `Overflow = 3` |

---

### ✏️ Files Modified

| File | Changes |
|------|---------|
| `contracts/token_sale/src/lib.rs` | Wired in `mod errors` and re-exported `Error` |
| `contracts/token_sale/src/contract.rs` | Removed 4 `#![allow(clippy::arithmetic_side_effects)]` suppression attrs; `contribute()` returns `Result<(), Error>`; 7 raw arithmetic sites replaced with `checked_add`/`ok_or(Error::Overflow)?`; `assert!`-based guards replaced with typed error returns |
| `contracts/token_sale/src/vesting.rs` | Same suppression removal; `get_vested_amount`, `get_releasable_amount`, `release_tokens`, and `update_vesting_schedule` all return `Result<T, Error>`; the exploitable `total_amount * time_since_cliff` multiplication is now `checked_mul` |
| `contracts/token_sale/src/test.rs` | Added `test_contribute_overflow_is_rejected` and `test_vesting_overflow_is_rejected` boundary tests |
| `contracts/federated_learning/src/lib.rs` | Added `Overflow = 24` to the `Error` enum; `reward_balance +=` replaced with `checked_add(...).ok_or(Error::Overflow)?`; two `reputation_score + n` replaced with `saturating_add` |

---

### ✅ What Was Achieved

- Overflow in token sale contribution, vesting calculation, and federated learning reward accumulation now returns a typed `Error::Overflow` instead of panicking or wrapping
- All Clippy arithmetic suppression attrs removed — the linter now enforces this going forward
- 7 existing tests continue to pass; 2 new boundary tests confirm overflow is correctly rejected at `u128::MAX` boundaries