### PR TITLE
feat: add batch variants for write_record, create_alert, submit_message (#831)

### DIFF
--- a/contracts/anomaly_detector/src/lib.rs
+++ b/contracts/anomaly_detector/src/lib.rs
@@ -95,6 +95,16 @@ pub struct AnomalyModel {
     pub updated_at: u64,
 }
 
+/// Per-alert input for batched alert creation.
+#[derive(Clone)]
+#[contracttype]
+pub struct AlertInput {
+    pub patient: Address,
+    pub model_id: BytesN<32>,
+    pub result: DetectionResult,
+    pub metadata: String,
+}
+
 /// Security alert record
 #[derive(Clone)]
 #[contracttype]
@@ -186,6 +196,7 @@ pub enum Error {
     DuplicateFederatedUpdate = 11,
     InvalidFeatureCount = 12,
     InvalidScore = 13,
+    BatchTooLarge = 14,
 }
 
 // ==================== Contract ====================
@@ -740,6 +751,64 @@ impl AnomalyDetectorContract {
         );
 
         Ok(alert_id)
+    }
+
+    /// Create multiple alerts in a single atomic call.
+    ///
+    /// All-or-nothing semantics: if any alert fails, the entire batch is
+    /// rejected and no alerts are persisted.
+    ///
+    /// ## Limits
+    /// - Max 50 alerts per batch.
+    pub fn create_alert_batch(
+        env: Env,
+        caller: Address,
+        alerts: Vec<AlertInput>,
+    ) -> Result<Vec<u64>, Error> {
+        caller.require_auth();
+        Self::require_authorized(&env, &caller)?;
+        Self::require_not_paused(&env)?;
+
+        let count = alerts.len();
+        if count == 0 || count > 50 {
+            return Err(Error::BatchTooLarge);
+        }
+
+        let mut ids: Vec<u64> = Vec::new(&env);
+        for input in alerts.iter() {
+            let alert_id = Self::next_alert_id(&env);
+            let now = env.ledger().timestamp();
+
+            let alert = Alert {
+                alert_id,
+                patient: input.patient.clone(),
+                triggered_by: caller.clone(),
+                model_id: input.model_id,
+                anomaly_score: input.result.anomaly_score,
+                alert_level: input.result.alert_level,
+                status: AlertStatus::Active,
+                pattern_type: input.result.pattern_type,
+                explanation_summary: input.result.explanation_summary,
+                metadata: input.metadata,
+                created_at: now,
+                updated_at: now,
+            };
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Alert(alert_id), &alert);
+
+            Self::increment_patient_active_alerts(&env, &input.patient);
+
+            env.events().publish(
+                (symbol_short!("AlertCrt"),),
+                (alert_id, input.patient, alert.anomaly_score),
+            );
+
+            ids.push_back(alert_id);
+        }
+
+        Ok(ids)
     }
 
     /// Acknowledge an active alert (marks as reviewed, does not close).

--- a/contracts/anomaly_detector/src/test.rs
+++ b/contracts/anomaly_detector/src/test.rs
@@ -6,7 +6,7 @@ use crate::{
     AlertLevel, AlertStatus, AnomalyDetectorContract, AnomalyDetectorContractClient, Error,
     HealthcarePatternType,
 };
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
 
 // ==================== Helpers ====================
 
@@ -1278,4 +1278,156 @@ fn test_unauthorized_caller_blocked() {
         Err(Ok(e)) => assert_eq!(e, Error::NotAuthorized),
         _ => panic!("expected NotAuthorized error"),
     }
+}
+
+// ==================== Batch Alert Tests ====================
+
+#[test]
+fn test_create_alert_batch_empty_fails() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    env.mock_all_auths();
+    let result = client.try_create_alert_batch(&admin, &Vec::new(&env));
+    assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
+}
+
+#[test]
+fn test_create_alert_batch_single() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let model_id = make_model_id(&env, 80);
+    let patient = Address::generate(&env);
+    register_default_model(&client, &env, &admin, &model_id);
+
+    env.mock_all_auths();
+    let features = soroban_sdk::vec![&env, 9_000u32, 9_000u32, 9_000u32];
+    let names = soroban_sdk::vec![
+        &env,
+        String::from_str(&env, "f1"),
+        String::from_str(&env, "f2"),
+        String::from_str(&env, "f3"),
+    ];
+    let result = client.run_inference(
+        &admin,
+        &patient,
+        &model_id,
+        &features,
+        &names,
+        &String::from_str(&env, "{}"),
+    );
+
+    let input = crate::AlertInput {
+        patient: patient.clone(),
+        model_id: model_id.clone(),
+        result,
+        metadata: String::from_str(&env, r#"{"context":"batch-test"}"#),
+    };
+    let inputs = soroban_sdk::vec![&env, input];
+
+    let ids = client.create_alert_batch(&admin, &inputs);
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids.get(0).unwrap(), 1);
+    assert_eq!(client.get_alert_count(), 1);
+
+    let alert = client.get_alert(&1).unwrap();
+    assert_eq!(alert.patient, patient);
+    assert_eq!(alert.status, AlertStatus::Active);
+}
+
+#[test]
+fn test_create_alert_batch_multiple() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let model_id = make_model_id(&env, 81);
+    let patient1 = Address::generate(&env);
+    let patient2 = Address::generate(&env);
+    register_default_model(&client, &env, &admin, &model_id);
+
+    env.mock_all_auths();
+    let features = soroban_sdk::vec![&env, 7_000u32, 7_000u32, 7_000u32];
+    let names = soroban_sdk::vec![
+        &env,
+        String::from_str(&env, "f1"),
+        String::from_str(&env, "f2"),
+        String::from_str(&env, "f3"),
+    ];
+    let r1 = client.run_inference(
+        &admin,
+        &patient1,
+        &model_id,
+        &features,
+        &names,
+        &String::from_str(&env, "{}"),
+    );
+    let r2 = client.run_inference(
+        &admin,
+        &patient2,
+        &model_id,
+        &features,
+        &names,
+        &String::from_str(&env, "{}"),
+    );
+
+    let mut inputs = Vec::new(&env);
+    inputs.push_back(crate::AlertInput {
+        patient: patient1.clone(),
+        model_id: model_id.clone(),
+        result: r1,
+        metadata: String::from_str(&env, "alert1"),
+    });
+    inputs.push_back(crate::AlertInput {
+        patient: patient2.clone(),
+        model_id: model_id.clone(),
+        result: r2,
+        metadata: String::from_str(&env, "alert2"),
+    });
+
+    let ids = client.create_alert_batch(&admin, &inputs);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(ids.get(0).unwrap(), 1);
+    assert_eq!(ids.get(1).unwrap(), 2);
+    assert_eq!(client.get_alert_count(), 2);
+
+    assert!(client.get_alert(&1).is_some());
+    assert!(client.get_alert(&2).is_some());
+}
+
+#[test]
+fn test_create_alert_batch_too_large() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let model_id = make_model_id(&env, 82);
+    let patient = Address::generate(&env);
+    register_default_model(&client, &env, &admin, &model_id);
+
+    env.mock_all_auths();
+    let features = soroban_sdk::vec![&env, 5_000u32, 5_000u32, 5_000u32];
+    let names = soroban_sdk::vec![
+        &env,
+        String::from_str(&env, "f1"),
+        String::from_str(&env, "f2"),
+        String::from_str(&env, "f3"),
+    ];
+    let detection = client.run_inference(
+        &admin,
+        &patient,
+        &model_id,
+        &features,
+        &names,
+        &String::from_str(&env, "{}"),
+    );
+
+    let mut inputs = Vec::new(&env);
+    for _ in 0..51 {
+        inputs.push_back(crate::AlertInput {
+            patient: patient.clone(),
+            model_id: model_id.clone(),
+            result: detection.clone(),
+            metadata: String::from_str(&env, "{}"),
+        });
+    }
+
+    let result = client.try_create_alert_batch(&admin, &inputs);
+    assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
 }

--- a/contracts/cross_chain_bridge/src/errors.rs
+++ b/contracts/cross_chain_bridge/src/errors.rs
@@ -17,6 +17,7 @@ pub enum Error {
     InvalidNonce = 281,
     InvalidPayload = 282,
     InvalidAddress = 290,
+    BatchTooLarge = 291,
 
     // --- Lifecycle & State (300–399) ---
     AlreadyInitialized = 301,

--- a/contracts/cross_chain_bridge/src/lib.rs
+++ b/contracts/cross_chain_bridge/src/lib.rs
@@ -662,6 +662,91 @@ impl CrossChainBridgeContract {
         Ok(request.message_id)
     }
 
+    /// Submit multiple cross-chain messages in a single atomic call.
+    ///
+    /// All-or-nothing semantics: if any message fails validation, the entire
+    /// batch is rejected and no messages are persisted.
+    ///
+    /// ## Limits
+    /// - Max 50 messages per batch.
+    pub fn submit_message_batch(
+        env: Env,
+        validator: Address,
+        requests: Vec<SubmitMessageRequest>,
+    ) -> Result<Vec<BytesN<32>>, Error> {
+        validator.require_auth();
+        Self::require_not_paused(&env)?;
+        let v_info = Self::get_active_validator_info(&env, &validator)?;
+
+        let count = requests.len();
+        if count == 0 || count > 50 {
+            return Err(Error::BatchTooLarge);
+        }
+
+        let mut ids: Vec<BytesN<32>> = Vec::new(&env);
+        for request in requests.iter() {
+            Self::require_chain_supported(&env, &request.source_chain)?;
+
+            Self::verify_nonce(&env, &request.sender, request.nonce)?;
+
+            // Cryptographic verification of the submitting validator
+            Self::verify_validator_nonce(&env, &v_info.public_key, request.v_nonce)?;
+            Self::verify_validator_signature(
+                &env,
+                &v_info.public_key,
+                &request.message_id,
+                request.v_nonce,
+                &request.v_signature,
+            )?;
+
+            let timestamp = env.ledger().timestamp();
+
+            let message = CrossChainMessage {
+                message_id: request.message_id.clone(),
+                source_chain: request.source_chain,
+                dest_chain: request.dest_chain,
+                sender: request.sender.clone(),
+                recipient: request.recipient,
+                payload_type: request.payload_type,
+                payload: request.payload,
+                nonce: request.nonce,
+                timestamp,
+                status: MessageStatus::Pending,
+                signature: request.signature,
+            };
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Message(request.message_id.clone()), &message);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Message(request.message_id.clone()),
+                PERSISTENT_TTL_THRESHOLD,
+                PERSISTENT_TTL_EXTEND_TO,
+            );
+
+            Self::update_nonce(&env, &request.sender, request.nonce);
+
+            let count: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::MessageCount)
+                .unwrap_or(0);
+            env.storage().instance().set(
+                &DataKey::MessageCount,
+                &(count.checked_add(1).ok_or(Error::Overflow)?),
+            );
+
+            env.events().publish(
+                (Symbol::new(&env, "MessageSubmitted"),),
+                (request.message_id.clone(), timestamp),
+            );
+
+            ids.push_back(request.message_id.clone());
+        }
+
+        Ok(ids)
+    }
+
     /// Confirm a cross-chain message (validator attestation)
     /// BUG FIX: Confirmations now stored per message_id (was using shared "conf_key")
     pub fn confirm_message(

--- a/contracts/cross_chain_bridge/src/test.rs
+++ b/contracts/cross_chain_bridge/src/test.rs
@@ -1762,3 +1762,169 @@ fn test_chaos_oracle_offline_mid_consensus() {
     );
     assert_eq!(result, Err(Ok(Error::InsufficientOracleReports)));
 }
+
+// ==================== Batch Submit Message Tests ====================
+
+#[test]
+fn test_submit_message_batch_empty_fails() {
+    let env = Env::default();
+    let (client, admin, medical, identity, access) = create_contract(&env);
+    initialize_contract(&env, &client, &admin, &medical, &identity, &access);
+    let (validator, _sk) = setup_validator(&env, &client, &admin);
+
+    env.mock_all_auths();
+    let result = client.try_submit_message_batch(&validator, &Vec::new(&env));
+    assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
+}
+
+#[test]
+fn test_submit_message_batch_single() {
+    let env = Env::default();
+    let (client, admin, medical, identity, access) = create_contract(&env);
+    initialize_contract(&env, &client, &admin, &medical, &identity, &access);
+    let (validator, sk) = setup_validator(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+
+    let message_id = generate_message_id(&env);
+    let sender = String::from_str(&env, "0xsender");
+    let payload = String::from_str(&env, "{}");
+
+    env.mock_all_auths();
+    let v_sig = create_sig(&env, &sk, &message_id, 1);
+    let request = SubmitMessageRequest {
+        message_id: message_id.clone(),
+        source_chain: ChainId::Ethereum,
+        dest_chain: ChainId::Stellar,
+        sender: sender.clone(),
+        recipient: recipient.clone(),
+        payload_type: MessageType::RecordRequest,
+        payload: payload.clone(),
+        nonce: 1,
+        signature: dummy_sig(&env),
+        v_signature: v_sig,
+        v_nonce: 1,
+    };
+
+    let ids = client.submit_message_batch(&validator, &soroban_sdk::vec![&env, request]);
+    assert_eq!(ids.len(), 1);
+    assert_eq!(ids.get(0).unwrap(), message_id);
+    assert_eq!(client.get_message_count(), 1);
+
+    let msg = client.get_message(&message_id).unwrap();
+    assert_eq!(msg.status, MessageStatus::Pending);
+}
+
+#[test]
+fn test_submit_message_batch_multiple() {
+    let env = Env::default();
+    let (client, admin, medical, identity, access) = create_contract(&env);
+    initialize_contract(&env, &client, &admin, &medical, &identity, &access);
+    let (validator, sk) = setup_validator(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+    let sender = String::from_str(&env, "0xsender");
+
+    env.mock_all_auths();
+    let id1 = BytesN::from_array(&env, &[0x01; 32]);
+    let id2 = BytesN::from_array(&env, &[0x02; 32]);
+
+    let v_sig1 = create_sig(&env, &sk, &id1, 1);
+    let v_sig2 = create_sig(&env, &sk, &id2, 2);
+
+    let req1 = SubmitMessageRequest {
+        message_id: id1.clone(),
+        source_chain: ChainId::Ethereum,
+        dest_chain: ChainId::Stellar,
+        sender: sender.clone(),
+        recipient: recipient.clone(),
+        payload_type: MessageType::RecordRequest,
+        payload: String::from_str(&env, "{}"),
+        nonce: 1,
+        signature: dummy_sig(&env),
+        v_signature: v_sig1,
+        v_nonce: 1,
+    };
+    let req2 = SubmitMessageRequest {
+        message_id: id2.clone(),
+        source_chain: ChainId::Polygon,
+        dest_chain: ChainId::Stellar,
+        sender: sender.clone(),
+        recipient: recipient.clone(),
+        payload_type: MessageType::RecordResponse,
+        payload: String::from_str(&env, r#"{"data":"test"}"#),
+        nonce: 2,
+        signature: dummy_sig(&env),
+        v_signature: v_sig2,
+        v_nonce: 2,
+    };
+
+    let ids = client.submit_message_batch(&validator, &soroban_sdk::vec![&env, req1, req2]);
+    assert_eq!(ids.len(), 2);
+    assert_eq!(client.get_message_count(), 2);
+
+    assert!(client.get_message(&id1).is_some());
+    assert!(client.get_message(&id2).is_some());
+}
+
+#[test]
+fn test_submit_message_batch_too_large() {
+    let env = Env::default();
+    let (client, admin, medical, identity, access) = create_contract(&env);
+    initialize_contract(&env, &client, &admin, &medical, &identity, &access);
+    let (validator, sk) = setup_validator(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+    let sender = String::from_str(&env, "0xsender");
+
+    env.mock_all_auths();
+    let mut requests = Vec::new(&env);
+    for i in 0..51 {
+        let mid = BytesN::from_array(&env, &[i as u8; 32]);
+        let v_sig = create_sig(&env, &sk, &mid, i as u64 + 1);
+        requests.push_back(SubmitMessageRequest {
+            message_id: mid,
+            source_chain: ChainId::Ethereum,
+            dest_chain: ChainId::Stellar,
+            sender: sender.clone(),
+            recipient: recipient.clone(),
+            payload_type: MessageType::RecordRequest,
+            payload: String::from_str(&env, "{}"),
+            nonce: i as u64 + 1,
+            signature: dummy_sig(&env),
+            v_signature: v_sig,
+            v_nonce: i as u64 + 1,
+        });
+    }
+
+    let result = client.try_submit_message_batch(&validator, &requests);
+    assert_eq!(result, Err(Ok(Error::BatchTooLarge)));
+}
+
+#[test]
+fn test_submit_message_batch_rejects_invalid_chain() {
+    let env = Env::default();
+    let (client, admin, medical, identity, access) = create_contract(&env);
+    initialize_contract(&env, &client, &admin, &medical, &identity, &access);
+    let (validator, sk) = setup_validator(&env, &client, &admin);
+    let recipient = Address::generate(&env);
+    let sender = String::from_str(&env, "0xsender");
+
+    let mid = generate_message_id(&env);
+    let v_sig = create_sig(&env, &sk, &mid, 1);
+
+    env.mock_all_auths();
+    let request = SubmitMessageRequest {
+        message_id: mid,
+        source_chain: ChainId::BinanceSmartChain,
+        dest_chain: ChainId::Stellar,
+        sender,
+        recipient,
+        payload_type: MessageType::RecordRequest,
+        payload: String::from_str(&env, "{}"),
+        nonce: 1,
+        signature: dummy_sig(&env),
+        v_signature: v_sig,
+        v_nonce: 1,
+    };
+
+    let result = client.try_submit_message_batch(&validator, &soroban_sdk::vec![&env, request]);
+    assert_eq!(result, Err(Ok(Error::ChainNotSupported)));
+}

--- a/contracts/medical_records/src/lib.rs
+++ b/contracts/medical_records/src/lib.rs
@@ -621,7 +621,23 @@ pub enum DataKey {
 // ==================== Errors ====================
 // NOTE: `Error` lives in `errors.rs` and is re-exported above.
 
-// ==================== Batch (Optional) ====================
+// ==================== Batch Types ====================
+
+/// Per-record input for batched record creation.
+/// Same fields as `write_record` minus `caller` (passed at batch level).
+#[derive(Clone)]
+#[contracttype]
+pub struct RecordInput {
+    pub patient: Address,
+    pub diagnosis: String,
+    pub treatment: String,
+    pub is_confidential: bool,
+    pub tags: Vec<String>,
+    pub category: String,
+    pub treatment_type: String,
+    pub data_ref: String,
+    pub traditional_metadata: Option<TraditionalMedicineMetadata>,
+}
 
 #[derive(Clone)]
 #[contracttype]
@@ -1718,54 +1734,20 @@ impl MedicalRecordsContract {
         }
         Self::check_and_update_rate_limit(&env, &caller, OP_ADD_RECORD)?;
 
-        // Validate inputs
-        if Self::is_patient_forgotten(&env, &patient) {
-            Self::log_warning(
-                &env,
-                "add_record",
-                Some(&caller),
-                Some(&patient),
-                None,
-                "Record creation denied because patient is marked as forgotten",
-            );
-            return Err(Error::Unauthorized);
-        }
-        validation::validate_diagnosis(&diagnosis)?;
-        validation::validate_treatment(&treatment)?;
-        validation::validate_tags(&tags)?;
-        validation::validate_category(&category, &env)?;
-        validation::validate_treatment_type(&treatment_type)?;
-        validation::validate_data_ref(&env, &data_ref)?;
-        validation::validate_addresses_different(&caller, &patient)?;
-
-        let record_id = Self::next_id(&env);
-        let record = MedicalRecord {
-            patient_id: patient.clone(),
-            doctor_id: caller.clone(),
-            timestamp: env.ledger().timestamp(),
-            diagnosis,
-            treatment,
-            is_confidential,
-            tags: tags.clone(),
-            category: category.clone(),
-            treatment_type,
-            data_ref,
-            doctor_did: None,
-        };
-
-        Self::store_record(&env, record_id, &record, &category, is_confidential);
-        Self::append_patient_record(&env, &patient, record_id);
-        Self::increment_record_count(&env);
-
-        events::emit_record_created(
+        let record_id = Self::write_record_internal(
             &env,
-            caller.clone(),
-            record_id,
-            patient.clone(),
+            &caller,
+            &patient,
+            &diagnosis,
+            &treatment,
             is_confidential,
-            category.clone(),
-            tags.clone(),
-        );
+            &tags,
+            &category,
+            &treatment_type,
+            &data_ref,
+            &None,
+        )?;
+
         Self::log_info(
             &env,
             "add_record",
@@ -1828,84 +1810,20 @@ impl MedicalRecordsContract {
         }
         Self::check_and_update_rate_limit(&env, &caller, OP_ADD_RECORD)?;
 
-        if Self::is_patient_forgotten(&env, &patient) {
-            Self::log_warning(
-                &env,
-                "write_record",
-                Some(&caller),
-                Some(&patient),
-                None,
-                "Record creation denied because patient is marked as forgotten",
-            );
-            return Err(Error::Unauthorized);
-        }
-        validation::validate_diagnosis(&diagnosis)?;
-        validation::validate_treatment(&treatment)?;
-        validation::validate_tags(&tags)?;
-        validation::validate_category(&category, &env)?;
-        validation::validate_treatment_type(&treatment_type)?;
-        validation::validate_data_ref(&env, &data_ref)?;
-        validation::validate_addresses_different(&caller, &patient)?;
-
-        let record_id = Self::next_id(&env);
-        let record = MedicalRecord {
-            patient_id: patient.clone(),
-            doctor_id: caller.clone(),
-            timestamp: env.ledger().timestamp(),
-            diagnosis,
-            treatment,
-            is_confidential,
-            tags: tags.clone(),
-            category: category.clone(),
-            treatment_type,
-            data_ref,
-            doctor_did: None,
-        };
-
-        Self::store_record(&env, record_id, &record, &category, is_confidential);
-        Self::append_patient_record(&env, &patient, record_id);
-        Self::increment_record_count(&env);
-
-        // --- Traditional medicine path ---
-        if let Some(meta) = traditional_metadata {
-            let practice_type = meta.practice_type.clone();
-
-            // Persist the metadata encrypted alongside the main record.
-            // The metadata struct is stored under the TraditionalMeta key; callers are
-            // expected to further encrypt `remedies_used` off-chain before passing it in.
-            env.storage()
-                .persistent()
-                .set(&DataKey::TraditionalMeta(record_id), &meta);
-
-            // Append to the per-patient traditional records index.
-            let idx_key = DataKey::PatientTraditionalRecords(patient.clone());
-            let mut trad_ids: Vec<u64> = env
-                .storage()
-                .persistent()
-                .get(&idx_key)
-                .unwrap_or(Vec::new(&env));
-            trad_ids.push_back(record_id);
-            env.storage().persistent().set(&idx_key, &trad_ids);
-
-            // Emit non-sensitive event (only practice_type, never remedies).
-            events::emit_traditional_record_added(
-                &env,
-                caller.clone(),
-                record_id,
-                patient.clone(),
-                practice_type,
-            );
-        }
-
-        events::emit_record_created(
+        let record_id = Self::write_record_internal(
             &env,
-            caller.clone(),
-            record_id,
-            patient.clone(),
+            &caller,
+            &patient,
+            &diagnosis,
+            &treatment,
             is_confidential,
-            category.clone(),
-            tags.clone(),
-        );
+            &tags,
+            &category,
+            &treatment_type,
+            &data_ref,
+            &traditional_metadata,
+        )?;
+
         Self::log_info(
             &env,
             "write_record",
@@ -1915,6 +1833,80 @@ impl MedicalRecordsContract {
             "Medical record written (write_record)",
         );
         Ok(record_id)
+    }
+
+    /// Create multiple medical records in a single atomic call.
+    ///
+    /// All-or-nothing semantics: if any record fails validation, the entire
+    /// batch is rejected and no records are persisted.
+    ///
+    /// ## Limits
+    /// - Max 50 records per batch.
+    pub fn write_record_batch(
+        env: Env,
+        caller: Address,
+        records: Vec<RecordInput>,
+    ) -> Result<Vec<u64>, Error> {
+        caller.require_auth();
+        Self::require_initialized(&env)?;
+        Self::require_not_paused(&env)?;
+        if Self::is_encryption_required_internal(&env) {
+            Self::log_error(
+                &env,
+                "write_record_batch",
+                Some(&caller),
+                None,
+                None,
+                "Batch record creation blocked because encrypted record flow is enforced",
+            );
+            return Err(Error::EncryptionRequired);
+        }
+
+        if !Self::check_permission(&env, &caller, Permission::CreateRecord) {
+            Self::log_error(
+                &env,
+                "write_record_batch",
+                Some(&caller),
+                None,
+                None,
+                "Batch record creation denied: caller lacks CreateRecord permission",
+            );
+            return Err(Error::Unauthorized);
+        }
+        Self::check_and_update_rate_limit(&env, &caller, OP_ADD_RECORD)?;
+
+        let count = records.len();
+        if count == 0 || count > 50 {
+            return Err(Error::BatchTooLarge);
+        }
+
+        let mut ids: Vec<u64> = Vec::new(&env);
+        for input in records.iter() {
+            let id = Self::write_record_internal(
+                &env,
+                &caller,
+                &input.patient,
+                &input.diagnosis,
+                &input.treatment,
+                input.is_confidential,
+                &input.tags,
+                &input.category,
+                &input.treatment_type,
+                &input.data_ref,
+                &input.traditional_metadata,
+            )?;
+            ids.push_back(id);
+        }
+
+        Self::log_info(
+            &env,
+            "write_record_batch",
+            Some(&caller),
+            None,
+            None,
+            "Batch record write completed",
+        );
+        Ok(ids)
     }
 
     /// Return the record IDs of all traditional-medicine records for a patient.
@@ -4966,6 +4958,97 @@ impl MedicalRecordsContract {
     // ---------------------------------------------------------------------
     // Internal helpers
     // ---------------------------------------------------------------------
+
+    /// Core per-record creation logic shared by `add_record`, `write_record`,
+    /// and `write_record_batch`.  Handles per-item validation, storage, and
+    /// event emission.  Callers are responsible for outer auth / init / paused /
+    /// permission / rate-limit checks.
+    fn write_record_internal(
+        env: &Env,
+        caller: &Address,
+        patient: &Address,
+        diagnosis: &String,
+        treatment: &String,
+        is_confidential: bool,
+        tags: &Vec<String>,
+        category: &String,
+        treatment_type: &String,
+        data_ref: &String,
+        traditional_metadata: &Option<TraditionalMedicineMetadata>,
+    ) -> Result<u64, Error> {
+        if Self::is_patient_forgotten(env, patient) {
+            Self::log_warning(
+                env,
+                "write_record_internal",
+                Some(caller),
+                Some(patient),
+                None,
+                "Record creation denied because patient is marked as forgotten",
+            );
+            return Err(Error::Unauthorized);
+        }
+        validation::validate_diagnosis(diagnosis)?;
+        validation::validate_treatment(treatment)?;
+        validation::validate_tags(tags)?;
+        validation::validate_category(category, env)?;
+        validation::validate_treatment_type(treatment_type)?;
+        validation::validate_data_ref(env, data_ref)?;
+        validation::validate_addresses_different(caller, patient)?;
+
+        let record_id = Self::next_id(env);
+        let record = MedicalRecord {
+            patient_id: patient.clone(),
+            doctor_id: caller.clone(),
+            timestamp: env.ledger().timestamp(),
+            diagnosis: diagnosis.clone(),
+            treatment: treatment.clone(),
+            is_confidential,
+            tags: tags.clone(),
+            category: category.clone(),
+            treatment_type: treatment_type.clone(),
+            data_ref: data_ref.clone(),
+            doctor_did: None,
+        };
+
+        Self::store_record(env, record_id, &record, category, is_confidential);
+        Self::append_patient_record(env, patient, record_id);
+        Self::increment_record_count(env);
+
+        // --- Traditional medicine metadata ---
+        if let Some(meta) = traditional_metadata {
+            let practice_type = meta.practice_type.clone();
+            env.storage()
+                .persistent()
+                .set(&DataKey::TraditionalMeta(record_id), meta);
+            let idx_key = DataKey::PatientTraditionalRecords(patient.clone());
+            let mut trad_ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&idx_key)
+                .unwrap_or(Vec::new(env));
+            trad_ids.push_back(record_id);
+            env.storage().persistent().set(&idx_key, &trad_ids);
+            events::emit_traditional_record_added(
+                env,
+                caller.clone(),
+                record_id,
+                patient.clone(),
+                practice_type,
+            );
+        }
+
+        events::emit_record_created(
+            env,
+            caller.clone(),
+            record_id,
+            patient.clone(),
+            is_confidential,
+            category.clone(),
+            tags.clone(),
+        );
+
+        Ok(record_id)
+    }
 
     fn require_initialized(env: &Env) -> Result<(), Error> {
         if env.storage().instance().has(&UPGRADE_ADMIN) {

--- a/docs/REFACTORING_SUGGESTIONS.md
+++ b/docs/REFACTORING_SUGGESTIONS.md
@@ -72,6 +72,37 @@ Known candidates (from last audit):
 
 - **Batch operations**: High-frequency callers (e.g., bulk record ingestion) would benefit from batch variants of `write_record`, `create_alert`, and `submit_message`.
 
+  **Implementation (issue #831):** All three contracts now expose batch variants with a shared pattern:
+
+  | Contract | Batch Function | Input Type | Output Type |
+  |---|---|---|---|
+  | `medical_records` | `write_record_batch` | `Vec<RecordInput>` | `Result<Vec<u64>, Error>` |
+  | `anomaly_detector` | `create_alert_batch` | `Vec<AlertInput>` | `Result<Vec<u64>, Error>` |
+  | `cross_chain_bridge` | `submit_message_batch` | `Vec<SubmitMessageRequest>` | `Result<Vec<BytesN<32>>, Error>` |
+
+  **Pattern:**
+  - All-or-nothing semantics — if any item fails validation, the entire batch is rejected (no partial commits).
+  - Max 50 items per batch (enforced by `BatchTooLarge` error at position 0).
+  - Outer auth/init/paused/permission checks are done once at the batch level.
+  - Per-item validation and storage reuse the same internal helpers as the single-item variants (e.g., `write_record_internal`).
+  - Single-item functions (`write_record`, `add_record`) were refactored to delegate to the same internal helper, eliminating code duplication.
+
+  **Error variants added:**
+  - `cross_chain_bridge`: `BatchTooLarge = 291`
+  - `anomaly_detector`: `BatchTooLarge = 14`
+  - `medical_records`: already had `BatchTooLarge = 1208` and `InvalidBatch = 1292`
+
+  **Gas estimate (Soroban, approximate):**
+  - Each batch item incurs the same storage cost as a single-item call (one `persistent::set` + event emission).
+  - Batch overhead per call: ~1 ledger entry for the outer checks (negligible).
+  - Total cost = overhead + (N × per-item cost). For N = 50, batch saves ~49× the overhead of repeated auth/init/paused checks.
+  - Precise gas figures require Soroban simulation; the above is a structural estimate.
+
+  **Test coverage:**
+  - `anomaly_detector`: 4 new tests — empty batch, single, multiple, oversized (43 total, +4).
+  - `cross_chain_bridge`: 5 new tests — empty batch, single, multiple, oversized, invalid chain (57 total, +5).
+  - `medical_records`: test suite blocked by pre-existing SDK compatibility issue (issue #828).
+
 ## CI/CD Integration
 
 Add the following step to `.github/workflows/ci.yml` to generate a refactoring report on every PR:


### PR DESCRIPTION
## Summary

Implements batch variants for `write_record`, `create_alert`, and `submit_message` across three contracts, preserving atomicity and reusing existing validation + storage logic.

## Changes

### medical_records
- Added `RecordInput` struct for per-record batch input
- Extracted `write_record_internal` — shared validation + storage helper
- Refactored `add_record` and `write_record` to delegate to the helper
- Added `write_record_batch(env, caller, records: Vec<RecordInput>) -> Result<Vec<u64>, Error>`

### anomaly_detector
- Added `AlertInput` struct
- Added `BatchTooLarge = 14` error variant
- Added `create_alert_batch(env, caller, alerts: Vec<AlertInput>) -> Result<Vec<u64>, Error>`

### cross_chain_bridge
- Added `BatchTooLarge = 291` error variant
- Added `submit_message_batch(env, validator, requests: Vec<SubmitMessageRequest>) -> Result<Vec<BytesN<32>>, Error>`

### docs
- Updated `REFACTORING_SUGGESTIONS.md` with batch API surface, pattern, and gas estimates

## Design
- All-or-nothing semantics: any item failure rejects entire batch
- Max 50 items per batch (enforced via `BatchTooLarge`)
- Outer auth/init/paused/permission checks done once at batch level
- Per-item logic reuses existing internal helpers

## Testing
- `anomaly_detector`: 43 tests pass (39 existing + 4 new batch tests)
- `cross_chain_bridge`: 57 tests pass (52 existing + 5 new batch tests)
- `medical_records`: pre-existing SDK issue (#828) blocks compilation

Closes #831