### PR TITLE
feat(soroban): add error-handling policy and shared ContractError uti…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+
+      - name: Run tests
+        run: |
+          cargo test --workspace --all-features
+
+      - name: Run clippy
+        run: |
+          cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Check formatting
+        run: |
+          cargo fmt -- --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ All code must follow the naming conventions defined in [CODING_STANDARDS.md](./d
 - Document all public APIs with `///` doc comments
 - Include examples for complex functions
 - Update relevant documentation when changing functionality
+ - Follow the repository policies for error handling: see `docs/policies/soroban-error-handling.md` for guidance on Soroban contract utilities.
 
 ## Testing Requirements
 

--- a/docs/policies/soroban-error-handling.md
+++ b/docs/policies/soroban-error-handling.md
@@ -1,0 +1,30 @@
+# Soroban Error Handling Policy
+
+Purpose
+- Provide a small, consistent policy for propagating and asserting errors from Soroban contract utilities used in tests and examples.
+
+Policy
+- Use a shared `ContractError` type for utility code: `Result<T, ContractError>`.
+- Convert low-level numeric codes (e.g. `i32`) into `ContractError::Code(i32)` at the boundary.
+- For human-readable failures use `ContractError::Message(String)`.
+- Do not expose internal or sensitive state in error messages.
+
+Logging
+- Log non-sensitive diagnostic messages in tests only. Contract production code should avoid verbose logs.
+
+Guidance for utility authors
+- Export the shared `ContractError` from `tests/utils/contract_error.rs` and use `ContractResult<T> = Result<T, ContractError>`.
+- Provide helper functions to assert error codes and convert legacy `i32` results to `ContractError` where needed.
+
+Example
+```rust
+pub type ContractResult<T> = Result<T, ContractError>;
+
+pub enum ContractError {
+    Code(i32),
+    Message(String),
+}
+```
+
+Reference
+- Include a brief reference to this policy in `CONTRIBUTING.md` and follow it when adding or updating contract utilities.

--- a/tests/utils/contract_error.rs
+++ b/tests/utils/contract_error.rs
@@ -1,0 +1,55 @@
+/// Shared error type for contract utilities used in tests and examples
+use alloc::string::String;
+use core::fmt;
+
+/// A small, test-oriented contract error type.
+#[derive(Clone, PartialEq, Eq)]
+pub enum ContractError {
+    Code(i32),
+    Message(String),
+}
+
+impl From<i32> for ContractError {
+    fn from(code: i32) -> Self {
+        ContractError::Code(code)
+    }
+}
+
+impl From<String> for ContractError {
+    fn from(s: String) -> Self {
+        ContractError::Message(s)
+    }
+}
+
+impl From<&str> for ContractError {
+    fn from(s: &str) -> Self {
+        ContractError::Message(s.to_string())
+    }
+}
+
+impl fmt::Display for ContractError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ContractError::Code(c) => write!(f, "ContractError::Code({})", c),
+            ContractError::Message(s) => write!(f, "ContractError::Message({})", s),
+        }
+    }
+}
+
+impl fmt::Debug for ContractError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl std::error::Error for ContractError {}
+
+impl ContractError {
+    /// If the error was numeric, return the code.
+    pub fn code(&self) -> Option<i32> {
+        match self {
+            ContractError::Code(c) => Some(*c),
+            _ => None,
+        }
+    }
+}

--- a/tests/utils/contract_utils.rs
+++ b/tests/utils/contract_utils.rs
@@ -2,11 +2,12 @@
 
 /// Contract utilities for common testing operations
 use soroban_sdk::{testutils::Address as _, Address, Env, String as SorobanString};
+use super::contract_error::ContractError;
 
 #[allow(clippy::expect_used)]
 #[allow(clippy::panic)]
-/// Result type for contract operations
-pub type ContractResult<T> = Result<T, String>;
+/// Result type for contract operations following the shared policy
+pub type ContractResult<T> = Result<T, ContractError>;
 
 /// Setup helper for contract initialization
 pub struct ContractSetup {
@@ -51,15 +52,24 @@ impl ContractSetup {
 }
 
 /// Error assertion helpers
-pub fn assert_contract_error(result: Result<(), i32>, expected_code: i32) {
+/// Assert that a legacy numeric contract result returned the expected code
+pub fn assert_contract_error_code(result: Result<(), i32>, expected_code: i32) {
     match result {
         Err(code) => assert_eq!(code, expected_code, "Contract error code mismatch"),
         Ok(_) => panic!("Expected contract error but succeeded"),
     }
 }
 
+/// Assert using the shared `ContractError` type
+pub fn assert_contract_error(result: ContractResult<()>, expected: ContractError) {
+    match result {
+        Err(e) => assert_eq!(format!("{}", e), format!("{}", expected), "Contract error mismatch"),
+        Ok(_) => panic!("Expected contract error but succeeded"),
+    }
+}
+
 /// Success assertion helper
-pub fn assert_contract_success<T>(result: Result<T, i32>) -> T {
+pub fn assert_contract_success<T>(result: ContractResult<T>) -> T {
     result.expect("Contract operation failed")
 }
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod assertions;
 pub mod contract_fixtures;
+pub mod contract_error;
 /// Testing utilities module for contract testing
 /// This module provides helper functions and utilities for testing Soroban contracts
 pub mod contract_utils;
@@ -10,6 +11,7 @@ pub mod test_fixtures;
 
 pub use assertions::*;
 pub use contract_fixtures::*;
+pub use contract_error::*;
 pub use contract_utils::*;
 pub use integration_framework::*;
 pub use performance::*;


### PR DESCRIPTION
…lity

- Add docs/policies/soroban-error-handling.md
- Add tests/utils/contract_error.rs
- Update tests/utils/contract_utils.rs to use ContractError
- Export module in tests/utils/mod.rs
- Update CONTRIBUTING.md to reference policy
- Add CI workflow to run tests, clippy, and fmt
- closes #614 