### PR TITLE
docs: add ADRs for Soroban platform choice and patient consent model

### DIFF
--- a/docs/adr/ADR-001-soroban-platform-choice.md
+++ b/docs/adr/ADR-001-soroban-platform-choice.md
@@ -1,0 +1,26 @@
+# ADR-001: Use Soroban (Stellar) over alternative smart-contract platforms
+
+**Status:** Accepted  
+**Date:** 2025-01-01
+
+## Context
+The project needed a smart-contract platform for healthcare payment processing.
+Candidates considered: Ethereum/EVM, Solana, Soroban (Stellar).
+
+## Decision
+Use Soroban on the Stellar network.
+
+## Rationale
+- **Deterministic fees** — Stellar's fee model is predictable, critical for
+  healthcare billing where cost certainty matters.
+- **Built-in asset primitives** — SEP-41 tokens map naturally to payment flows
+  without custom ERC-20 boilerplate.
+- **WASM sandbox** — Soroban's WASM execution environment is auditable and
+  size-constrained (64 KB), encouraging lean contracts.
+- **No gas estimation surprises** — fixed resource fees simplify UX for
+  non-crypto-native healthcare operators.
+
+## Consequences
+- Team must learn Rust + Soroban SDK.
+- Ecosystem tooling (wallets, explorers) is smaller than Ethereum.
+- WASM 64 KB limit requires careful dependency management.

--- a/docs/adr/ADR-002-patient-consent-model.md
+++ b/docs/adr/ADR-002-patient-consent-model.md
@@ -1,0 +1,24 @@
+# ADR-002: Patient consent model — explicit on-chain authorisation
+
+**Status:** Accepted  
+**Date:** 2025-01-15
+
+## Context
+Medical records access requires patient consent. Options:
+1. Off-chain consent stored in a database.
+2. On-chain consent via `require_auth()` on every sensitive call.
+
+## Decision
+Use Soroban's `Address::require_auth()` for all patient-data operations.
+
+## Rationale
+- **Auditability** — every consent event is recorded on-chain and immutable.
+- **No oracle dependency** — consent is verified by the network, not a
+  centralised service that could be compromised.
+- **Simplicity** — `require_auth()` is a single line; no custom ACL tables.
+
+## Consequences
+- Patients must sign transactions, requiring a Stellar wallet.
+- Batch operations on behalf of a patient require multi-auth or delegated
+  signing, which adds UX complexity.
+- Off-chain consent caching is not possible without additional trust assumptions.


### PR DESCRIPTION
## Summary
Creates \docs/adr/\ with two Architecture Decision Records:
- **ADR-001** — Why Soroban over EVM/Solana (deterministic fees, SEP-41 assets, WASM sandbox)
- **ADR-002** — Patient consent via on-chain \equire_auth()\ vs off-chain database

closes #641