### PR TITLE
mplement cross-contract call result caching in healthcare_oracle_network

### DIFF
--- a/contracts/healthcare_oracle_network/src/benchmarks.rs
+++ b/contracts/healthcare_oracle_network/src/benchmarks.rs
@@ -1,0 +1,105 @@
+#![allow(clippy::unwrap_used)]
+extern crate std;
+use std::time::Instant;
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, Symbol, Vec};
+
+struct BenchResult {
+    name: &'static str,
+    cpu_instructions: u64,
+    memory_bytes: u64,
+    wall_us: u128,
+}
+
+impl BenchResult {
+    fn print(&self) {
+        std::println!(
+            "[BENCH] {:40} cpu={:>12} insns  mem={:>10} bytes  wall={:>8}µs",
+            self.name, self.cpu_instructions, self.memory_bytes, self.wall_us
+        );
+    }
+
+    fn assert_cpu_reduction(&self, baseline: u64, min_reduction_pct: u64) {
+        let allowed = baseline.saturating_mul(100 - min_reduction_pct) / 100;
+        assert!(
+            self.cpu_instructions <= allowed,
+            "[BENCH] {} did not meet expected reduction: {} > {}",
+            self.name,
+            self.cpu_instructions,
+            allowed,
+        );
+    }
+}
+
+fn measure<F: FnOnce()>(env: &Env, name: &'static str, f: F) -> BenchResult {
+    env.budget().reset_unlimited();
+    let t0 = Instant::now();
+    f();
+    BenchResult {
+        name,
+        cpu_instructions: env.budget().cpu_instruction_cost(),
+        memory_bytes: env.budget().memory_bytes_cost(),
+        wall_us: t0.elapsed().as_micros(),
+    }
+}
+
+#[contract]
+pub struct MockFeedProvider;
+
+#[contractimpl]
+impl MockFeedProvider {
+    pub fn get_feed_payload(env: Env, _feed_id: String) -> FeedPayload {
+        FeedPayload::DrugPrice(DrugPriceData {
+            ndc_code: String::from_str(&env, "NDC-12345"),
+            currency: String::from_str(&env, "USD"),
+            price_minor: 123450,
+            availability_units: 75,
+            observed_at: env.ledger().timestamp(),
+        })
+    }
+}
+
+#[test]
+fn bench_cached_cross_contract_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = Address::generate(&env);
+    env.register_contract(&contract_id, HealthcareOracleNetwork);
+    let client = HealthcareOracleNetworkClient::new(&env, &contract_id);
+
+    let provider_id = Address::generate(&env);
+    env.register_contract(&provider_id, MockFeedProvider);
+    let feed_id = String::from_str(&env, "benchmark-drug-feed");
+
+    let uncached = measure(&env, "healthcare_oracle_network::raw_external_calls", || {
+        let args = Vec::from_array(&env, [feed_id.clone().into_val(&env)]);
+        let _: FeedPayload = env.invoke_contract(
+            &provider_id,
+            &Symbol::new(&env, "get_feed_payload"),
+            args.clone(),
+        );
+        let _: FeedPayload = env.invoke_contract(
+            &provider_id,
+            &Symbol::new(&env, "get_feed_payload"),
+            args.clone(),
+        );
+        let _: FeedPayload = env.invoke_contract(
+            &provider_id,
+            &Symbol::new(&env, "get_feed_payload"),
+            args,
+        );
+    });
+    uncached.print();
+
+    let cached = measure(&env, "healthcare_oracle_network::cached_external_calls", || {
+        let _ = client.fetch_external_payload(&provider_id, &feed_id);
+        let _ = client.fetch_external_payload(&provider_id, &feed_id);
+        let _ = client.fetch_external_payload(&provider_id, &feed_id);
+    });
+    cached.print();
+
+    cached.assert_cpu_reduction(uncached.cpu_instructions, 40);
+}

--- a/contracts/healthcare_oracle_network/src/lib.rs
+++ b/contracts/healthcare_oracle_network/src/lib.rs
@@ -9,11 +9,13 @@ mod disputes;
 mod oracles;
 mod submissions;
 #[cfg(test)]
+mod benchmarks;
+#[cfg(test)]
 mod test;
 mod types;
 mod utils;
 
-use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 
 pub use types::{
     AggregationRound, ClinicalTrialData, Config, ConsensusRecord, DataKey, Dispute, DisputeStatus,
@@ -220,6 +222,17 @@ impl HealthcareOracleNetwork {
 
     pub fn get_oracle(env: Env, operator: Address) -> Option<OracleNode> {
         oracles::get_oracle(env, operator)
+    }
+
+    pub fn fetch_external_payload(
+        env: Env,
+        provider: Address,
+        feed_id: String,
+    ) -> Result<FeedPayload, Error> {
+        let symbol = Symbol::new(&env, "get_feed_payload");
+        let args = Vec::from_array(&env, [feed_id.clone().into_val(&env)]);
+        let payload: FeedPayload = utils::invoke_contract_cached(&env, provider, symbol, args);
+        Ok(payload)
     }
 
     pub fn get_dispute(env: Env, dispute_id: u64) -> Option<Dispute> {

--- a/contracts/healthcare_oracle_network/src/types.rs
+++ b/contracts/healthcare_oracle_network/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracterror, contracttype, Address, String, Vec};
+use soroban_sdk::{BytesN, contracterror, contracttype, Address, String, Symbol, Vec};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -207,4 +207,12 @@ pub enum DataKey {
     Consensus(FeedKey),
     DisputeCount,
     Dispute(u64),
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct CrossContractCallCacheKey {
+    pub contract: Address,
+    pub function_name: Symbol,
+    pub args_hash: BytesN<32>,
 }

--- a/contracts/healthcare_oracle_network/src/utils.rs
+++ b/contracts/healthcare_oracle_network/src/utils.rs
@@ -1,8 +1,9 @@
-use soroban_sdk::{symbol_short, Address, Env, String, Vec};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, IntoVal, RawVal, String, Symbol, TryFromVal, Val, Vec};
 
 use crate::types::{
-    AggregationRound, ClinicalTrialData, Config, ConsensusRecord, DataKey, DrugPriceData, Error,
-    FeedKey, FeedKind, FeedPayload, OracleNode, RegulatoryUpdateData, TreatmentOutcomeData,
+    AggregationRound, ClinicalTrialData, CallCacheKey, Config, ConsensusRecord, DataKey,
+    DrugPriceData, Error, FeedKey, FeedKind, FeedPayload, OracleNode, RegulatoryUpdateData,
+    TreatmentOutcomeData,
 };
 
 pub fn payload_feed_id_from_trial(payload: &FeedPayload) -> String {
@@ -39,6 +40,38 @@ pub fn require_admin(env: &Env, admin: Address) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+pub fn make_cross_contract_cache_key(
+    env: &Env,
+    contract: &Address,
+    function_name: Symbol,
+    args: &Vec<RawVal>,
+) -> CallCacheKey {
+    let args_hash: BytesN<32> = env.crypto().sha256(&args.to_xdr(env)).into();
+    CallCacheKey {
+        contract: contract.clone(),
+        function_name,
+        args_hash,
+    }
+}
+
+pub fn invoke_contract_cached<
+    T: TryFromVal<Env, Val> + IntoVal<Env, Val> + Clone,
+>(
+    env: &Env,
+    contract: Address,
+    function_name: Symbol,
+    args: Vec<RawVal>,
+) -> T {
+    let cache_key = make_cross_contract_cache_key(env, &contract, function_name.clone(), &args);
+    if let Some(value) = env.storage().temporary().get(&cache_key) {
+        return value;
+    }
+
+    let result: T = env.invoke_contract(&contract, &function_name, args.clone());
+    env.storage().temporary().set(&cache_key, &result);
+    result
 }
 
 pub fn require_verified_oracle(env: &Env, operator: Address) -> Result<Config, Error> {


### PR DESCRIPTION
The environment here does not include Rust tooling (cargo unavailable), so I could not run the actual compile/test suite.
The implementation uses Soroban temporary storage as requested and preserves cache behavior only for read-only external fetches.

closes #664 
closes #672 