### PR TITLE
docs(compliance): add GDPR Article 17 right-to-erasure specification

### DIFF
--- a/docs/REGULATORY_COMPLIANCE.md
+++ b/docs/REGULATORY_COMPLIANCE.md
@@ -31,3 +31,31 @@ soroban contract invoke --id $MEDICAL_RECORDS_ID \
   -- caller $ADMIN_ADDRESS \
   -- compliance $COMPLIANCE_ID
 ```
+
+
+## GDPR Article 17 — Right to Erasure (Cryptographic Key Deletion)
+
+Since blockchain data is immutable, full deletion is not possible. The system uses
+**cryptographic erasure**: deleting the patient's encryption key renders all encrypted
+records permanently inaccessible.
+
+### How It Works
+
+1. Patient calls `request_erasure(patient_id)` on the `medical_records` contract.
+2. Identity is verified against `identity_registry`.
+3. The patient's encryption key is deleted from `crypto_registry`.
+4. All active consents for the patient are atomically revoked.
+5. An `ErasureCompleted` event is emitted (timestamp + patient ID hash — no PII).
+6. Subsequent read attempts return `Err(ContractError::DataErased)`.
+
+### Key Properties
+
+| Property | Value |
+|---|---|
+| Irreversible | Yes — deleted key cannot be recovered |
+| Who can invoke | Patient only (verified via `identity_registry`) |
+| Event emitted | `ErasureCompleted { timestamp, patient_hash }` |
+| Read after erasure | Returns `DataErased` error |
+
+> **Note:** This satisfies GDPR Article 17 because encrypted data becomes permanently
+> unreadable without the encryption key.


### PR DESCRIPTION
## Summary

Documents the cryptographic erasure approach for GDPR Article 17 compliance in `docs/REGULATORY_COMPLIANCE.md`.

Since blockchain data is immutable, the system achieves erasure by deleting the patient's encryption key, making all encrypted records permanently unreadable. This section details the flow, properties, and event schema for `request_erasure`.

## Related

closes #646
