### PR TITLE
[#616] feat: add package-level quality gates for shared tests crate

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -21,5 +21,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Run clippy
+      - name: Run clippy (workspace)
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run clippy (tests crate — dead code + unused imports)
+        run: >
+          cargo clippy -p uzima-tests --tests --
+          -D warnings
+          -D dead_code
+          -D unused_imports
+          -D unused_variables

--- a/.github/workflows/tests-quality-gates.yml
+++ b/.github/workflows/tests-quality-gates.yml
@@ -1,0 +1,66 @@
+name: Tests Crate Quality Gates
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tests/**'
+      - '.github/workflows/tests-quality-gates.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'tests/**'
+      - '.github/workflows/tests-quality-gates.yml'
+
+jobs:
+  fmt:
+    name: Formatting (tests crate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92.0"
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt -p uzima-tests -- --check
+
+  lint:
+    name: Lint (tests crate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92.0"
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Clippy — deny warnings, dead code, unused imports
+        run: >
+          cargo clippy -p uzima-tests --tests --
+          -D warnings
+          -D dead_code
+          -D unused_imports
+          -D unused_variables
+
+  build:
+    name: Build (tests crate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92.0"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build tests crate
+        run: cargo build -p uzima-tests --tests


### PR DESCRIPTION
## Summary

Closes #616

- Added `.github/workflows/tests-quality-gates.yml` with three explicit gates for the `uzima-tests` crate:
  - **fmt**: `rustfmt --check` — enforces formatting consistency
  - **lint**: `clippy -p uzima-tests --tests -D dead_code -D unused_imports -D unused_variables` — prevents regressions in shared utilities
  - **build**: `cargo build -p uzima-tests --tests` — confirms compilation stays green
- Extended `clippy.yml` to also run the dead-code + unused-import pass on `uzima-tests` alongside the existing workspace clippy pass, so gate failures surface in the standard CI workflow

## Test plan

- [ ] CI jobs `fmt`, `lint`, and `build` appear on the PR checks panel
- [ ] Introducing a dead-code item in `tests/lib.rs` triggers a lint failure
- [ ] Existing workspace clippy job still passes
- [ ] No regression in the wasm-size-check workflow