### PR TITLE
fix(tests): harmonize import ordering and module organization (#610)

### DIFF
--- a/contracts/medical_records/src/test.rs
+++ b/contracts/medical_records/src/test.rs
@@ -1,7 +1,11 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
+
+// internal
 use super::*;
 use crate::errors::Error;
+
+// external crates
 use soroban_sdk::testutils::{Address as _, Events, Ledger};
 use soroban_sdk::{symbol_short, vec, Address, Env, String, Symbol, TryFromVal, Vec};
 
@@ -993,7 +997,10 @@ fn test_rate_limit_admin_bypass() {
 
 #[cfg(test)]
 mod test_metadata {
+    // internal
     use super::*;
+
+    // external crates
     use soroban_sdk::{map, vec, Address, Env, Map, String};
 
     fn setup(

--- a/contracts/medical_records/src/test_migration.rs
+++ b/contracts/medical_records/src/test_migration.rs
@@ -1,4 +1,7 @@
+// internal
 use crate::{MedicalRecordsContract, MedicalRecordsContractClient};
+
+// external crates
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
 
 #[test]

--- a/contracts/medical_records/src/test_permissions.rs
+++ b/contracts/medical_records/src/test_permissions.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
+
+// internal
 use crate::{MedicalRecordsContract, MedicalRecordsContractClient, Permission};
+
+// external crates
 use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
 
 #[test]

--- a/contracts/medical_records/tests/common/mod.rs
+++ b/contracts/medical_records/tests/common/mod.rs
@@ -1,3 +1,4 @@
+// external crates
 use medical_records::{MedicalRecordsContract, MedicalRecordsContractClient, Role};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 

--- a/contracts/medical_records/tests/crypto_security_tests.rs
+++ b/contracts/medical_records/tests/crypto_security_tests.rs
@@ -3,13 +3,16 @@
 
 mod common;
 
-use common::setup_uzima;
+// external crates
 use medical_records::{
     AdvancedEncryptedRecordInput, CryptoAuditAction, EnvelopeAlgorithm, Error, KeyEnvelope,
     Permission,
 };
 use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{Bytes, BytesN, String, Vec};
+
+// test helpers
+use common::setup_uzima;
 
 fn make_envelopes(
     env: &soroban_sdk::Env,

--- a/contracts/medical_records/tests/integration/mod.rs
+++ b/contracts/medical_records/tests/integration/mod.rs
@@ -1,11 +1,11 @@
 // tests/integration/mod.rs
-use soroban_sdk::{Address, Env, String};
 
 pub mod medical_records_tests {
-    use super::*;
-    use medical_records::{MedicalRecordsContract, MedicalRecordsContractClient, Role, Error, RateLimitConfig};
+    // external crates
+    use medical_records::{MedicalRecordsContract, MedicalRecordsContractClient, Error, RateLimitConfig, Role};
     use soroban_sdk::{
         testutils::{Address as _, MockAuth, MockAuthInvoke},
+        Address, Env, String,
     };
 
     #[test]

--- a/contracts/medical_records/tests/logging_tests.rs
+++ b/contracts/medical_records/tests/logging_tests.rs
@@ -1,3 +1,6 @@
+#![cfg(test)]
+
+// external crates
 use medical_records::{MedicalRecordsContract, MedicalRecordsContractClient, Role, StructuredLog};
 use soroban_sdk::testutils::{Address as _, Events};
 use soroban_sdk::{symbol_short, Address, Env, String, Symbol, TryFromVal, Vec};

--- a/contracts/medical_records/tests/zk_access_tests.rs
+++ b/contracts/medical_records/tests/zk_access_tests.rs
@@ -2,7 +2,10 @@
 
 mod common;
 
-use common::setup_uzima;
+// std
+use std::time::Instant;
+
+// external crates
 use credential_registry::{CredentialRegistryContract, CredentialRegistryContractClient};
 use medical_records::{Error, ZkAuditRecord, ZkPublicInputs};
 use soroban_sdk::xdr::ToXdr;
@@ -11,8 +14,10 @@ use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
     Address, Bytes, BytesN, Env, String, Symbol, TryFromVal,
 };
-use std::time::Instant;
 use zk_verifier::{ZkVerifierContract, ZkVerifierContractClient};
+
+// test helpers
+use common::setup_uzima;
 
 fn append_bytes32(env: &Env, payload: &mut Bytes, value: &BytesN<32>) {
     payload.append(&Bytes::from_slice(env, &value.to_array()));


### PR DESCRIPTION
closes #610 

## Summary
  
  Resolves #610 — standardizes import ordering and module boundaries across all `medical_records` test files to reduce lint churn and improve
  navigability.
  
  ## Changes
  
  | File | Change |
  |------|--------|
  | `tests/logging_tests.rs` | Added missing `#![cfg(test)]` crate-level gate |
  | `tests/zk_access_tests.rs` | Moved `use std::time::Instant` to the `std` group at the top |
  | `tests/crypto_security_tests.rs` | Moved `use common::setup_uzima` to a dedicated `// test helpers` group |
  | `tests/integration/mod.rs` | Removed duplicate outer-level imports; replaced `use super::*` with concrete imports |
  | `tests/common/mod.rs` | Added import group comment for clarity |
  | `src/test.rs` | Separated import groups with blank lines (top-level and `mod test_metadata`) |
  | `src/test_permissions.rs` | Separated internal and external crate import groups |
  | `src/test_migration.rs` | Separated internal and external crate import groups |
  
  ## Import ordering convention applied
  
  // std
  // external crates (soroban_sdk, etc.)
  // internal (crate::, super::)
  // test helpers (common::)
  
  ## Testing
  
  No logic or assertions were changed — only import ordering and module structure. All existing tests remain intact.
