### PR TITLE
chore(ci): fix pre-existing rustfmt.toml/CI mismatch (#842)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets -- -D warnings
+      # Install nightly rustfmt alongside the project's pinned stable
+      # toolchain (rust-toolchain.toml pins stable 1.92.0). The repo's
+      # `rustfmt.toml` uses options that are only available on nightly
+      # rustfmt (e.g. `imports_granularity`, `format_macro_bodies`), so a
+      # plain `cargo fmt --check` would either be a no-op or emit
+      # "unstable feature" warnings on every run. Running `cargo +nightly fmt`
+      # honours the file's intent without forcing the rest of the workspace
+      # onto nightly. Devs who want to apply the same formatting locally can
+      # run `rustup component add rustfmt --toolchain nightly`.
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: cargo fmt (nightly — honours rustfmt.toml's nightly-only options)
+        run: cargo +nightly fmt --all -- --check
+      - name: cargo clippy (uses project's pinned stable toolchain)
+        run: cargo clippy --all-targets -- -D warnings

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,17 @@
 # Rustfmt configuration for Uzima Contracts
-# Ensures consistent code formatting across the project
-
+# Ensures consistent code formatting across the project.
+#
+# IMPORTANT: several options in this file are only available on nightly
+# rustfmt (e.g. `imports_granularity`, `format_macro_bodies`, parts of the
+# comments/format-macros subsections). The project's `rust-toolchain.toml`
+# pins stable 1.92.0, so dev installs get a stable rustfmt and will print
+# "unstable feature" warnings against this file. CI runs
+# `cargo +nightly fmt --all -- --check` (see `.github/workflows/ci.yml`,
+# the `code-quality` job) so the format check actually applies these
+# rules. If you reformat locally, do so with nightly:
+#   rustup component add rustfmt --toolchain nightly
+#   cargo +nightly fmt
+#
 # Formatting style
 hard_tabs = false
 tab_spaces = 4


### PR DESCRIPTION
## Summary

The `cargo fmt --all -- --check` step on `main` was failing because `rustfmt.toml` enables nightly-only rustfmt options (e.g. `imports_granularity`, `format_macro_bodies`, parts of the comments/format-macros subsections) while `rust-toolchain.toml` pins stable 1.92.0 and CI installs stable rustfmt. Stable rustfmt treats those options as "unstable features" and either ignores them with a warning or rejects them, making the format step non-deterministic.

This change is the smallest possible fix: install nightly rustfmt in the `code-quality` job alongside the pinned stable toolchain, run `cargo +nightly fmt --all -- --check`, and leave clippy on stable. A defensive header comment was added to `rustfmt.toml` so local devs know to use `cargo +nightly fmt` if they want the same formatting applied locally.

## Changes

* **`.github/workflows/ci.yml`** (`code-quality` job):
  * Adds a `dtolnay/rust-toolchain@nightly` step that installs nightly `rustfmt`.
  * Replaces the single `cargo fmt --all -- --check` step with two named steps:
    * `cargo fmt (nightly)` runs `cargo +nightly fmt --all -- --check`.
    * `cargo clippy (uses the projects pinned stable toolchain)` is unchanged.
  * The other CI jobs (`test`, `build`, `doc-coverage`) are untouched.
* **`rustfmt.toml`**:
  * Adds a header comment documenting that the file uses nightly-only options and that CI runs `cargo +nightly fmt` against it.
  * No formatting options are removed or changed.

Diff summary: **2 files, +29 / -4**, surgical.

## Testing

* `python3 -c "yaml.safe_load(open(.../ci.yml))"` — the YAML parses cleanly; both dtolnay/rust-toolchain steps are present plus the two new named fmt/clippy steps.
* `python3 -c "tomllib.loads(open(.../rustfmt.toml).read())"` — `rustfmt.toml` parses with the same key set as before (only the header comment was added).
* CI will run the full pipeline (test, build, code-quality, doc-coverage) on this PR. The `code-quality` job should now succeed because `cargo +nightly fmt --check` will actually apply `rustfmt.toml` rather than rejecting/ignoring its nightly-only options.

## Why not the alternative?

The alternative was to *remove* the nightly-only keys from `rustfmt.toml`. That risks widespread formatting churn across the 700+ files: removing `imports_granularity`, `format_macro_bodies`, etc. forces stable rustfmt to fall back to its defaults, which will almost certainly surface large numbers of `--check` failures on the existing nightly-formatted tree. Without a local `cargo fmt` to apply the new defaults across the workspace, we would stay stuck. Running `cargo +nightly fmt` in CI is the smaller, safer fix.

## Note on the issue number

This PR title references `#842` per the maintainers convention (the issue number in the title is context, not necessarily a `Closes`). Upstream issue `#842` is already tracking an unrelated PR ("real ERC-2771 meta-tx forwarder with Ed25519 sig verify"), so this PR does **not** include `Closes #842` — doing so would risk closing the wrong thread. Merge this PR by hand once CI is green.

## Checklist

* [x] Pre-existing infrastructure issue isolated and fixed
* [x] Surgical diff (2 files, +29/-4)
* [x] YAML + rustfmt.toml validate locally
* [x] No source/diff churn across the 700+ Rust files
* [x] PR title is clear and matches the user-specified format