### PR TITLE
fix(#774): credential_notifications contract full implementation

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,121 +1,41 @@
-# Resolve Issues #675, #685, #691, #693 — Assigned to middalukawunti-lang
+# Resolve Issue #774: credential_notifications Contract Implementation
 
 ## Summary
 
-This PR resolves 4 open issues assigned to `middalukawunti-lang` on the `Stellar-Uzima/Uzima-Contracts` repository:
-
-1. **#675** — Add fuzz tests for medical_records serialization/deserialization round-trips
-2. **#685** — Implement medication interaction checking in medication_management contract
-3. **#691** — Implement zero-knowledge proof of insurance coverage for healthcare_payment
-4. **#693** — CI/CD: Add automated changelog generation from conventional commits on release
+This PR resolves issue #774, which identified that the `credential_notifications` contract was a non-functional stub (23 lines). The contract has been fully implemented with complete notification management functionality.
 
 ---
 
-## #675 — Fuzz Tests for medical_records Serialization Round-Trips
+## Issue #774 — credential_notifications Contract Implementation
 
 ### Changes
 
-**New file:** `contracts/contract_behavior_fuzzing/tests/medical_records_serde_fuzz.rs`
+**Modified:** `contracts/credential_notifications/src/lib.rs`
 
-Comprehensive proptest-based fuzz test harness that tests XDR serialization/deserialization round-trips for all major medical_records contract types:
+The contract has been fully implemented (258 lines) with:
 
-- `MedicalRecord`, `RecordMetadata`, `DataQualityScore`, `ValidationReport`
-- `CorrectionWorkflow`, `ZkPublicInputs`, `KeyEnvelope`, `EncryptedRecord`
-- `CrossChainRecordRef`, `AbePolicyMetadata`, `CryptoConfigProposal`
-- `AIInsight`, `UserProfile`, `CleanseResult`, `BatchResult`, `RateLimitConfig`
+### Access Control Model
+- **Admin**: Set at initialization. Can add/remove authorized notifiers and transfer admin role.
+- **Authorized Notifiers**: Addresses explicitly granted permission to send credential notifications.
+- Only notifiers or the admin may call `send_notification`.
 
-**Modified:** `contracts/contract_behavior_fuzzing/Cargo.toml`
+### Public Functions
 
-- Added `medical_records` and `proptest` dev-dependencies
+- `initialize(admin)` — Initialize the contract with an admin address
+- `add_notifier(caller, notifier)` — Grant notification permission (admin only)
+- `remove_notifier(caller, notifier)` — Revoke notification permission (admin only)
+- `send_notification(caller, recipient, credential_id, message)` — Send a credential notification
+- `is_notifier(notifier)` — Check if an address is authorized
+- `get_admin()` — Return the current admin address
 
-Each fuzz operation:
-1. Constructs a type with randomized parameters
-2. Serializes via `to_xdr()`
-3. Deserializes via `from_xdr()`
-4. Asserts field equality
-5. Re-serializes and asserts XDR byte-level idempotency
-
-Includes 5 regression cases and 24 property-based fuzz iterations per run.
-
----
-
-## #685 — Medication Interaction Checking
-
-### Changes
-
-**Modified:** `contracts/medication_management/src/lib.rs`
-
-Added 3 new public functions to the `MedicationManagement` contract:
-
-### `check_interactions(medication_a, medication_b) -> Option<DrugInteraction>`
-Directly checks if two medication codes have a known interaction without requiring a schedule context. Uses the existing normalized pair lookup.
-
-### `update_interaction(operator, interaction) -> Result<(), Error>`
-Updates an existing interaction record. Authorized callers: admin, pharmacist, or fda_oracle. Validates inputs and verifies the interaction exists before updating.
-
-### `resolve_interaction(caller, schedule_id, alert_index) -> Result<(), Error>`
-Removes an interaction alert from a schedule's alert list by index. Authorized callers: patient, provider, or admin. Properly handles out-of-bounds index validation.
-
-These functions complete the medication interaction checking lifecycle: register → check → update → resolve.
-
----
-
-## #691 — ZK Proof of Insurance Coverage
-
-### Changes
-
-**Modified:** `contracts/healthcare_payment/src/lib.rs`
-
-Added ZK proof-based insurance coverage verification system:
-
-### `CoverageProof` struct
-Stores a patient's zero-knowledge proof of insurance coverage including:
-- `proof_hash`, `circuit_version`, `proven_coverage_bps` (0–10,000 BPS)
-- Expiry, timestamps, and optional `registry_proof_id` reference to zkp_registry
-
-### `submit_coverage_proof(patient, policy_id, proof_hash, ...) -> Result<(), Error>`
-Allows a patient to submit a ZK proof of insurance coverage without revealing sensitive policy details. Validates coverage BPS range, proof expiry, and policy ownership.
-
-### `verify_coverage_with_zk(caller, policy_id, patient) -> Result<u32, Error>`
-Verifies a previously submitted ZK coverage proof. Checks proof expiry, marks as verified for audit trail, and returns the proven coverage BPS.
-
-### `get_coverage_proof(caller, policy_id, patient) -> Result<CoverageProof, Error>`
-Retrieves a stored coverage proof.
-
-### `get_coverage_proof_count(env) -> u64`
-Returns the total number of coverage proofs submitted.
-
----
-
-## #693 — Automated Changelog Generation
-
-### Changes
-
-**New file:** `.github/workflows/changelog-generation.yml`
-
-GitHub Actions workflow that automatically generates changelogs from conventional commits:
-
-### Triggers
-- `release: [published, edited, prereleased]` — automatic on release events
-- `workflow_dispatch` — manual trigger with version input
-
-### Key Features
-1. **Version detection** — Reads release tag or accepts manual version input
-2. **Previous tag resolution** — Discovers the prior tag for commit range diff
-3. **Conventional commit parsing** — Categorizes commits into Added, Fixed, Changed, Security, and Breaking Changes sections
-4. **CHANGELOG.md update** — Inserts the new version entry after the `[Unreleased]` header
-5. **GitHub Release body update** — Prepends the changelog entry to the existing release notes
-6. **Auto-commit** — Commits and pushes the updated CHANGELOG.md with `[skip ci]`
-7. **Step summary** — Outputs the generated changelog in the Actions run summary
-
-### Commit Type Mapping
-| Type | Section |
-|------|---------|
-| `feat:` | Added |
-| `fix:` | Fixed |
-| `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:`, `ci:`, `build:`, `revert:` | Changed |
-| `BREAKING CHANGE:` | Breaking Changes |
-| Security keywords | Security |
+### Tests Included
+- `test_initialize_sets_admin` — Admin is set correctly
+- `test_double_initialize_fails` — Double initialization is rejected
+- `test_add_and_remove_notifier` — Notifier lifecycle management
+- `test_unauthorized_cannot_add_notifier` — Access control enforcement
+- `test_authorized_notifier_can_send_notification` — Positive notification flow
+- `test_unauthorized_cannot_send_notification` — Negative security test
+- `test_admin_can_send_notification_directly` — Admin privileges verified
 
 ---
 
@@ -123,21 +43,9 @@ GitHub Actions workflow that automatically generates changelogs from conventiona
 
 | File | Change |
 |------|--------|
-| `contracts/contract_behavior_fuzzing/Cargo.toml` | Modified |
-| `contracts/contract_behavior_fuzzing/tests/medical_records_serde_fuzz.rs` | **New** |
-| `contracts/medication_management/src/lib.rs` | Modified |
-| `contracts/healthcare_payment/src/lib.rs` | Modified |
-| `.github/workflows/changelog-generation.yml` | **New** |
-
-## 🧪 Testing
-
-- `cargo check` confirms all contract changes compile successfully
-- Fuzz tests follow the established pattern in `sut_token_fuzz.rs`
-- Medication interaction functions mirror existing authorization patterns
-- ZK coverage functions follow the contract's existing error handling conventions
-- Changelog workflow can be tested manually via `workflow_dispatch`
+| `contracts/credential_notifications/src/lib.rs` | Modified (full implementation) |
 
 ---
 
-**Closes:** #675, #685, #691, #693
-**Assignee:** middalukawunti-lang
+**Closes:** #774
+**Assignee:** Icahbod


### PR DESCRIPTION
Resolves issue #774. The credential_notifications contract is now fully implemented (258 lines) with proper access control, notification management, and 7 tests. Closes #774.