### PR TITLE
test: gate integration-only modules

### DIFF
--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,2 +1,4 @@
-pub mod integration;
 pub mod utils;
+
+#[cfg(test)]
+pub mod integration;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,20 +1,26 @@
 pub mod assertions;
-pub mod contract_fixtures;
 /// Testing utilities module for contract testing
 /// This module provides helper functions and utilities for testing Soroban contracts
 pub mod contract_utils;
-pub mod integration_framework;
 pub mod performance;
 pub mod test_data;
 pub mod test_fixtures;
 
+#[cfg(test)]
+pub mod contract_fixtures;
+#[cfg(test)]
+pub mod integration_framework;
+
 pub use assertions::*;
-pub use contract_fixtures::*;
 pub use contract_utils::*;
-pub use integration_framework::*;
 pub use performance::*;
 pub use test_data::*;
 pub use test_fixtures::*;
+
+#[cfg(test)]
+pub use contract_fixtures::*;
+#[cfg(test)]
+pub use integration_framework::*;
 
 /// Common test constants
 pub mod constants {


### PR DESCRIPTION
## Summary
- keep shared test utilities available during normal library builds
- gate the integration test tree and integration-only utility modules/re-exports behind `#[cfg(test)]`
- group shared modules separately from test-only modules to make the test utility layout easier to scan

Fixes #602

## Validation
- `RUSTC=/Users/jakehatchett/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin/rustc /Users/jakehatchett/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin/cargo check -p uzima-tests --lib`
- `RUSTC=/Users/jakehatchett/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin/rustc /Users/jakehatchett/.rustup/toolchains/1.91.1-aarch64-apple-darwin/bin/cargo test -p uzima-tests --lib --no-run`
- `git diff --check`

Note: full `cargo test -p uzima-tests --lib` compiles and reaches runtime, then fails five existing integration/runtime assertions unrelated to module gating (55 passed, 5 failed).