### PR TITLE
ci(load-tests): add scheduled load-test workflow

### DIFF
--- a/.github/workflows/load-tests-schedule.yml
+++ b/.github/workflows/load-tests-schedule.yml
@@ -1,0 +1,29 @@
+name: Load Tests (Scheduled)
+
+on:
+  schedule:
+    - cron: "0 2 * * 1"
+  workflow_dispatch:
+
+jobs:
+  load-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.92.0"
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run load tests
+        run: cargo test -p load_testing --release -- --nocapture
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: load-test-results
+          path: reports/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds `.github/workflows/load-tests-schedule.yml` — a scheduled GitHub Actions workflow that runs load tests weekly (every Monday at 02:00 UTC) rather than on every PR, avoiding CI flakiness on regular pull requests.

The workflow:
- Runs `cargo test -p load_testing --release -- --nocapture` for live output
- Uploads test results as a GitHub Actions artifact for the `reports/` directory
- Can also be triggered manually via `workflow_dispatch`

## Related

closes #633
