### PR TITLE
ci: add wasm size regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   # ============================================================================
   # Tests
@@ -38,6 +43,92 @@ jobs:
         # contracts not yet compatible with the pinned soroban-sdk, see
         # Cargo.toml "Issue #828 audit" comment) is respected automatically.
         run: cargo build --workspace --target wasm32-unknown-unknown --release
+      - name: Collect wasm artifacts
+        run: |
+          set -euo pipefail
+          rm -rf dist reports
+          mkdir -p dist reports
+          shopt -s nullglob
+          for wasm_file in target/wasm32-unknown-unknown/release/*.wasm; do
+            contract_name="$(basename "$wasm_file" .wasm)"
+            if [ "$contract_name" = "load_testing" ]; then
+              echo "Skipping known oversized test contract: $contract_name"
+              continue
+            fi
+            cp "$wasm_file" "dist/$contract_name.wasm"
+          done
+          if ! compgen -G "dist/*.wasm" > /dev/null; then
+            echo "No wasm artifacts were collected from target/wasm32-unknown-unknown/release"
+            exit 1
+          fi
+      - name: Resolve wasm size baseline
+        run: |
+          set -euo pipefail
+          baseline_path="reports/wasm_size_baselines.base.json"
+          cp scripts/wasm_size_baselines.json "$baseline_path"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" \
+              && git show "origin/${{ github.base_ref }}:scripts/wasm_size_baselines.json" > "$baseline_path" 2>/dev/null; then
+              echo "Using wasm size baseline from origin/${{ github.base_ref }}"
+            else
+              echo "Base branch baseline unavailable; using checked-out baseline file"
+              cp scripts/wasm_size_baselines.json "$baseline_path"
+            fi
+          fi
+      - name: Monitor wasm sizes
+        run: bash ./scripts/wasm_size_monitor.sh --baseline reports/wasm_size_baselines.base.json
+      - name: Upload wasm size report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-size-report
+          path: reports/wasm_size_report.md
+      - name: Comment PR with wasm size summary
+        if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'reports/wasm_size_report.md';
+            if (!fs.existsSync(path)) {
+              core.warning('wasm-size report not found at ' + path);
+              return;
+            }
+            const report = fs.readFileSync(path, 'utf8');
+            const status = (report.match(/^WASM_SIZE_STATUS=(\w+)\s*$/m) || [])[1] || 'unknown';
+            const emoji = status === 'passed' ? ':white_check_mark:' : ':x:';
+            const marker = '<!-- wasm-size-report -->';
+            const body = [
+              marker,
+              '### ' + emoji + ' WASM Size Report',
+              '',
+              report,
+            ].join('\n');
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            const previous = comments.data.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body
+              });
+            }
       - name: Verify #![no_std] attribute
         # Skip directories that are in the workspace `[workspace] exclude = [...]`
         # list (Cargo.toml) so deferred contracts do not gate CI on lint-style

--- a/docs/WASM_SIZE_MONITORING.md
+++ b/docs/WASM_SIZE_MONITORING.md
@@ -1,294 +1,90 @@
-# WASM Size Monitoring System
+# WASM Size Monitoring
 
-## Overview
+This repository gates contract WASM growth in CI so deployment-size regressions are caught before they reach `main`.
 
-This document describes the WASM size monitoring system implemented for Stellar smart contracts to prevent deployment failures due to size limitations.
+## CI Behavior
 
-## Stellar Limits
+The `Build (wasm32)` job in `.github/workflows/ci.yml` runs:
 
-- **Max contract size**: 64KB (65,536 bytes)
-- **Max transaction size**: 64KB (65,536 bytes)
-- **Warning threshold**: 80% (51.2KB)
-- **Critical threshold**: 95% (61.4KB)
+1. `cargo build --workspace --target wasm32-unknown-unknown --release`
+2. A collection step that copies `target/wasm32-unknown-unknown/release/*.wasm` into `dist/`
+3. A baseline-resolution step that uses the base branch copy of `scripts/wasm_size_baselines.json` for pull requests
+4. `bash ./scripts/wasm_size_monitor.sh --baseline reports/wasm_size_baselines.base.json`
+5. Upload of `reports/wasm_size_report.md`
+6. A pull request comment with the report table and delta against the base branch baseline
 
-## Features
+The `load_testing` contract is excluded because it is a known non-deployable test contract that exceeds the deployment-size budget.
 
-### 1. Real-time Size Monitoring
-- Tracks WASM file sizes for all contracts
-- Provides color-coded status indicators
-- Shows percentage of Stellar limit usage
+## Gates
 
-### 2. Trend Analysis
-- Maintains historical size data
-- Shows size trends over builds
-- Identifies growth patterns
+`scripts/wasm_size_monitor.sh` fails the job when any non-excluded contract:
 
-### 3. Optimization Recommendations
-- Provides targeted optimization tips based on size ranges
-- Suggests specific actions for different size categories
-- Links to helpful tools and resources
+- exceeds its committed baseline by more than 10%
+- exceeds the 60 KiB warning threshold
 
-### 4. CI Integration
-- Automated size checks in CI pipeline
-- Fails builds on critical size violations
-- Uploads trend data as artifacts
+The script writes `WASM_SIZE_STATUS=passed` or `WASM_SIZE_STATUS=failed` into `reports/wasm_size_report.md`. The PR comment step reads that stable token and updates a single bot-authored WASM report comment on each workflow rerun.
 
-## Usage
+Contracts without a baseline are still checked against the 60 KiB warning threshold and are marked `NO_BASELINE` in the report. Run `--update` after a clean `main` build to add or refresh their baseline entries.
 
-### Command Line
+On pull requests, CI compares against the baseline file from the target branch when it exists. That prevents a feature branch from hiding a regression by updating its own baseline in the same PR.
 
-#### Full Monitoring with Trends
-```bash
-# Build contracts and monitor sizes
-make monitor-wasm
+## Baseline File
 
-# Or run the script directly
-./scripts/wasm_size_monitor.sh
-```
-
-#### Quick Size Check
-```bash
-# Fast size check without trend analysis
-make check-wasm-size
-```
-
-#### Export Trend Data
-```bash
-# Export trend data as JSON
-./scripts/wasm_size_monitor.sh --export-trends
-```
-
-### CI Pipeline
-
-The monitoring system is integrated into the CI pipeline:
-
-```yaml
-- name: Monitor WASM sizes
-  run: |
-    echo "=== WASM Size Monitoring ==="
-    ./scripts/wasm_size_monitor.sh
-```
-
-## Output Format
-
-### Status Indicators
-
-- **GREEN** (`OK`): Contract within safe limits (< 80%)
-- **YELLOW** (`WARNING`): Contract approaching limit (80-95%)
-- **RED** (`CRITICAL`): Contract exceeds safe limit (> 95%)
-
-### Example Output
-
-```
-=== WASM Size Monitor ===
-Stellar contract size limit: 64KB
-Warning threshold: 80%
-Critical threshold: 95%
-
-=== Contract Size Analysis ===
-Contract                  Size   Usage Status
---------                  ----   ----- ------
-aml_contract              45KB   69.5% WARNING
-  Trend: +2.3% over last 5 builds
-  Optimization recommendations:
-    - Review error message sizes
-    - Use more efficient data structures
-    - Remove debug code and assertions
-    - Optimize serialization formats
-
-audit_contract            28KB   43.2% OK
-  Trend: Stable over last 5 builds
-
-=== WASM Size Summary ===
-Total contracts: 2
-Total size: 73KB
-Average size: 36KB
-Warning contracts: 1
-
-=== Recommendations ===
-1. Run 'cargo install cargo-bloat' to analyze large functions
-2. Use 'cargo build --target wasm32-unknown-unknown --release' for optimized builds
-3. Consider splitting large contracts into smaller ones
-4. Review dependencies and remove unused ones
-```
-
-## Trend Tracking
-
-The system maintains trend data in `.wasm_size_trends.json`:
+Baselines live in `scripts/wasm_size_baselines.json`.
 
 ```json
 {
-  "contracts": {
-    "aml_contract": {
-      "size_history": [
-        {"size": 44236, "timestamp": "2024-01-15T10:30:00Z"},
-        {"size": 45012, "timestamp": "2024-01-15T11:15:00Z"}
-      ],
-      "current_size": 45012,
-      "last_updated": "2024-01-15T11:15:00Z"
-    }
+  "schemaVersion": 1,
+  "limits": {
+    "maxBytes": 65536,
+    "warningBytes": 61440,
+    "regressionPercent": 10.0
   },
-  "last_updated": "2024-01-15T11:15:00Z"
+  "excludedContracts": ["load_testing"],
+  "contracts": {
+    "medical_records": 48231
+  }
 }
 ```
 
-## Optimization Strategies
+The `contracts` object maps contract artifact names, without the `.wasm` suffix, to byte counts generated from `dist/*.wasm`.
 
-### For 50-60KB Contracts
-- Remove unused dependencies and features
-- Use cargo-bloat to identify large functions
-- Consider splitting contract into multiple contracts
-- Optimize string operations and reduce allocations
+## Local Usage
 
-### For 40-50KB Contracts
-- Review error message sizes
-- Use more efficient data structures
-- Remove debug code and assertions
-- Optimize serialization formats
-
-### For 30-40KB Contracts
-- Use feature flags for optional functionality
-- Review and optimize imports
-- Consider using no_std when possible
-- Optimize enum representations
-
-## Tools and Utilities
-
-### cargo-bloat
-Install and use cargo-bloat to analyze what's contributing to WASM size:
+Build the WASM artifacts and run the gate:
 
 ```bash
-cargo install cargo-bloat
-cargo bloat --target wasm32-unknown-unknown --release --crates
+cargo build --workspace --target wasm32-unknown-unknown --release
+rm -rf dist reports
+mkdir -p dist reports
+cp target/wasm32-unknown-unknown/release/*.wasm dist/
+bash ./scripts/wasm_size_monitor.sh
 ```
 
-### wasm-opt
-Use wasm-opt from Binaryen for additional optimizations:
+Regenerate the baseline after intentionally accepted size changes on a clean `main` build:
 
 ```bash
-# Install Binaryen
-# macOS: brew install binaryen
-# Ubuntu: sudo apt-get install binaryen
-
-# Optimize WASM
-wasm-opt -Oz input.wasm -o output.wasm
+bash ./scripts/wasm_size_monitor.sh --update
 ```
 
-### Size Analysis Commands
-```bash
-# Check individual contract size
-wc -c dist/contract_name.wasm
-
-# Find largest contracts
-ls -lh dist/*.wasm | sort -k5 -hr
-
-# Analyze WASM sections
-wasm-objdump -h dist/contract_name.wasm
-```
-
-## Configuration
-
-### Thresholds
-Modify thresholds in `scripts/wasm_size_monitor.sh`:
+Useful options:
 
 ```bash
-MAX_CONTRACT_SIZE=65536      # 64KB Stellar limit
-WARNING_THRESHOLD=0.8        # 80% warning threshold
-CRITICAL_THRESHOLD=0.95     # 95% critical threshold
+bash ./scripts/wasm_size_monitor.sh --dist dist
+bash ./scripts/wasm_size_monitor.sh --baseline scripts/wasm_size_baselines.json
+bash ./scripts/wasm_size_monitor.sh --report reports/wasm_size_report.md
 ```
 
-### Optimization Tips
-Customize optimization recommendations in `.wasm_optimization_tips.json`.
+The script uses Python 3 for JSON parsing and report generation, so it does not require `jq` or `bc`.
 
-## Troubleshooting
+## Reviewing Regressions
 
-### Common Issues
+When CI fails, open the `wasm-size-report` artifact or the PR comment and check:
 
-1. **Missing Dependencies**
-   ```bash
-   # Install jq and bc
-   sudo apt-get install jq bc  # Ubuntu/Debian
-   brew install jq bc          # macOS
-   ```
+- which contract failed
+- current size
+- baseline size
+- delta percentage
+- whether the failure is the 10% regression gate, the 60 KiB threshold, or both
 
-2. **No WASM Files Found**
-   ```bash
-   # Build contracts first
-   make dist
-   ```
-
-3. **Permission Errors**
-   ```bash
-   # Make script executable
-   chmod +x scripts/wasm_size_monitor.sh
-   ```
-
-### Debug Mode
-Run with debug output:
-
-```bash
-bash -x scripts/wasm_size_monitor.sh
-```
-
-## Integration Examples
-
-### Pre-commit Hook
-```bash
-#!/bin/sh
-# .git/hooks/pre-commit
-make check-wasm-size
-```
-
-### GitHub Actions
-```yaml
-- name: Check WASM Sizes
-  run: |
-    make dist
-    make monitor-wasm
-```
-
-### Docker Integration
-```dockerfile
-RUN apt-get update && apt-get install -y jq bc
-COPY scripts/wasm_size_monitor.sh /usr/local/bin/
-RUN chmod +x /usr/local/bin/wasm_size_monitor.sh
-```
-
-## Best Practices
-
-1. **Monitor Early**: Check sizes frequently during development
-2. **Trend Analysis**: Watch for size creep over time
-3. **Optimization**: Address size issues before they become critical
-4. **Documentation**: Keep size optimization decisions documented
-5. **Testing**: Verify contracts still work after optimization
-
-## Performance Impact
-
-- **Runtime**: Minimal overhead (< 1 second for typical projects)
-- **Storage**: Trend data typically < 10KB for most projects
-- **CI Impact**: Adds ~30 seconds to build time
-
-## Security Considerations
-
-- Trend data files should not contain sensitive information
-- WASM files are analyzed locally, no external services used
-- No network connectivity required for basic monitoring
-
-## Support
-
-For issues with the WASM monitoring system:
-
-1. Check this documentation first
-2. Verify all dependencies are installed
-3. Ensure WASM files are built with `make dist`
-4. Check script permissions on Unix systems
-
-## Future Enhancements
-
-Potential improvements for the monitoring system:
-
-- Graphical trend visualization
-- Integration with code analysis tools
-- Automated optimization suggestions
-- Size impact prediction for code changes
-- Integration with IDE for real-time feedback
+If the size growth is intentional, document the reason in the PR and regenerate the baseline from a clean build. If it is accidental, inspect dependencies, large error strings, serialization code, or other recently added logic before updating the baseline.

--- a/scripts/wasm_size_baselines.json
+++ b/scripts/wasm_size_baselines.json
@@ -1,0 +1,13 @@
+{
+  "contracts": {},
+  "excludedContracts": [
+    "load_testing"
+  ],
+  "generatedBy": "scripts/wasm_size_monitor.sh --update",
+  "limits": {
+    "maxBytes": 65536,
+    "regressionPercent": 10.0,
+    "warningBytes": 61440
+  },
+  "schemaVersion": 1
+}

--- a/scripts/wasm_size_monitor.sh
+++ b/scripts/wasm_size_monitor.sh
@@ -1,385 +1,286 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # WASM Size Monitoring Script for Stellar Contracts
-# Monitors contract WASM sizes against Stellar limits and provides optimization recommendations
+# Checks built .wasm artifacts against committed baselines and Stellar size limits.
 
 set -euo pipefail
 
-# Configuration
-MAX_CONTRACT_SIZE=65536      # 64KB Stellar limit
-WARNING_THRESHOLD=0.8        # 80% warning threshold
-CRITICAL_THRESHOLD=0.95     # 95% critical threshold
-TREND_DATA_FILE=".wasm_size_trends.json"
-OPTIMIZATION_TIPS_FILE=".wasm_optimization_tips.json"
+DIST_DIR="dist"
+BASELINE_FILE="scripts/wasm_size_baselines.json"
+REPORT_FILE="reports/wasm_size_report.md"
+UPDATE_BASELINE=0
+EXPORT_TRENDS=0
+EXCLUDED_CONTRACTS=("load_testing")
 
-# Colors for output
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Logging function
-log() {
-    echo -e "$1"
-}
-
-# Initialize trend data file
-init_trend_data() {
-    if [[ ! -f "$TREND_DATA_FILE" ]]; then
-        echo '{"contracts": {}, "last_updated": "'$(date -Iseconds)'"}' > "$TREND_DATA_FILE"
-    fi
-}
-
-# Initialize optimization tips file
-init_optimization_tips() {
-    if [[ ! -f "$OPTIMIZATION_TIPS_FILE" ]]; then
-        cat > "$OPTIMIZATION_TIPS_FILE" << 'EOF'
-{
-  "tips": [
-    {
-      "size_range": "50-60KB",
-      "recommendations": [
-        "Remove unused dependencies and features",
-        "Use cargo-bloat to identify large functions",
-        "Consider splitting contract into multiple contracts",
-        "Optimize string operations and reduce allocations"
-      ]
-    },
-    {
-      "size_range": "40-50KB", 
-      "recommendations": [
-        "Review error message sizes",
-        "Use more efficient data structures",
-        "Remove debug code and assertions",
-        "Optimize serialization formats"
-      ]
-    },
-    {
-      "size_range": "30-40KB",
-      "recommendations": [
-        "Use feature flags for optional functionality",
-        "Review and optimize imports",
-        "Consider using no_std when possible",
-        "Optimize enum representations"
-      ]
-    }
-  ]
-}
-EOF
-    fi
-}
-
-# Get current timestamp
-get_timestamp() {
-    date -Iseconds
-}
-
-# Convert bytes to human readable format
-bytes_to_human() {
-    local bytes=$1
-    if [[ $bytes -ge 65536 ]]; then
-        echo "$(($bytes / 1024))KB"
-    elif [[ $bytes -ge 1024 ]]; then
-        echo "$(($bytes / 1024))KB"
-    else
-        echo "${bytes}B"
-    fi
-}
-
-# Calculate percentage
-calculate_percentage() {
-    local size=$1
-    local max=$2
-    echo "scale=1; $size * 100 / $max" | bc -l
-}
-
-# Get optimization recommendations based on size
-get_optimization_recommendations() {
-    local size=$1
-    local size_kb=$((size / 1024))
-    
-    if [[ $size_kb -ge 50 ]]; then
-        echo "50-60KB"
-    elif [[ $size_kb -ge 40 ]]; then
-        echo "40-50KB"
-    elif [[ $size_kb -ge 30 ]]; then
-        echo "30-40KB"
-    else
-        echo ""
-    fi
-}
-
-# Update trend data
-update_trend_data() {
-    local contract_name=$1
-    local size=$2
-    local timestamp=$(get_timestamp)
-    
-    # Read current data
-    local temp_file=$(mktemp)
-    jq --arg contract "$contract_name" --arg size "$size" --arg timestamp "$timestamp" '
-        .contracts[$contract] = (.contracts[$contract] // {} | 
-            .size_history += [{"size": ($size | tonumber), "timestamp": $timestamp}] |
-            .current_size = ($size | tonumber) |
-            .last_updated = $timestamp
-        ) |
-        .last_updated = $timestamp
-    ' "$TREND_DATA_FILE" > "$temp_file"
-    mv "$temp_file" "$TREND_DATA_FILE"
-}
-
-# Analyze size trend
-analyze_trend() {
-    local contract_name=$1
-    local current_size=$2
-    
-    # Get last 5 measurements
-    local trend_data=$(jq -r --arg contract "$contract_name" '
-        .contracts[$contract].size_history[-5:] // []
-    ' "$TREND_DATA_FILE")
-    
-    if [[ "$trend_data" != "[]" ]]; then
-        local count=$(echo "$trend_data" | jq length)
-        if [[ $count -gt 1 ]]; then
-            local first_size=$(echo "$trend_data" | jq -r '.[0].size')
-            local last_size=$(echo "$trend_data" | jq -r '.[-1].size')
-            local change=$((last_size - first_size))
-            local change_percent=$(echo "scale=1; $change * 100 / $first_size" | bc -l)
-            
-            if [[ $change -gt 0 ]]; then
-                log "${YELLOW}  Trend: +${change_percent}% over last $count builds${NC}"
-            elif [[ $change -lt 0 ]]; then
-                log "${GREEN}  Trend: ${change_percent}% over last $count builds${NC}"
-            else
-                log "${BLUE}  Trend: Stable over last $count builds${NC}"
-            fi
-        fi
-    fi
-}
-
-# Check single contract
-check_contract() {
-    local wasm_file=$1
-    local contract_name=$2
-    
-    if [[ ! -f "$wasm_file" ]]; then
-        log "${RED}  Error: WASM file not found: $wasm_file${NC}"
-        return 1
-    fi
-    
-    local size=$(wc -c < "$wasm_file")
-    local percentage=$(calculate_percentage "$size" "$MAX_CONTRACT_SIZE")
-    local size_human=$(bytes_to_human "$size")
-    
-    # Update trend data
-    update_trend_data "$contract_name" "$size"
-    
-    # Display results
-    printf "%-25s %8s %6s%% " "$contract_name" "$size_human" "$percentage"
-    
-    # Status indicators
-    if [[ $size -gt $((MAX_CONTRACT_SIZE * CRITICAL_THRESHOLD / 100)) ]]; then
-        log "${RED}CRITICAL${NC}"
-        log "${RED}  Risk: Contract will likely fail deployment!${NC}"
-    elif [[ $size -gt $((MAX_CONTRACT_SIZE * WARNING_THRESHOLD / 100)) ]]; then
-        log "${YELLOW}WARNING${NC}"
-        log "${YELLOW}  Risk: Approaching deployment limit${NC}"
-    else
-        log "${GREEN}OK${NC}"
-    fi
-    
-    # Show trend
-    analyze_trend "$contract_name" "$size"
-    
-    # Show optimization recommendations if needed
-    local recommendation_range=$(get_optimization_recommendations "$size")
-    if [[ -n "$recommendation_range" ]]; then
-        local tips=$(jq -r --arg range "$recommendation_range" '
-            .tips[] | select(.size_range == $range) | .recommendations[]
-        ' "$OPTIMIZATION_TIPS_FILE")
-        log "${BLUE}  Optimization recommendations:${NC}"
-        while IFS= read -r tip; do
-            log "${BLUE}    - $tip${NC}"
-        done <<< "$tips"
-    fi
-}
-
-# Generate summary report
-generate_summary() {
-    log "\n${BLUE}=== WASM Size Summary ===${NC}"
-    
-    local total_contracts=0
-    local total_size=0
-    local warning_count=0
-    local critical_count=0
-    
-    for wasm_file in dist/*.wasm; do
-        if [[ -f "$wasm_file" ]]; then
-            local size=$(wc -c < "$wasm_file")
-            local percentage=$(calculate_percentage "$size" "$MAX_CONTRACT_SIZE")
-            total_contracts=$((total_contracts + 1))
-            total_size=$((total_size + size))
-            
-            if [[ $size -gt $((MAX_CONTRACT_SIZE * CRITICAL_THRESHOLD / 100)) ]]; then
-                critical_count=$((critical_count + 1))
-            elif [[ $size -gt $((MAX_CONTRACT_SIZE * WARNING_THRESHOLD / 100)) ]]; then
-                warning_count=$((warning_count + 1))
-            fi
-        fi
-    done
-    
-    log "Total contracts: $total_contracts"
-    log "Total size: $(bytes_to_human $total_size)"
-    log "Average size: $(bytes_to_human $((total_size / total_contracts)))"
-    
-    if [[ $critical_count -gt 0 ]]; then
-        log "${RED}Critical contracts: $critical_count${NC}"
-    fi
-    if [[ $warning_count -gt 0 ]]; then
-        log "${YELLOW}Warning contracts: $warning_count${NC}"
-    fi
-    if [[ $critical_count -eq 0 && $warning_count -eq 0 ]]; then
-        log "${GREEN}All contracts within safe limits${NC}"
-    fi
-}
-
-# Export trend data as JSON
-export_trend_data() {
-    log "\n${BLUE}=== Trend Data Export ===${NC}"
-    jq '.' "$TREND_DATA_FILE"
-}
-
-# Check dependencies
-check_dependencies() {
-    local missing_deps=()
-    
-    if ! command -v jq >/dev/null 2>&1; then
-        missing_deps+=("jq")
-    fi
-    
-    if ! command -v bc >/dev/null 2>&1; then
-        missing_deps+=("bc")
-    fi
-    
-    if [[ ${#missing_deps[@]} -gt 0 ]]; then
-        log "${RED}Error: Missing required dependencies: ${missing_deps[*]}${NC}"
-        log "${YELLOW}Install with: sudo apt-get install jq bc (Ubuntu/Debian)${NC}"
-        log "${YELLOW}Or with: brew install jq bc (macOS)${NC}"
-        exit 1
-    fi
-}
-
-# Main function
-main() {
-    log "${BLUE}=== WASM Size Monitor ===${NC}"
-    log "Stellar contract size limit: $(bytes_to_human $MAX_CONTRACT_SIZE)"
-    log "Warning threshold: $((WARNING_THRESHOLD * 100))%"
-    log "Critical threshold: $((CRITICAL_THRESHOLD * 100))%"
-    
-    # Check dependencies first
-    check_dependencies
-    
-    # Initialize data files
-    init_trend_data
-    init_optimization_tips
-    
-    # Check if dist directory exists
-    if [[ ! -d "dist" ]]; then
-        log "${YELLOW}Warning: dist/ directory not found. Creating it...${NC}"
-        mkdir -p dist
-        log "${YELLOW}No WASM files to monitor. Run 'make dist' first.${NC}"
-        exit 0
-    fi
-    
-    # Check for WASM files
-    local wasm_files=(dist/*.wasm)
-    if [[ ${#wasm_files[@]} -eq 0 || ! -f "${wasm_files[0]}" ]]; then
-        log "${YELLOW}Warning: No WASM files found in dist/. Run 'make dist' first.${NC}"
-        exit 0
-    fi
-    
-    log "\n${BLUE}=== Contract Size Analysis ===${NC}"
-    printf "%-25s %8s %6s %s\n" "Contract" "Size" "Usage" "Status"
-    printf "%-25s %8s %6s %s\n" "--------" "----" "-----" "------"
-    
-    # Check each contract
-    for wasm_file in dist/*.wasm; do
-        if [[ -f "$wasm_file" ]]; then
-            local contract_name=$(basename "$wasm_file" .wasm)
-            check_contract "$wasm_file" "$contract_name"
-        fi
-    done
-    
-    # Generate summary
-    generate_summary
-    
-    # Export trend data if requested
-    if [[ "${1:-}" == "--export-trends" ]]; then
-        export_trend_data
-    fi
-    
-    log "\n${BLUE}=== Recommendations ===${NC}"
-    log "1. Run 'cargo install cargo-bloat' to analyze large functions"
-    log "2. Use 'cargo build --target wasm32-unknown-unknown --release' for optimized builds"
-    log "3. Consider splitting large contracts into smaller ones"
-    log "4. Review dependencies and remove unused ones"
-    
-    # Exit with error code if critical issues found
-    local critical_count=0
-    for wasm_file in dist/*.wasm; do
-        if [[ -f "$wasm_file" ]]; then
-            local size=$(wc -c < "$wasm_file")
-            if [[ $size -gt $((MAX_CONTRACT_SIZE * CRITICAL_THRESHOLD / 100)) ]]; then
-                critical_count=$((critical_count + 1))
-            fi
-        fi
-    done
-    
-    if [[ $critical_count -gt 0 ]]; then
-        log "\n${RED}Critical: $critical_count contracts exceed safe limits${NC}"
-        exit 1
-    else
-        log "\n${GREEN}All contracts pass size checks${NC}"
-        exit 0
-    fi
-}
-
-# Help function
 show_help() {
-    cat << EOF
-Usage: $0 [OPTIONS]
-
-WASM Size Monitoring Script for Stellar Contracts
+    cat <<'EOF'
+Usage: scripts/wasm_size_monitor.sh [OPTIONS]
 
 Options:
-  --export-trends    Export trend data as JSON
-  --help            Show this help message
+  --dist DIR          Directory containing built .wasm files (default: dist)
+  --baseline FILE    Baseline JSON file (default: scripts/wasm_size_baselines.json)
+  --report FILE      Markdown report path (default: reports/wasm_size_report.md)
+  --update           Regenerate the baseline JSON from the current dist directory
+  --export-trends    Backward-compatible alias: print the JSON summary path
+  --help, -h         Show this help message
 
-Examples:
-  $0                    # Check all contracts
-  $0 --export-trends    # Check contracts and export trend data
-
-Requirements:
-  - jq (JSON processor)
-  - bc (calculator)
-  - dist/ directory with WASM files
-
-Stellar Limits:
-  - Max contract size: 64KB
-  - Max transaction size: 64KB
-  - Warning at 80% (51.2KB)
-  - Critical at 95% (61.4KB)
+The gate fails when a non-excluded contract exceeds its baseline by more than
+10% or crosses the 60 KiB warning threshold. The load_testing contract is
+excluded because it is a known non-deployable test contract.
 EOF
 }
 
-# Parse arguments
-case "${1:-}" in
-    --help|-h)
-        show_help
-        exit 0
-        ;;
-    *)
-        main "$@"
-        ;;
-esac
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dist)
+            DIST_DIR="${2:?missing value for --dist}"
+            shift 2
+            ;;
+        --baseline)
+            BASELINE_FILE="${2:?missing value for --baseline}"
+            shift 2
+            ;;
+        --report)
+            REPORT_FILE="${2:?missing value for --report}"
+            shift 2
+            ;;
+        --update)
+            UPDATE_BASELINE=1
+            shift
+            ;;
+        --export-trends)
+            EXPORT_TRENDS=1
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            show_help >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: python3 is required for WASM size monitoring" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$REPORT_FILE")" "$(dirname "$BASELINE_FILE")"
+
+EXCLUDED_JOINED=$(IFS=,; echo "${EXCLUDED_CONTRACTS[*]}")
+export DIST_DIR BASELINE_FILE REPORT_FILE UPDATE_BASELINE EXPORT_TRENDS EXCLUDED_JOINED
+
+python3 <<'PY'
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DIST_DIR = Path(os.environ["DIST_DIR"])
+BASELINE_FILE = Path(os.environ["BASELINE_FILE"])
+REPORT_FILE = Path(os.environ["REPORT_FILE"])
+UPDATE_BASELINE = os.environ["UPDATE_BASELINE"] == "1"
+EXPORT_TRENDS = os.environ["EXPORT_TRENDS"] == "1"
+EXCLUDED = {name for name in os.environ["EXCLUDED_JOINED"].split(",") if name}
+
+MAX_BYTES = 65_536
+WARNING_BYTES = 60 * 1024
+REGRESSION_PERCENT = 10.0
+SCHEMA_VERSION = 1
+
+
+def human_size(size: int) -> str:
+    prefix = "-" if size < 0 else ""
+    value = abs(size)
+    if value >= 1024:
+        return f"{prefix}{value / 1024:.1f} KiB"
+    return f"{prefix}{value} B"
+
+
+def load_baseline() -> dict:
+    if not BASELINE_FILE.exists():
+        return {
+            "schemaVersion": SCHEMA_VERSION,
+            "limits": {
+                "maxBytes": MAX_BYTES,
+                "warningBytes": WARNING_BYTES,
+                "regressionPercent": REGRESSION_PERCENT,
+            },
+            "excludedContracts": sorted(EXCLUDED),
+            "contracts": {},
+        }
+    with BASELINE_FILE.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    data.setdefault("contracts", {})
+    data.setdefault("excludedContracts", sorted(EXCLUDED))
+    data.setdefault("limits", {})
+    return data
+
+
+def discover_wasm_files() -> list[Path]:
+    if not DIST_DIR.exists():
+        return []
+    return sorted(path for path in DIST_DIR.glob("*.wasm") if path.is_file())
+
+
+def write_baseline(sizes: dict[str, int]) -> None:
+    payload = {
+        "schemaVersion": SCHEMA_VERSION,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "generatedBy": "scripts/wasm_size_monitor.sh --update",
+        "limits": {
+            "maxBytes": MAX_BYTES,
+            "warningBytes": WARNING_BYTES,
+            "regressionPercent": REGRESSION_PERCENT,
+        },
+        "excludedContracts": sorted(EXCLUDED),
+        "contracts": dict(sorted(sizes.items())),
+    }
+    BASELINE_FILE.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def format_delta(current: int, baseline: int | None) -> str:
+    if baseline is None:
+        return "new"
+    delta = current - baseline
+    if baseline == 0:
+        pct = 100.0 if current else 0.0
+    else:
+        pct = (delta / baseline) * 100
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{human_size(delta)} ({sign}{pct:.1f}%)"
+
+
+def evaluate_contract(name: str, size: int, baseline: int | None) -> dict:
+    excluded = name in EXCLUDED
+    over_warning = size > WARNING_BYTES
+    over_max = size > MAX_BYTES
+    regression = False
+    regression_pct = 0.0
+    if baseline is not None and baseline > 0:
+        regression_pct = ((size - baseline) / baseline) * 100
+        regression = regression_pct > REGRESSION_PERCENT
+    elif baseline == 0:
+        regression_pct = 100.0 if size else 0.0
+        regression = size > 0
+
+    failures = []
+    if not excluded and over_warning:
+        failures.append("over 60 KiB warning threshold")
+    if not excluded and regression:
+        failures.append(f">{REGRESSION_PERCENT:.0f}% baseline regression")
+
+    if excluded:
+        status = "EXCLUDED"
+    elif failures:
+        status = "FAIL"
+    elif baseline is None:
+        status = "NO_BASELINE"
+    else:
+        status = "OK"
+
+    return {
+        "name": name,
+        "size": size,
+        "baseline": baseline,
+        "delta": format_delta(size, baseline),
+        "status": status,
+        "excluded": excluded,
+        "over_warning": over_warning,
+        "over_max": over_max,
+        "regression_pct": regression_pct,
+        "failures": failures,
+    }
+
+
+def render_report(results: list[dict], baseline_path: Path, dist_path: Path) -> str:
+    failing = [item for item in results if item["failures"]]
+    missing_baseline = [item for item in results if item["status"] == "NO_BASELINE"]
+    lines = [
+        "# WASM Size Report",
+        "",
+        f"WASM_SIZE_STATUS={'failed' if failing else 'passed'}",
+        f"Baseline: `{baseline_path.as_posix()}`",
+        f"Artifact directory: `{dist_path.as_posix()}`",
+        f"Regression gate: > {REGRESSION_PERCENT:.0f}% over baseline",
+        f"Warning gate: > {human_size(WARNING_BYTES)}",
+        f"Excluded contracts: {', '.join(sorted(EXCLUDED)) or 'none'}",
+        "",
+        "| Contract | Size | Baseline | Delta vs baseline | Status |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    if results:
+        for item in results:
+            baseline = "new" if item["baseline"] is None else human_size(item["baseline"])
+            lines.append(
+                f"| `{item['name']}` | {human_size(item['size'])} | {baseline} | {item['delta']} | {item['status']} |"
+            )
+    else:
+        lines.append("| _none_ | - | - | - | NO_WASM |")
+
+    lines.append("")
+    if failing:
+        lines.append("## Regression Failures")
+        lines.append("")
+        for item in failing:
+            lines.append(f"- `{item['name']}`: {', '.join(item['failures'])}; size {human_size(item['size'])}, delta {item['delta']}.")
+        lines.append("")
+    if missing_baseline:
+        lines.append("## Missing Baselines")
+        lines.append("")
+        lines.append("These contracts were checked against the 60 KiB warning gate but have no committed baseline yet.")
+        for item in missing_baseline:
+            lines.append(f"- `{item['name']}`: {human_size(item['size'])}")
+        lines.append("")
+    lines.append("Regenerate baselines locally with:")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("./scripts/wasm_size_monitor.sh --update")
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+baseline = load_baseline()
+limits = baseline.get("limits", {})
+MAX_BYTES = int(limits.get("maxBytes", MAX_BYTES))
+WARNING_BYTES = int(limits.get("warningBytes", WARNING_BYTES))
+REGRESSION_PERCENT = float(limits.get("regressionPercent", REGRESSION_PERCENT))
+EXCLUDED.update(str(name) for name in baseline.get("excludedContracts", []) if name)
+wasm_files = discover_wasm_files()
+sizes = {path.stem: path.stat().st_size for path in wasm_files if path.stem not in EXCLUDED}
+
+if UPDATE_BASELINE:
+    if not sizes:
+        print(f"No non-excluded WASM files found in {DIST_DIR}; refusing to write an empty baseline.", file=sys.stderr)
+        sys.exit(1)
+    write_baseline(sizes)
+    print(f"Updated {BASELINE_FILE} with {len(sizes)} contract baseline(s).")
+    sys.exit(0)
+
+results = []
+contracts = baseline.get("contracts", {})
+for path in wasm_files:
+    name = path.stem
+    baseline_size = contracts.get(name)
+    results.append(evaluate_contract(name, path.stat().st_size, baseline_size))
+
+report = render_report(results, BASELINE_FILE, DIST_DIR)
+REPORT_FILE.write_text(report, encoding="utf-8")
+print(report)
+
+if EXPORT_TRENDS:
+    print(f"\nJSON baseline: {BASELINE_FILE}")
+
+if not wasm_files:
+    print(f"No WASM files found in {DIST_DIR}; run the wasm build and collect artifacts first.", file=sys.stderr)
+    sys.exit(1)
+
+if any(item["failures"] for item in results):
+    sys.exit(1)
+PY


### PR DESCRIPTION
Closes #846

## Summary
- adds a committed WASM size baseline file with the 10% regression and 60 KiB gates
- runs the WASM size monitor after the wasm32 release build and uploads `reports/wasm_size_report.md`
- comments on PRs with the size table, updating the existing bot comment on reruns
- documents baseline regeneration with `scripts/wasm_size_monitor.sh --update` and keeps `load_testing` excluded

## Validation
- `bash -n scripts/wasm_size_monitor.sh`
- `python3 -m json.tool scripts/wasm_size_baselines.json`
- `git diff --check`
- local fake-WASM smoke test: pass case returned 0, `--update` returned 0, >10% regression returned 1, and >60 KiB threshold returned 1

Note: this repo tracks large build artifacts, so I used a sparse checkout for the local validation work.