### PR TITLE
fix: implement rate limiting on emergency_access_override

### DIFF
--- a/contracts/emergency_access_override/src/errors.rs
+++ b/contracts/emergency_access_override/src/errors.rs
@@ -10,6 +10,7 @@ pub enum Error {
     InvalidThreshold = 230,
     InvalidDuration = 231,
     RecordNotFound = 403,
+    RateLimitExceeded = 429,
 }
 
 pub fn get_suggestion(error: Error) -> Symbol {
@@ -19,5 +20,6 @@ pub fn get_suggestion(error: Error) -> Symbol {
         Error::AlreadyInitialized => symbol_short!("ALREADY"),
         Error::InvalidThreshold | Error::InvalidDuration => symbol_short!("CHK_LEN"),
         Error::RecordNotFound => symbol_short!("CHK_ID"),
+        Error::RateLimitExceeded => symbol_short!("WAIT_CD"),
     }
 }

--- a/contracts/emergency_access_override/src/events.rs
+++ b/contracts/emergency_access_override/src/events.rs
@@ -68,3 +68,22 @@ pub fn publish_initialization(env: &Env, admin: &Address) {
     env.events()
         .publish((symbol_short!("EMER"), symbol_short!("INIT")), admin);
 }
+
+pub fn publish_rate_limit_exceeded(
+    env: &Env,
+    caller: &Address,
+    next_allowed_at: u64,
+    attempted_at: u64,
+) {
+    env.events().publish(
+        (symbol_short!("EMER"), symbol_short!("RATELMT")),
+        (caller, next_allowed_at, attempted_at),
+    );
+}
+
+pub fn publish_cooldown_updated(env: &Env, admin: &Address, new_period: u64) {
+    env.events().publish(
+        (symbol_short!("EMER"), symbol_short!("CDUPD")),
+        (admin, new_period),
+    );
+}

--- a/contracts/emergency_access_override/src/lib.rs
+++ b/contracts/emergency_access_override/src/lib.rs
@@ -32,9 +32,14 @@ pub enum DataKey {
     ApprovalThreshold,
     TrustedApprover(Address),          // approver -> bool (exists)
     EmergencyAccess(Address, Address), // (patient, provider)
+    Cooldown(Address),                 // approver -> last_used timestamp
+    CooldownPeriod,                    // configurable cooldown in seconds (default 86400 = 24h)
 }
 
 // ==================== Contract ====================
+
+/// Default cooldown period: 24 hours in seconds.
+const DEFAULT_COOLDOWN_SECONDS: u64 = 86_400;
 
 #[contract]
 pub struct EmergencyAccessOverride;
@@ -60,6 +65,9 @@ impl EmergencyAccessOverride {
         env.storage()
             .instance()
             .set(&DataKey::ApprovalThreshold, &threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::CooldownPeriod, &DEFAULT_COOLDOWN_SECONDS);
 
         for approver in approvers.iter() {
             env.storage()
@@ -95,6 +103,30 @@ impl EmergencyAccessOverride {
         }
 
         let now = env.ledger().timestamp();
+
+        // Rate limiting: enforce per-caller cooldown
+        let cooldown_period: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::CooldownPeriod)
+            .unwrap_or(DEFAULT_COOLDOWN_SECONDS);
+
+        let last_used: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Cooldown(approver.clone()))
+            .unwrap_or(0);
+
+        let next_allowed_at = last_used.saturating_add(cooldown_period);
+        if now < next_allowed_at {
+            events::publish_rate_limit_exceeded(&env, &approver, next_allowed_at, now);
+            return Err(Error::RateLimitExceeded);
+        }
+
+        // Record this invocation timestamp
+        env.storage()
+            .persistent()
+            .set(&DataKey::Cooldown(approver.clone()), &now);
 
         let key = DataKey::EmergencyAccess(patient.clone(), provider.clone());
         let mut record: EmergencyAccessRecord =
@@ -153,6 +185,40 @@ impl EmergencyAccessOverride {
         env.storage().persistent().set(&key, &record);
         events::publish_emergency_access_approved(&env, &patient, &provider, &approver, now);
         Ok(false)
+    }
+
+    /// Update the cooldown period. Only callable by admin (governance-gated).
+    pub fn update_cooldown_period(
+        env: Env,
+        admin: Address,
+        new_period_seconds: u64,
+    ) -> Result<(), Error> {
+        admin.require_auth();
+        Self::require_initialized(&env)?;
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::CooldownPeriod, &new_period_seconds);
+
+        events::publish_cooldown_updated(&env, &admin, new_period_seconds);
+        Ok(())
+    }
+
+    /// Get the current cooldown period in seconds.
+    pub fn get_cooldown_period(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::CooldownPeriod)
+            .unwrap_or(DEFAULT_COOLDOWN_SECONDS)
     }
 
     pub fn check_emergency_access(

--- a/contracts/emergency_access_override/src/test.rs
+++ b/contracts/emergency_access_override/src/test.rs
@@ -155,6 +155,7 @@ mod tests {
         assert_eq!(Error::InvalidThreshold as u32, 230);
         assert_eq!(Error::InvalidDuration as u32, 231);
         assert_eq!(Error::RecordNotFound as u32, 403);
+        assert_eq!(Error::RateLimitExceeded as u32, 429);
     }
 
     #[test]
@@ -181,5 +182,83 @@ mod tests {
             get_suggestion(Error::InvalidThreshold),
             symbol_short!("CHK_LEN")
         );
+    }
+
+    #[test]
+    fn test_first_call_succeeds_within_cooldown() {
+        let (env, client, admin, approver1, _approver2, _approver3, approvers) = setup();
+        client.initialize(&admin, &approvers, &2);
+
+        let patient = Address::generate(&env);
+        let provider = Address::generate(&env);
+
+        // First call should succeed (no prior cooldown)
+        let result = client.try_grant_emergency_access(&approver1, &patient, &provider, &600);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_second_call_within_cooldown_fails() {
+        let (env, client, admin, approver1, _approver2, _approver3, approvers) = setup();
+        client.initialize(&admin, &approvers, &2);
+
+        let patient = Address::generate(&env);
+        let provider = Address::generate(&env);
+
+        // First call succeeds
+        client.grant_emergency_access(&approver1, &patient, &provider, &600);
+
+        // Second call immediately after should fail with RateLimitExceeded
+        let result = client.try_grant_emergency_access(&approver1, &patient, &provider, &600);
+        assert_eq!(result, Err(Ok(Error::RateLimitExceeded)));
+    }
+
+    #[test]
+    fn test_call_after_cooldown_window_succeeds() {
+        let (env, client, admin, approver1, _approver2, _approver3, approvers) = setup();
+        client.initialize(&admin, &approvers, &2);
+
+        // Set a short cooldown of 100 seconds
+        client.update_cooldown_period(&admin, &100u64);
+
+        let patient = Address::generate(&env);
+        let provider = Address::generate(&env);
+
+        // First call at t=0
+        client.grant_emergency_access(&approver1, &patient, &provider, &600);
+
+        // Advance ledger time past the cooldown window
+        env.ledger().with_mut(|li| {
+            li.timestamp = li.timestamp.saturating_add(101);
+        });
+
+        // Call after cooldown should succeed
+        let result = client.try_grant_emergency_access(&approver1, &patient, &provider, &600);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_admin_can_update_cooldown_period() {
+        let (_env, client, admin, _, _, _, approvers) = setup();
+        client.initialize(&admin, &approvers, &2);
+
+        assert_eq!(client.get_cooldown_period(), 86_400u64);
+
+        client.update_cooldown_period(&admin, &3600u64);
+        assert_eq!(client.get_cooldown_period(), 3600u64);
+    }
+
+    #[test]
+    fn test_non_admin_cannot_update_cooldown_period() {
+        let (env, client, admin, approver1, _, _, approvers) = setup();
+        client.initialize(&admin, &approvers, &2);
+
+        let outsider = Address::generate(&env);
+        let result = client.try_update_cooldown_period(&outsider, &3600u64);
+        assert_eq!(result, Err(Ok(Error::Unauthorized)));
+
+        // Approver also cannot update
+        let result2 = client.try_update_cooldown_period(&approver1, &3600u64);
+        assert_eq!(result2, Err(Ok(Error::Unauthorized)));
     }
 }


### PR DESCRIPTION
Closes #625

## Summary
Adds per-caller cooldown enforcement to `emergency_access_override` to prevent abuse of the emergency access grant function.

## Changes
- Added `Cooldown(Address)` and `CooldownPeriod` keys to `DataKey` enum
- `grant_emergency_access` now checks per-caller last-used timestamp against the cooldown period before proceeding
- Default cooldown is 24h (86,400 seconds), stored in contract instance storage on initialization
- Emits `RateLimitExceeded` event with caller address and next-allowed timestamp when limit is hit
- Added `update_cooldown_period(admin, seconds)` — governance-gated, only admin can call
- Added `get_cooldown_period()` query function
- Added `RateLimitExceeded = 429` error variant

## Testing
- `test_first_call_succeeds_within_cooldown`: first call always succeeds
- `test_second_call_within_cooldown_fails`: immediate second call returns `RateLimitExceeded`
- `test_call_after_cooldown_window_succeeds`: call after window expires succeeds
- `test_admin_can_update_cooldown_period`: admin can change the period
- `test_non_admin_cannot_update_cooldown_period`: non-admin gets `Unauthorized`