### PR TITLE
fix(#772): change getter functions to return Result instead of defaults

### DIFF
--- a/PR_DESCRIPTION_772.md
+++ b/PR_DESCRIPTION_772.md
@@ -1,0 +1,56 @@
+# Resolve Issue #772 — Public Getter Functions Return Empty/Default Values
+
+## Summary
+
+This PR resolves issue #772: "Public Getter Functions Return Empty/Default Values Instead of Errors for Missing Data".
+
+---
+
+## Issue #772 — Getter Return Type Fixes
+
+### Problem
+Several contracts returned default values (e.g., panicking with `.unwrap()`, or returning `Role::None`) when queried for non-existent data, making it impossible for callers to distinguish between valid data and missing data.
+
+### Changes
+
+#### 1. treasury_controller/src/lib.rs
+
+**Fixed `get_config()`** — Now returns `Result<TreasuryConfig, Error>` instead of panicking with `.unwrap()`.
+- Added `Error::ConfigNotFound` variant for missing configuration
+- Callers can now handle the "not initialized" case gracefully
+
+**Fixed `get_proposal()`** — Now returns `Result<TreasuryProposal, Error>` instead of panicking with `.unwrap()`.
+- Returns `Error::ProposalNotFound` for missing proposals or empty maps
+
+**Fixed `gnosis_get_threshold()`** — Now returns `Result<u32, Error>` instead of `u32`
+
+**Fixed `gnosis_get_owners()`** — Now returns `Result<Vec<Address>, Error>` instead of `Vec<Address>`
+
+#### 2. medical_records/src/lib.rs
+
+**Fixed `get_user_role()`** — Now returns `Result<Role, Error>` instead of silently returning `Role::None` for non-existent or inactive users.
+- Returns `Error::Unauthorized` when user is not found or is inactive
+- Callers can now distinguish between a valid user with a role and a missing user
+
+#### 3. Updated all callers
+
+- `tests/utils/contract_fixtures.rs`: Updated to use `.unwrap()` on new Result types
+- `tests/integration/healthcare_workflows.rs`: Updated to use `.unwrap()` on new Result types
+- `contracts/treasury_controller/src/test.rs`: Updated tests to handle new Result return types
+
+---
+
+## 📋 Files Changed
+
+| File | Change |
+|------|--------|
+| `contracts/treasury_controller/src/lib.rs` | Modified (4 functions) |
+| `contracts/treasury_controller/src/test.rs` | Modified (test updates) |
+| `contracts/medical_records/src/lib.rs` | Modified (1 function) |
+| `tests/utils/contract_fixtures.rs` | Modified (caller update) |
+| `tests/integration/healthcare_workflows.rs` | Modified (caller update) |
+
+---
+
+**Closes:** #772
+**Assignee:** Icahbod

--- a/contracts/medical_records/src/lib.rs
+++ b/contracts/medical_records/src/lib.rs
@@ -1187,11 +1187,11 @@ impl MedicalRecordsContract {
         }
     }
 
-    pub fn get_user_role(env: Env, user: Address) -> Role {
+    pub fn get_user_role(env: Env, user: Address) -> Result<Role, Error> {
         let users = Self::read_users(&env);
         match users.get(user) {
-            Some(p) if p.active => p.role,
-            _ => Role::None,
+            Some(p) if p.active => Ok(p.role),
+            _ => Err(Error::Unauthorized),
         }
     }
 

--- a/contracts/treasury_controller/src/lib.rs
+++ b/contracts/treasury_controller/src/lib.rs
@@ -548,11 +548,17 @@ impl TreasuryController {
     }
 
     /// Get total number of proposals
-    pub fn get_proposal_count(env: Env) -> u64 {
+    pub fn get_proposal_count(env: Env) -> Result<u64, Error> {
+        // Verify config exists (contract is initialized)
         env.storage()
             .instance()
+            .get::<DataKey, TreasuryConfig>(&DataKey::Config)
+            .ok_or(Error::ConfigNotFound)?;
+        Ok(env
+            .storage()
+            .instance()
             .get(&DataKey::ProposalCount)
-            .unwrap_or(0)
+            .unwrap_or(0))
     }
 
     /// Check if proposal is ready for execution

--- a/contracts/treasury_controller/src/lib.rs
+++ b/contracts/treasury_controller/src/lib.rs
@@ -30,6 +30,7 @@ pub enum Error {
     NotAuthorized = 12,
     SymbolTooLong = 13,
     TransferFailed = 14,
+    ConfigNotFound = 15,
 }
 
 /// Treasury proposal types
@@ -528,16 +529,22 @@ impl TreasuryController {
     // === View Functions ===
 
     /// Get treasury configuration
-    pub fn get_config(env: Env) -> TreasuryConfig {
-        env.storage().instance().get(&DataKey::Config).unwrap()
+    pub fn get_config(env: Env) -> Result<TreasuryConfig, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .ok_or(Error::ConfigNotFound)
     }
 
     /// Get proposal details
-    pub fn get_proposal(env: Env, proposal_id: u64) -> TreasuryProposal {
-        let proposals: Map<u64, TreasuryProposal> =
-            env.storage().persistent().get(&DataKey::Proposals).unwrap();
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Result<TreasuryProposal, Error> {
+        let proposals: Map<u64, TreasuryProposal> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposals)
+            .ok_or(Error::ProposalNotFound)?;
 
-        proposals.get(proposal_id).unwrap()
+        proposals.get(proposal_id).ok_or(Error::ProposalNotFound)
     }
 
     /// Get total number of proposals
@@ -593,15 +600,15 @@ impl TreasuryController {
     // === Gnosis Safe Compatibility Interface ===
 
     /// Get threshold for Gnosis Safe compatibility
-    pub fn gnosis_get_threshold(env: Env) -> u32 {
-        let config = Self::get_config(env);
-        config.multisig_config.threshold
+    pub fn gnosis_get_threshold(env: Env) -> Result<u32, Error> {
+        let config = Self::get_config(env)?;
+        Ok(config.multisig_config.threshold)
     }
 
     /// Get owners for Gnosis Safe compatibility
-    pub fn gnosis_get_owners(env: Env) -> Vec<Address> {
-        let config = Self::get_config(env);
-        config.multisig_config.signers
+    pub fn gnosis_get_owners(env: Env) -> Result<Vec<Address>, Error> {
+        let config = Self::get_config(env)?;
+        Ok(config.multisig_config.signers)
     }
 
     // === Private Helper Functions ===

--- a/contracts/treasury_controller/src/test.rs
+++ b/contracts/treasury_controller/src/test.rs
@@ -1,54 +1,135 @@
 #[cfg(test)]
 mod tests {
-    use crate::{Error, ProposalStatus, ProposalType};
+    use crate::{
+        Error, ProposalStatus, ProposalType, TreasuryController, TreasuryControllerClient,
+    };
+    use soroban_sdk::testutils::{Address as _, Ledger as _};
+    use soroban_sdk::{Address, Bytes, Env, String, Vec};
 
-    // Unit tests for treasury controller functions
-    // These tests focus on the core logic without using testutils
-    // to avoid stellar-xdr dependency conflicts
-
-    #[test]
-    fn test_error_types_exist() {
-        // Simple test to verify error types are defined correctly
-        let _error = Error::NotInitialized;
-        let _error = Error::TransferFailed;
-    }
-
-    #[test]
-    fn test_proposal_types_exist() {
-        // Test that our proposal types are properly defined
-        let _withdrawal = ProposalType::Withdrawal;
-        let _config_change = ProposalType::ConfigChange;
-    }
-
-    #[test]
-    fn test_proposal_status_types() {
-        // Test proposal status enumeration
-        let _pending = ProposalStatus::Pending;
-        let _approved = ProposalStatus::Approved;
-        let _executed = ProposalStatus::Executed;
-        let _rejected = ProposalStatus::Rejected;
-    }
-
-    // Note: Integration tests that require Env and testutils are commented out
-    // due to stellar-xdr dependency conflicts in Soroban SDK v20.x
-    // The core token transfer functionality is implemented and tested manually
-
-    /*
-    #[test]
-    fn test_basic_initialization() {
+    fn setup() -> (Env, TreasuryControllerClient<'static>, Address) {
         let env = Env::default();
         env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
 
         let admin = Address::generate(&env);
         let signer1 = Address::generate(&env);
-        let signers = Vec::from_array(&env, [signer1]);
+        let signer2 = Address::generate(&env);
+        let signers = Vec::from_array(&env, [signer1.clone(), signer2.clone()]);
 
         let contract_id = env.register_contract(None, TreasuryController);
         let client = TreasuryControllerClient::new(&env, &contract_id);
 
-        client.initialize(&admin, &signers, &1u32, &3600u64, &1u32, &1_000_000i128);
+        client.initialize(&admin, &signers, &2u32, &3600u64, &2u32, &1_000_000i128);
 
-        assert!(!contract_id.to_string().is_empty());
+        (env, client, admin)
     }
-    */
+
+    // ============================================================================
+    // INITIALIZATION TESTS
+    // ============================================================================
+
+    #[test]
+    fn test_initialize() {
+        let (_env, _client, _admin) = setup();
+    }
+
+    #[test]
+    fn test_double_initialize() {
+        let (env, client, admin) = setup();
+        let result = client.try_initialize(
+            &admin,
+            &Vec::from_array(&env, [Address::generate(&env)]),
+            &1u32, &3600u64, &1u32, &1_000_000i128,
+        );
+        assert!(result.is_err());
+    }
+
+    // ============================================================================
+    // VIEW FUNCTION TESTS (updated for Result return types)
+    // ============================================================================
+
+    #[test]
+    fn test_get_config_returns_result() {
+        let (_env, client, _admin) = setup();
+        let result = client.try_get_config();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_get_config_not_initialized() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TreasuryController);
+        let client = TreasuryControllerClient::new(&env, &contract_id);
+        let result = client.try_get_config();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_proposal_count() {
+        let (_env, client, _admin) = setup();
+        let count = client.get_proposal_count();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_gnosis_get_threshold_returns_result() {
+        let (_env, client, _admin) = setup();
+        let result = client.try_gnosis_get_threshold();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_gnosis_get_owners_returns_result() {
+        let (_env, client, _admin) = setup();
+        let result = client.try_gnosis_get_owners();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_is_proposal_executable_no_config() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register_contract(None, TreasuryController);
+        let client = TreasuryControllerClient::new(&env, &contract_id);
+        assert!(!client.is_proposal_executable(&1));
+    }
+
+    // ============================================================================
+    // ERROR CODES TESTS
+    // ============================================================================
+
+    #[test]
+    fn test_error_types_exist() {
+        let _error = Error::NotInitialized;
+        let _error = Error::AlreadyInitialized;
+        let _error = Error::InvalidThreshold;
+        let _error = Error::NotSigner;
+        let _error = Error::ProposalNotFound;
+        let _error = Error::NotPending;
+        let _error = Error::TransferFailed;
+        let _error = Error::ConfigNotFound;
+    }
+
+    #[test]
+    fn test_proposal_types_exist() {
+        let _withdrawal = ProposalType::Withdrawal;
+        let _config_change = ProposalType::ConfigChange;
+        let _emergency_halt = ProposalType::EmergencyHalt;
+    }
+
+    #[test]
+    fn test_proposal_status_types() {
+        let _pending = ProposalStatus::Pending;
+        let _approved = ProposalStatus::Approved;
+        let _executed = ProposalStatus::Executed;
+        let _rejected = ProposalStatus::Rejected;
+        let _expired = ProposalStatus::Expired;
+    }
+
+    #[test]
+    fn test_error_code_values_stable() {
+        assert_eq!(Error::NotInitialized as u32, 1);
+        assert_eq!(Error::ConfigNotFound as u32, 15);
+    }
 }

--- a/tests/integration/healthcare_workflows.rs
+++ b/tests/integration/healthcare_workflows.rs
@@ -20,8 +20,8 @@ fn test_user_registration_workflow() {
     records_client.manage_user(admin, patient, &Role::Patient);
 
     // Verify roles
-    assert_eq!(records_client.get_user_role(doctor), Role::Doctor);
-    assert_eq!(records_client.get_user_role(patient), Role::Patient);
+    assert_eq!(records_client.get_user_role(doctor).unwrap(), Role::Doctor);
+    assert_eq!(records_client.get_user_role(patient).unwrap(), Role::Patient);
 }
 
 #[test]

--- a/tests/utils/contract_fixtures.rs
+++ b/tests/utils/contract_fixtures.rs
@@ -122,7 +122,7 @@ mod tests {
         assert_eq!(fixture.admin, test_env.admin);
 
         let doctor = &test_env.team.doctors[0].address;
-        assert_eq!(fixture.client.get_user_role(doctor), Role::Doctor);
+        assert_eq!(fixture.client.get_user_role(doctor).unwrap(), Role::Doctor);
     }
 
     #[test]


### PR DESCRIPTION
Resolves issue #772. Fixed get_config(), get_proposal(), get_proposal_count(), gnosis_get_threshold(), gnosis_get_owners() in treasury_controller and get_user_role() in medical_records to return Result instead of panicking or returning defaults. Added ConfigNotFound error. Updated all callers. Closes #772.