### PR TITLE
feat(healthcare_data_marketplace): token-gated access tiers (#658)

### DIFF
--- a/contracts/healthcare_data_marketplace/src/lib.rs
+++ b/contracts/healthcare_data_marketplace/src/lib.rs
@@ -597,3 +597,132 @@ impl HealthcareDataMarketplace {
         Ok(())
     }
 }
+
+
+// ============================================================
+// Issue #658: Token-Gated Access Tiers
+// ============================================================
+
+const BASIC_COST: i128 = 0;
+const STANDARD_COST: i128 = 100;   // 100 SUT
+const PREMIUM_COST: i128 = 1000;   // 1000 SUT
+const TIER_DURATION_LEDGERS: u32 = 30 * 24 * 60 * 12; // ~30 days at 5s/ledger
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum AccessTier {
+    Basic,
+    Standard,
+    Premium,
+}
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct TierGrant {
+    pub tier: AccessTier,
+    pub granted_at: u32, // ledger sequence
+    pub expires_at: u32,
+}
+
+#[contracttype]
+pub enum TierKey {
+    Grant(Address), // keyed by buyer/researcher address
+}
+
+/// Purchase an access tier by transferring SUT tokens to treasury.
+/// Basic is free; Standard costs 100 SUT; Premium costs 1000 SUT.
+pub fn purchase_access_tier(
+    env: Env,
+    buyer: Address,
+    tier: AccessTier,
+    sut_token: Address,
+    treasury: Address,
+) {
+    buyer.require_auth();
+    let cost: i128 = match &tier {
+        AccessTier::Basic => BASIC_COST,
+        AccessTier::Standard => STANDARD_COST,
+        AccessTier::Premium => PREMIUM_COST,
+    };
+    if cost > 0 {
+        let token_client = token::Client::new(&env, &sut_token);
+        token_client.transfer(&buyer, &treasury, &cost);
+    }
+    let current = env.ledger().sequence();
+    let grant = TierGrant {
+        tier: tier.clone(),
+        granted_at: current,
+        expires_at: current + TIER_DURATION_LEDGERS,
+    };
+    env.storage()
+        .persistent()
+        .set(&TierKey::Grant(buyer.clone()), &grant);
+    env.events().publish(
+        (Symbol::new(&env, "TierPurchased"),),
+        (buyer, tier, cost),
+    );
+}
+
+/// Get a caller's current tier. Returns Basic if grant is missing or expired.
+pub fn get_effective_tier(env: Env, caller: Address) -> AccessTier {
+    match env
+        .storage()
+        .persistent()
+        .get::<TierKey, TierGrant>(&TierKey::Grant(caller))
+    {
+        Some(grant) if env.ledger().sequence() <= grant.expires_at => grant.tier,
+        _ => AccessTier::Basic,
+    }
+}
+
+/// Query data — returns granularity matching the caller's tier.
+/// Basic: aggregated only. Standard: anonymized records. Premium: full de-identified.
+pub fn query_data(env: Env, caller: Address) -> Symbol {
+    match get_effective_tier(env.clone(), caller) {
+        AccessTier::Basic => Symbol::new(&env, "aggregated_only"),
+        AccessTier::Standard => Symbol::new(&env, "anonymized_records"),
+        AccessTier::Premium => Symbol::new(&env, "full_deidentified"),
+    }
+}
+
+#[cfg(test)]
+mod tier_tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+    use soroban_sdk::Env;
+
+    #[test]
+    fn test_basic_tier_default() {
+        let env = Env::default();
+        let caller = Address::generate(&env);
+        let tier = get_effective_tier(env.clone(), caller);
+        assert_eq!(tier, AccessTier::Basic);
+    }
+
+    #[test]
+    fn test_query_returns_correct_granularity_by_tier() {
+        // Basic returns aggregated_only
+        let env = Env::default();
+        let caller = Address::generate(&env);
+        let result = query_data(env.clone(), caller);
+        assert_eq!(result, Symbol::new(&env, "aggregated_only"));
+    }
+
+    #[test]
+    fn test_expired_tier_reverts_to_basic() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let caller = Address::generate(&env);
+        // Manually write an already-expired grant
+        let grant = TierGrant {
+            tier: AccessTier::Premium,
+            granted_at: 0,
+            expires_at: 0,
+        };
+        env.storage()
+            .persistent()
+            .set(&TierKey::Grant(caller.clone()), &grant);
+        let tier = get_effective_tier(env.clone(), caller);
+        assert_eq!(tier, AccessTier::Basic);
+    }
+}


### PR DESCRIPTION
Closes #658

## Changes
- Added `AccessTier` enum: `Basic`, `Standard`, `Premium`
- Tier costs: Basic (free), Standard (100 SUT), Premium (1000 SUT)
- `purchase_access_tier()` transfers SUT to treasury and stores a timed grant
- Grants expire after ~30 days (configurable via `TIER_DURATION_LEDGERS`)
- `get_effective_tier()` falls back to Basic if expired or absent
- `query_data()` returns correct granularity per tier
- `TierPurchased` event emitted on purchase
- Unit tests: default tier, correct granularity, expired tier reverts to Basic