### PR TITLE
feat(emergency_access_override): M-of-N multi-sig emergency access (#655)

### DIFF
--- a/contracts/emergency_access_override/src/lib.rs
+++ b/contracts/emergency_access_override/src/lib.rs
@@ -241,3 +241,229 @@ impl EmergencyAccessOverride {
         Ok(())
     }
 }
+
+
+// ============================================================
+// Issue #655: M-of-N Multi-Sig Emergency Access Override
+// ============================================================
+
+const DEFAULT_EXPIRY_SECONDS: u64 = 3600; // 1 hour
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct EmergencyRequest {
+    pub patient_id: Symbol,
+    pub reason: Symbol,
+    pub requester: Address,
+    pub approvals: Vec<Address>,
+    pub created_at: u64,
+    pub granted: bool,
+}
+
+#[contracttype]
+pub enum EmergencyKey {
+    Request(u64),       // keyed by request_id
+    Config,             // stores (approvers: Vec<Address>, required: u32)
+    RequestCounter,
+}
+
+#[derive(Clone, Debug)]
+#[contracttype]
+pub struct MultiSigConfig {
+    pub approvers: Vec<Address>,
+    pub required_approvals: u32,
+    pub expiry_seconds: u64,
+}
+
+/// Governance sets the approver set and required M.
+pub fn configure_multisig(
+    env: Env,
+    admin: Address,
+    approvers: Vec<Address>,
+    required_approvals: u32,
+    expiry_seconds: u64,
+) {
+    admin.require_auth();
+    let config = MultiSigConfig {
+        approvers,
+        required_approvals,
+        expiry_seconds,
+    };
+    env.storage()
+        .persistent()
+        .set(&EmergencyKey::Config, &config);
+}
+
+/// Any party creates a pending emergency access request.
+pub fn request_emergency_access(
+    env: Env,
+    requester: Address,
+    patient_id: Symbol,
+    reason: Symbol,
+) -> u64 {
+    requester.require_auth();
+    let counter: u64 = env
+        .storage()
+        .persistent()
+        .get(&EmergencyKey::RequestCounter)
+        .unwrap_or(0u64);
+    let request_id = counter + 1;
+    let request = EmergencyRequest {
+        patient_id: patient_id.clone(),
+        reason: reason.clone(),
+        requester: requester.clone(),
+        approvals: Vec::new(&env),
+        created_at: env.ledger().timestamp(),
+        granted: false,
+    };
+    env.storage()
+        .persistent()
+        .set(&EmergencyKey::Request(request_id), &request);
+    env.storage()
+        .persistent()
+        .set(&EmergencyKey::RequestCounter, &request_id);
+    env.events().publish(
+        (Symbol::new(&env, "EmergencyRequested"),),
+        (request_id, requester, patient_id),
+    );
+    request_id
+}
+
+/// An approver signs off on a pending request.
+/// Access is granted automatically once M approvals are collected.
+pub fn approve_emergency_access(env: Env, approver: Address, request_id: u64) {
+    approver.require_auth();
+    let config: MultiSigConfig = env
+        .storage()
+        .persistent()
+        .get(&EmergencyKey::Config)
+        .expect("MultiSig not configured");
+    assert!(
+        config.approvers.contains(&approver),
+        "Caller is not a designated approver"
+    );
+    let mut request: EmergencyRequest = env
+        .storage()
+        .persistent()
+        .get(&EmergencyKey::Request(request_id))
+        .expect("Request not found");
+    assert!(!request.granted, "Request already granted");
+    let elapsed = env.ledger().timestamp() - request.created_at;
+    assert!(elapsed <= config.expiry_seconds, "Request has expired");
+    assert!(
+        !request.approvals.contains(&approver),
+        "Approver already signed"
+    );
+    request.approvals.push_back(approver.clone());
+    env.events().publish(
+        (Symbol::new(&env, "EmergencyApproval"),),
+        (request_id, approver.clone()),
+    );
+    if request.approvals.len() >= config.required_approvals {
+        request.granted = true;
+        env.events().publish(
+            (Symbol::new(&env, "EmergencyAccessGranted"),),
+            (request_id, request.patient_id.clone()),
+        );
+    }
+    env.storage()
+        .persistent()
+        .set(&EmergencyKey::Request(request_id), &request);
+}
+
+/// Read a request's current state.
+pub fn get_emergency_request(env: Env, request_id: u64) -> Option<EmergencyRequest> {
+    env.storage()
+        .persistent()
+        .get(&EmergencyKey::Request(request_id))
+}
+
+#[cfg(test)]
+mod multisig_tests {
+    use super::*;
+    use soroban_sdk::testutils::{Address as _, Ledger, LedgerInfo};
+    use soroban_sdk::{Env, Symbol, Vec};
+
+    fn setup_config(env: &Env, approvers: Vec<Address>, m: u32) -> Address {
+        let admin = Address::generate(env);
+        configure_multisig(
+            env.clone(),
+            admin.clone(),
+            approvers,
+            m,
+            DEFAULT_EXPIRY_SECONDS,
+        );
+        admin
+    }
+
+    #[test]
+    fn test_m_approvals_grant_access() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let a1 = Address::generate(&env);
+        let a2 = Address::generate(&env);
+        let a3 = Address::generate(&env);
+        let mut approvers = Vec::new(&env);
+        approvers.push_back(a1.clone());
+        approvers.push_back(a2.clone());
+        approvers.push_back(a3.clone());
+        setup_config(&env, approvers, 2);
+        let requester = Address::generate(&env);
+        let id = request_emergency_access(
+            env.clone(),
+            requester,
+            Symbol::new(&env, "P001"),
+            Symbol::new(&env, "cardiac_arrest"),
+        );
+        approve_emergency_access(env.clone(), a1.clone(), id);
+        approve_emergency_access(env.clone(), a2.clone(), id);
+        let req = get_emergency_request(env.clone(), id).unwrap();
+        assert!(req.granted);
+    }
+
+    #[test]
+    fn test_m_minus_1_does_not_grant() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let a1 = Address::generate(&env);
+        let a2 = Address::generate(&env);
+        let mut approvers = Vec::new(&env);
+        approvers.push_back(a1.clone());
+        approvers.push_back(a2.clone());
+        setup_config(&env, approvers, 2);
+        let requester = Address::generate(&env);
+        let id = request_emergency_access(
+            env.clone(),
+            requester,
+            Symbol::new(&env, "P002"),
+            Symbol::new(&env, "reason"),
+        );
+        approve_emergency_access(env.clone(), a1.clone(), id);
+        let req = get_emergency_request(env.clone(), id).unwrap();
+        assert!(!req.granted);
+    }
+
+    #[test]
+    #[should_panic(expected = "Request has expired")]
+    fn test_expired_request_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let a1 = Address::generate(&env);
+        let mut approvers = Vec::new(&env);
+        approvers.push_back(a1.clone());
+        configure_multisig(env.clone(), Address::generate(&env), approvers, 1, 10); // 10s expiry
+        let requester = Address::generate(&env);
+        let id = request_emergency_access(
+            env.clone(),
+            requester,
+            Symbol::new(&env, "P003"),
+            Symbol::new(&env, "reason"),
+        );
+        // Fast-forward time past expiry
+        env.ledger().set(LedgerInfo {
+            timestamp: env.ledger().timestamp() + 100,
+            ..env.ledger().get()
+        });
+        approve_emergency_access(env.clone(), a1.clone(), id);
+    }
+}


### PR DESCRIPTION
Closes #655

## Changes
- `configure_multisig()` — governance sets approver set, M, and expiry timeout
- `request_emergency_access()` — creates a pending request, returns request_id
- `approve_emergency_access()` — approver signs; access auto-granted at M approvals
- Requests expire after configurable timeout (default 1 hour)
- Events: `EmergencyRequested`, `EmergencyApproval`, `EmergencyAccessGranted`
- Unit tests: M approvals grant, M-1 does not, expired request rejected