### PR TITLE
feat: add planned migration dry-run tooling

### DIFF
--- a/deployments/testnet/medical_records/plan.json
+++ b/deployments/testnet/medical_records/plan.json
@@ -1,0 +1,58 @@
+{
+  "contract_name": "medical_records",
+  "network": "testnet",
+  "contract_id": "REPLACE_WITH_DEPLOYED_CONTRACT_ID",
+  "admin_identity": "testnet-admin",
+  "upgrade_entrypoint": "upgrade",
+  "caller_arg_name": "caller",
+  "new_wasm_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "version_bump": {
+    "from": 3,
+    "to": 4
+  },
+  "expected_storage_migration_steps": [
+    {
+      "action": "update",
+      "key": "ContractVersion",
+      "from": "3",
+      "to": "4",
+      "description": "Advance the schema version guard before reading migrated records."
+    },
+    {
+      "action": "backfill",
+      "key": "PatientRecordIndex",
+      "from": "missing for legacy records",
+      "to": "secondary index populated for historical entries",
+      "description": "Create the lookup index needed by the new release without changing contract IDs."
+    },
+    {
+      "action": "add",
+      "key": "MigrationCheckpoint",
+      "from": "absent",
+      "to": "completed:v4",
+      "description": "Persist an operator-visible checkpoint so post-upgrade verification can confirm the migration finished."
+    }
+  ],
+  "expected_gas": {
+    "cpu_instructions": 1850000,
+    "read_bytes": 4096,
+    "write_bytes": 6144,
+    "transaction_fee_stroops": 275000
+  },
+  "expected_event_emissions": [
+    {
+      "topic": "Upgrade",
+      "data": "medical_records wasm updated to v4",
+      "description": "Native contract upgrade event emitted by the target contract."
+    },
+    {
+      "topic": "Migration",
+      "data": "schema advanced to v4 and legacy records indexed",
+      "description": "Operator-facing migration checkpoint event for audit trails."
+    }
+  ],
+  "notes": [
+    "Replace the placeholder contract_id and wasm hash before any live execution.",
+    "Keep expected gas in sync with the latest pre-prod measurements before mainnet rollout."
+  ]
+}

--- a/docs/CONTRACT_UPGRADE_SAFETY.md
+++ b/docs/CONTRACT_UPGRADE_SAFETY.md
@@ -63,11 +63,22 @@ Before deploying any upgrade:
 cargo test --test upgradeability_tests
 
 # Simulate migration on testnet fork
-./scripts/upgrade_contract.sh <contract_name> testnet --dry-run
+./scripts/migrate_contract.sh medical_records --network testnet --dry-run
 ```
 
-## Rollback Plans
+### Migration Plan Checklist
 
+Before either dry-run or live execution, create `deployments/<network>/<contract>/plan.json` with:
+
+- the new WASM hash
+- the version bump (`from` and `to`)
+- the expected storage migration steps
+- the expected gas budget
+- the expected event emissions
+
+The dry-run report is only as good as the plan, so treat the file as a release artifact that must be reviewed alongside the WASM diff.
+
+## Rollback Plans
 Every upgrade must have a documented rollback plan before deployment.
 
 ### Rollback Checklist
@@ -113,6 +124,8 @@ For upgrades that affect external callers:
 
 - [ ] New WASM built with `cargo build --target wasm32-unknown-unknown --release`
 - [ ] WASM hash verified: `sha256sum dist/<contract>.wasm`
+- [ ] `deployments/<network>/<contract>/plan.json` reviewed and approved
+- [ ] `./scripts/migrate_contract.sh <contract> --network <network> --dry-run` output captured
 - [ ] Migration function tested on testnet fork
 - [ ] Rollback plan documented and tested
 - [ ] Backup of current deployment created
@@ -124,3 +137,5 @@ For upgrades that affect external callers:
 ## Examples
 
 See [`docs/upgradeability.md`](./upgradeability.md) for the deprecation tracking pattern and [`docs/migration.md`](./migration.md) for storage migration examples used in this project.
+
+

--- a/docs/OPERATIONAL_RUNBOOK.md
+++ b/docs/OPERATIONAL_RUNBOOK.md
@@ -50,26 +50,31 @@ This runbook covers common operational tasks for Uzima Contracts in production.
    make build-opt
    ```
 
-2. Upload the new WASM to the network:
+2. Install the new WASM and scaffold the migration plan:
    ```bash
-   soroban contract upload \
-     --source deployer \
-     --network testnet \
-     --wasm target/wasm32-unknown-unknown/release/<contract>.wasm
+   ./scripts/upgrade_contract.sh <contract> testnet \
+     target/wasm32-unknown-unknown/release/<contract>.wasm \
+     <current_version> \
+     <next_version> \
+     --identity admin
    ```
-   Note the returned `WASM_HASH`.
+   This writes `deployments/testnet/<contract>/plan.json` with the installed WASM hash.
 
-3. Upgrade the deployed contract:
+3. Review the plan and perform a dry run:
    ```bash
-   soroban contract invoke \
-     --id <CONTRACT_ID> \
-     --source admin \
-     --network testnet \
-     -- upgrade \
-     --new_wasm_hash <WASM_HASH>
+   ./scripts/migrate_contract.sh <contract> --network testnet --dry-run
    ```
 
-4. Verify the upgrade:
+4. Execute the live migration only after the dry-run is approved:
+   ```bash
+   ./scripts/migrate_contract.sh <contract> \
+     --network testnet \
+     --identity admin \
+     --i-understand-this-is-live
+   ```
+   The script requires an explicit `LIVE` confirmation at the prompt before it submits.
+
+5. Verify the upgrade:
    ```bash
    soroban contract invoke \
      --id <CONTRACT_ID> \
@@ -78,12 +83,11 @@ This runbook covers common operational tasks for Uzima Contracts in production.
      -- version
    ```
 
-5. Update `deployments/<network>_<contract>.json` with the new WASM hash and timestamp.
+6. Update deployment metadata and attach the approved dry-run output to the change record.
 
 ---
 
 ## Emergency Pause
-
 If a contract must be halted immediately:
 
 1. Invoke the pause function:
@@ -135,3 +139,4 @@ If a deployment causes issues:
 ```
 
 See [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md) for full rollback procedures.
+

--- a/docs/SOROBAN_CLI_DEPLOYMENT.md
+++ b/docs/SOROBAN_CLI_DEPLOYMENT.md
@@ -322,8 +322,62 @@ soroban contract invoke \
   --arg-feature "advanced_features"
 ```
 
-## Troubleshooting
+## Planned Upgrade Migrations
 
+For upgradeable Uzima contracts, use the migration helper before any live upgrade so operators can inspect the storage and gas impact locally.
+
+### Step 1: Install the New WASM and Scaffold the Plan
+
+```bash
+./scripts/upgrade_contract.sh medical_records testnet \
+  target/wasm32-unknown-unknown/release/medical_records.wasm \
+  3 \
+  4 \
+  --identity testnet-admin
+```
+
+This writes `deployments/testnet/medical_records/plan.json` with the installed WASM hash and placeholder migration metadata that should be reviewed before continuing.
+
+### Step 2: Run the Local Dry Run
+
+```bash
+./scripts/migrate_contract.sh medical_records --network testnet --dry-run
+```
+
+Dry-run mode does not submit a transaction. It prints:
+
+- the projected storage state diff from `expected_storage_migration_steps`
+- the projected gas cost from `expected_gas`
+- the projected event emissions from `expected_event_emissions`
+
+### Step 3: Execute the Live Upgrade
+
+```bash
+./scripts/migrate_contract.sh medical_records \
+  --network testnet \
+  --identity testnet-admin \
+  --i-understand-this-is-live
+```
+
+Live mode is guarded in two ways:
+
+- `--i-understand-this-is-live` must be present
+- the operator must type `LIVE` at the interactive confirmation prompt
+
+The plan file can also carry contract-specific invocation metadata:
+
+```json
+{
+  "contract_id": "REPLACE_WITH_DEPLOYED_CONTRACT_ID",
+  "admin_identity": "testnet-admin",
+  "upgrade_entrypoint": "upgrade",
+  "caller_arg_name": "caller"
+}
+```
+
+That keeps the live invocation reproducible and reviewable alongside the storage-migration expectations.
+
+## Troubleshooting
 ### Common Deployment Issues
 
 #### Network Connectivity
@@ -520,3 +574,4 @@ soroban config network add --global custom \
 ---
 
 This guide provides a comprehensive foundation for deploying Soroban contracts. For more advanced topics, see the [Contract Interaction Guide](./SOROBAN_CLI_INTERACTION.md) and [Development Guide](./SOROBAN_CLI_DEVELOPMENT.md).
+

--- a/docs/upgradeability.md
+++ b/docs/upgradeability.md
@@ -26,15 +26,63 @@ To prevent data corruption during upgrades, the system enforces:
 
 1. **Development**: Build the new contract WASM.
 2. **Installation**: Deploy (install) the new WASM hash to the network.
-3. **Proposal**: Call `propose_upgrade` on the `UpgradeManager`.
-4. **Observation**: Wait for the timelock to expire.
-5. **Approval**: Obtain necessary validator signatures.
-6. **Execution**: Trigger `execute` on the `UpgradeManager`.
-7. **Migration (Optional)**: If the data layout changed, the new version's `initialize` or a dedicated `migrate` function should be called.
-8. **Deprecation Registration (Optional)**: If old entrypoints remain temporarily supported, register them with the shared upgradeability deprecation registry.
+3. **Plan**: Record the intended migration in `deployments/<network>/<contract>/plan.json`.
+4. **Dry Run**: Execute `./scripts/migrate_contract.sh <contract> --network <network> --dry-run` locally and review the projected storage diff, gas, and emitted events before any live transaction.
+5. **Proposal**: Call `propose_upgrade` on the `UpgradeManager`.
+6. **Observation**: Wait for the timelock to expire.
+7. **Approval**: Obtain necessary validator signatures.
+8. **Execution**: Trigger `execute` on the `UpgradeManager`, or run `./scripts/migrate_contract.sh <contract> --network <network> --i-understand-this-is-live` for direct admin-managed upgrades after the dry-run has been approved internally.
+9. **Migration (Optional)**: If the data layout changed, the new version's `initialize` or a dedicated `migrate` function should be called.
+10. **Deprecation Registration (Optional)**: If old entrypoints remain temporarily supported, register them with the shared upgradeability deprecation registry.
+
+## Planned Migration Dry Runs
+
+Operators should keep each planned migration beside other deployment artifacts:
+
+```text
+deployments/<network>/<contract>/plan.json
+```
+
+The migration plan is the source of truth for both dry-run review and live execution. At minimum it must include:
+
+- `new_wasm_hash`
+- `version_bump`
+- `expected_storage_migration_steps`
+- `expected_gas`
+- `expected_event_emissions`
+
+The checked-in template at `deployments/testnet/medical_records/plan.json` shows the full shape used by `scripts/migrate_contract.sh`, including optional operator metadata such as `contract_id`, `admin_identity`, `upgrade_entrypoint`, and `caller_arg_name`.
+
+### Dry-Run Workflow
+
+```bash
+./scripts/migrate_contract.sh medical_records --network testnet --dry-run
+```
+
+Dry-run mode performs no network submission. Instead it reads the plan file and prints:
+
+- the projected storage state diff derived from `expected_storage_migration_steps`
+- the projected gas budget from `expected_gas`
+- the projected event emissions from `expected_event_emissions`
+
+### Live Execution Guardrails
+
+Live mode is intentionally harder to trigger:
+
+```bash
+./scripts/migrate_contract.sh medical_records \
+  --network testnet \
+  --identity testnet-admin \
+  --i-understand-this-is-live
+```
+
+The script refuses to submit unless:
+
+- `--i-understand-this-is-live` is present
+- the operator types `LIVE` at the interactive prompt
+- the plan includes the contract ID and upgrade metadata needed for the `upgrade` invocation
 
 ## Deprecation Warnings
-
 The shared `upgradeability` crate now supports:
 
 - tracking deprecated functions in contract storage
@@ -54,3 +102,4 @@ Comprehensive integration tests are located in `tests/upgrade_integration_test.r
 - Failed upgrades (invalid version, not enough approvals).
 - Timelock enforcement.
 - Data persistence across versions.
+

--- a/scripts/migrate_contract.sh
+++ b/scripts/migrate_contract.sh
@@ -1,0 +1,390 @@
+#!/bin/bash
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+print_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_step() {
+    echo -e "${BLUE}[STEP]${NC} $1"
+}
+
+print_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+usage() {
+    cat <<'EOF'
+Usage:
+  ./scripts/migrate_contract.sh <contract_name> --network <network> --dry-run [--plan <path>]
+  ./scripts/migrate_contract.sh <contract_name> --network <network> --i-understand-this-is-live [--identity <name>] [--plan <path>]
+
+Description:
+  Reads a planned contract migration from deployments/<network>/<contract_name>/plan.json
+  and either:
+    - renders a dry-run projection for storage diff, gas, and events
+    - executes the live upgrade after an explicit acknowledgement and prompt
+
+Options:
+  --network <network>                   Soroban network name (for example: testnet)
+  --plan <path>                        Override the default plan path
+  --identity <identity>                Soroban identity for live execution
+  --dry-run                            Print a projected migration report without submitting
+  --i-understand-this-is-live          Required for live execution
+EOF
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        print_error "Required command '$1' is not installed or not on PATH"
+        exit 1
+    fi
+}
+
+parse_args() {
+    CONTRACT_NAME=""
+    NETWORK=""
+    PLAN_PATH=""
+    IDENTITY=""
+    DRY_RUN=false
+    LIVE_ACK=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --network)
+                NETWORK="${2:-}"
+                shift 2
+                ;;
+            --plan)
+                PLAN_PATH="${2:-}"
+                shift 2
+                ;;
+            --identity)
+                IDENTITY="${2:-}"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --i-understand-this-is-live)
+                LIVE_ACK=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            -*)
+                print_error "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+            *)
+                if [[ -z "$CONTRACT_NAME" ]]; then
+                    CONTRACT_NAME="$1"
+                else
+                    print_error "Unexpected positional argument: $1"
+                    usage
+                    exit 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "$CONTRACT_NAME" || -z "$NETWORK" ]]; then
+        print_error "Both <contract_name> and --network are required"
+        usage
+        exit 1
+    fi
+
+    if [[ "$DRY_RUN" == true && "$LIVE_ACK" == true ]]; then
+        print_error "Choose either --dry-run or --i-understand-this-is-live, not both"
+        exit 1
+    fi
+
+    if [[ "$DRY_RUN" == false && "$LIVE_ACK" == false ]]; then
+        print_error "Specify either --dry-run or --i-understand-this-is-live"
+        exit 1
+    fi
+
+    if [[ -z "$PLAN_PATH" ]]; then
+        PLAN_PATH="$PROJECT_ROOT/deployments/$NETWORK/$CONTRACT_NAME/plan.json"
+    fi
+}
+
+validate_plan() {
+    if [[ ! -f "$PLAN_PATH" ]]; then
+        print_error "Migration plan not found: $PLAN_PATH"
+        exit 1
+    fi
+
+    python3 - "$PLAN_PATH" "$CONTRACT_NAME" "$NETWORK" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+plan_path = Path(sys.argv[1])
+contract_name = sys.argv[2]
+network = sys.argv[3]
+
+with plan_path.open("r", encoding="utf-8") as handle:
+    plan = json.load(handle)
+
+required_fields = [
+    "new_wasm_hash",
+    "version_bump",
+    "expected_storage_migration_steps",
+    "expected_gas",
+    "expected_event_emissions",
+]
+
+missing = [field for field in required_fields if field not in plan]
+if missing:
+    raise SystemExit(f"Plan is missing required field(s): {', '.join(missing)}")
+
+version_bump = plan["version_bump"]
+if not isinstance(version_bump, dict) or "from" not in version_bump or "to" not in version_bump:
+    raise SystemExit("Plan field 'version_bump' must be an object with 'from' and 'to'")
+
+if not isinstance(plan["expected_storage_migration_steps"], list) or not plan["expected_storage_migration_steps"]:
+    raise SystemExit("Plan field 'expected_storage_migration_steps' must be a non-empty array")
+
+if not isinstance(plan["expected_event_emissions"], list):
+    raise SystemExit("Plan field 'expected_event_emissions' must be an array")
+
+plan_contract = plan.get("contract_name")
+if plan_contract and plan_contract != contract_name:
+    raise SystemExit(
+        f"Plan contract_name '{plan_contract}' does not match requested contract '{contract_name}'"
+    )
+
+plan_network = plan.get("network")
+if plan_network and plan_network != network:
+    raise SystemExit(
+        f"Plan network '{plan_network}' does not match requested network '{network}'"
+    )
+
+print("ok")
+PY
+}
+
+render_dry_run_report() {
+    print_step "Rendering dry-run migration projection from $PLAN_PATH"
+    python3 - "$PLAN_PATH" "$CONTRACT_NAME" "$NETWORK" <<'PY'
+import json
+import sys
+from collections import Counter
+
+plan_path = sys.argv[1]
+contract_name = sys.argv[2]
+network = sys.argv[3]
+
+with open(plan_path, "r", encoding="utf-8") as handle:
+    plan = json.load(handle)
+
+contract_id = plan.get("contract_id", "<set contract_id in plan>")
+version_bump = plan["version_bump"]
+steps = plan["expected_storage_migration_steps"]
+events = plan["expected_event_emissions"]
+gas = plan["expected_gas"]
+
+symbols = {
+    "add": "+",
+    "backfill": "+",
+    "update": "~",
+    "rename": "~",
+    "remove": "-",
+    "delete": "-",
+    "noop": "=",
+}
+
+counter = Counter()
+
+print(f"Migration dry-run for {contract_name} on {network}")
+print(f"  Contract ID: {contract_id}")
+print(f"  New WASM hash: {plan['new_wasm_hash']}")
+print(f"  Version bump: v{version_bump['from']} -> v{version_bump['to']}")
+print()
+
+print("Projected storage state diff:")
+for index, step in enumerate(steps, start=1):
+    action = str(step.get("action", "update")).lower()
+    key = step.get("key") or step.get("storage_key") or f"migration_step_{index}"
+    before = step.get("from", "<unchanged>")
+    after = step.get("to", "<unchanged>")
+    description = step.get("description")
+    symbol = symbols.get(action, "~")
+    counter[action] += 1
+    print(f"  {symbol} [{action}] {key}: {before} -> {after}")
+    if description:
+        print(f"    note: {description}")
+print(
+    f"  Summary: {sum(counter.values())} step(s) "
+    f"across {counter.get('add', 0) + counter.get('backfill', 0)} adds/backfills, "
+    f"{counter.get('update', 0) + counter.get('rename', 0)} updates, "
+    f"{counter.get('remove', 0) + counter.get('delete', 0)} removals"
+)
+print()
+
+print("Projected gas cost:")
+if isinstance(gas, dict):
+    for key, value in gas.items():
+        print(f"  - {key}: {value}")
+else:
+    print(f"  - total: {gas}")
+print()
+
+print("Projected event emissions:")
+if events:
+    for index, event in enumerate(events, start=1):
+        topic = event.get("topic", f"event_{index}")
+        data = event.get("data", "<no data>")
+        description = event.get("description")
+        print(f"  - {topic}: {data}")
+        if description:
+            print(f"    note: {description}")
+else:
+    print("  - none declared")
+print()
+
+notes = plan.get("notes", [])
+if notes:
+    print("Operator notes:")
+    for note in notes:
+        print(f"  - {note}")
+    print()
+
+print("Dry-run mode only: no Soroban transaction has been submitted.")
+PY
+}
+
+plan_value() {
+    local key="$1"
+    python3 - "$PLAN_PATH" "$key" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    plan = json.load(handle)
+
+key = sys.argv[2]
+
+if key == "contract_id":
+    value = plan.get("contract_id", "")
+elif key == "new_wasm_hash":
+    value = plan["new_wasm_hash"]
+elif key == "to_version":
+    value = plan["version_bump"]["to"]
+elif key == "admin_identity":
+    value = plan.get("admin_identity", "")
+elif key == "upgrade_entrypoint":
+    value = plan.get("upgrade_entrypoint", "upgrade")
+elif key == "caller_arg_name":
+    value = plan.get("caller_arg_name", "caller")
+else:
+    raise SystemExit(f"Unsupported key: {key}")
+
+print(value)
+PY
+}
+
+confirm_live_run() {
+    local contract_id="$1"
+    local wasm_hash="$2"
+    local to_version="$3"
+    local identity="$4"
+
+    print_warn "Live mode will submit an upgrade transaction."
+    echo "  Network: $NETWORK"
+    echo "  Contract: $CONTRACT_NAME"
+    echo "  Contract ID: $contract_id"
+    echo "  Identity: $identity"
+    echo "  New WASM hash: $wasm_hash"
+    echo "  Target version: $to_version"
+    echo
+    read -r -p "Type LIVE to continue: " confirmation
+    if [[ "$confirmation" != "LIVE" ]]; then
+        print_error "Live migration aborted by operator"
+        exit 1
+    fi
+}
+
+run_live_migration() {
+    require_command soroban
+
+    local contract_id
+    contract_id="$(plan_value "contract_id")"
+    local wasm_hash
+    wasm_hash="$(plan_value "new_wasm_hash")"
+    local to_version
+    to_version="$(plan_value "to_version")"
+    local default_identity
+    default_identity="$(plan_value "admin_identity")"
+    local upgrade_entrypoint
+    upgrade_entrypoint="$(plan_value "upgrade_entrypoint")"
+    local caller_arg_name
+    caller_arg_name="$(plan_value "caller_arg_name")"
+
+    if [[ -z "$contract_id" ]]; then
+        print_error "Plan must include contract_id for live execution"
+        exit 1
+    fi
+
+    if [[ -z "$IDENTITY" ]]; then
+        IDENTITY="$default_identity"
+    fi
+
+    if [[ -z "$IDENTITY" ]]; then
+        print_error "No live identity supplied. Use --identity or add admin_identity to the plan."
+        exit 1
+    fi
+
+    local caller_address
+    caller_address="$(soroban config identity address "$IDENTITY")"
+
+    confirm_live_run "$contract_id" "$wasm_hash" "$to_version" "$IDENTITY"
+
+    print_step "Submitting live migration transaction"
+    soroban contract invoke \
+        --id "$contract_id" \
+        --source "$IDENTITY" \
+        --network "$NETWORK" \
+        -- \
+        "$upgrade_entrypoint" \
+        "--$caller_arg_name" "$caller_address" \
+        --new_wasm_hash "$wasm_hash" \
+        --new_version "$to_version"
+
+    print_info "Live migration submitted successfully"
+}
+
+main() {
+    require_command python3
+    parse_args "$@"
+    validate_plan >/dev/null
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        render_dry_run_report
+        return 0
+    fi
+
+    run_live_migration
+}
+
+main "$@"

--- a/scripts/upgrade_contract.sh
+++ b/scripts/upgrade_contract.sh
@@ -1,34 +1,95 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Tool to assist in contract upgrades
-# Usage: ./upgrade_contract.sh <contract_id> <new_wasm_path> <version> <description>
+# upgrade_contract.sh - Install a new WASM hash and scaffold a migration plan.
+# Usage: ./scripts/upgrade_contract.sh <contract_name> <network> <new_wasm_path> <from_version> <to_version> [--identity <name>]
 
-CONTRACT_ID=$1
-WASM_PATH=$2
-VERSION=$3
-# DESC=$4
+CONTRACT_NAME="${1:-}"
+NETWORK="${2:-}"
+WASM_PATH="${3:-}"
+FROM_VERSION="${4:-}"
+TO_VERSION="${5:-}"
+IDENTITY="default"
 
-if [ -z "$CONTRACT_ID" ] || [ -z "$WASM_PATH" ] || [ -z "$VERSION" ]; then
-    echo "Usage: $0 <contract_id> <new_wasm_path> <version> [description]"
+shift $(( $# > 5 ? 5 : $# ))
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --identity)
+            IDENTITY="${2:-}"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Usage: $0 <contract_name> <network> <new_wasm_path> <from_version> <to_version> [--identity <name>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$CONTRACT_NAME" || -z "$NETWORK" || -z "$WASM_PATH" || -z "$FROM_VERSION" || -z "$TO_VERSION" ]]; then
+    echo "Usage: $0 <contract_name> <network> <new_wasm_path> <from_version> <to_version> [--identity <name>]" >&2
     exit 1
 fi
 
-echo "--- Starting Upgrade Process for $CONTRACT_ID ---"
+if ! command -v soroban >/dev/null 2>&1; then
+    echo "soroban CLI is required" >&2
+    exit 1
+fi
 
-# 1. Install new WASM
+PLAN_DIR="deployments/$NETWORK/$CONTRACT_NAME"
+PLAN_PATH="$PLAN_DIR/plan.json"
+
+echo "--- Preparing upgrade assets for $CONTRACT_NAME on $NETWORK ---"
 echo "Installing new WASM..."
-WASM_HASH=$(soroban contract install --wasm "$WASM_PATH")
+WASM_HASH=$(soroban contract install --wasm "$WASM_PATH" --source "$IDENTITY" --network "$NETWORK")
 echo "New WASM Hash: $WASM_HASH"
 
-# 2. Get UpgradeManager ID (Assuming it's stored or we pass it)
-# For this script we assume the caller is the admin of the target or using the manager
-# Here we'll just show how to call the upgrade directly for simple cases
-# or propose to the manager.
+mkdir -p "$PLAN_DIR"
 
-echo "Proposing upgrade to version $VERSION..."
-# soroban contract invoke --id <UPGRADE_MANAGER_ID> -- \
-#   propose_upgrade --proposer <ADMIN_ADDR> --target "$CONTRACT_ID" \
-#   --new_wasm_hash "$WASM_HASH" --new_version "$VERSION" --description "$DESC"
+cat > "$PLAN_PATH" <<EOF
+{
+  "contract_name": "$CONTRACT_NAME",
+  "network": "$NETWORK",
+  "contract_id": "REPLACE_WITH_DEPLOYED_CONTRACT_ID",
+  "admin_identity": "$IDENTITY",
+  "upgrade_entrypoint": "upgrade",
+  "caller_arg_name": "caller",
+  "new_wasm_hash": "$WASM_HASH",
+  "version_bump": {
+    "from": $FROM_VERSION,
+    "to": $TO_VERSION
+  },
+  "expected_storage_migration_steps": [
+    {
+      "action": "update",
+      "key": "ContractVersion",
+      "from": "$FROM_VERSION",
+      "to": "$TO_VERSION",
+      "description": "Replace this placeholder with the actual schema bump and migration details."
+    }
+  ],
+  "expected_gas": {
+    "cpu_instructions": 0,
+    "read_bytes": 0,
+    "write_bytes": 0,
+    "transaction_fee_stroops": 0
+  },
+  "expected_event_emissions": [
+    {
+      "topic": "Upgrade",
+      "data": "Replace with the expected upgrade event payload."
+    }
+  ],
+  "notes": [
+    "Fill in contract_id, gas, storage diff, and event expectations before running migrate_contract.sh."
+  ]
+}
+EOF
 
-echo "Upgrade proposed. Check proposal ID and get approvals."
+echo "Migration plan scaffolded at $PLAN_PATH"
+echo "Next steps:"
+echo "  1. Review and complete $PLAN_PATH"
+echo "  2. Run ./scripts/migrate_contract.sh $CONTRACT_NAME --network $NETWORK --dry-run"
+echo "  3. Run ./scripts/migrate_contract.sh $CONTRACT_NAME --network $NETWORK --i-understand-this-is-live"
+


### PR DESCRIPTION
## Summary
Add a planned migration dry-run workflow for contract upgrades so operators can inspect storage changes, gas, and expected events before a live Soroban upgrade.

## What Changed
- added `scripts/migrate_contract.sh` to read `deployments/<network>/<contract>/plan.json`
- added dry-run reporting for projected storage state diff, gas cost, and event emissions
- required `--i-understand-this-is-live` plus interactive `LIVE` confirmation for live execution
- updated `scripts/upgrade_contract.sh` to install a WASM hash and scaffold a migration plan
- added a checked-in plan template at `deployments/testnet/medical_records/plan.json`
- documented the workflow in:
  - `docs/upgradeability.md`
  - `docs/CONTRACT_UPGRADE_SAFETY.md`
  - `docs/OPERATIONAL_RUNBOOK.md`
  - `docs/SOROBAN_CLI_DEPLOYMENT.md`

## Why
Operators previously had no local helper to review a planned upgrade before submitting it live, which made wrong WASM hashes, contract IDs, or version bumps expensive to catch.

## Local Validation
Run from the healthy `Ubuntu-24.04` WSL shell:

```bash
source "$HOME/.cargo/env"
cd /mnt/c/Users/USER/Desktop/Uzima-contracts

bash -n scripts/migrate_contract.sh
bash -n scripts/upgrade_contract.sh
python3 -m json.tool deployments/testnet/medical_records/plan.json >/dev/null
bash scripts/migrate_contract.sh medical_records --network testnet --dry-run

Closes #864 