### PR TITLE
fix(ci): use replay_protection library in submit_message_batch

### DIFF
--- a/contracts/cross_chain_bridge/src/lib.rs
+++ b/contracts/cross_chain_bridge/src/lib.rs
@@ -707,7 +707,32 @@ impl CrossChainBridgeContract {
         for request in requests.iter() {
             Self::require_chain_supported(&env, &request.source_chain)?;
 
-            Self::verify_nonce(&env, &request.sender, request.nonce)?;
+            // Replay protection: nonce uniqueness, expiration, and chain binding.
+            // The shared `replay_protection` library also advances the per-sender
+            // nonce on success, so no separate `update_nonce` is required.
+            let rp_source = Self::to_replay_chain_id(&request.source_chain);
+            let timestamp = env.ledger().timestamp();
+            let mut tmp = [0u8; 128];
+            let sender_len = request.sender.len() as usize;
+            request.sender.copy_into_slice(&mut tmp[..sender_len]);
+            let sender_bytes = Bytes::from_slice(&env, &tmp[..sender_len]);
+            let sender_key: BytesN<32> = env.crypto().sha256(&sender_bytes).into();
+            replay_protection::verify_replay_protection(
+                &env,
+                &request.message_id,
+                &sender_key,
+                request.nonce,
+                timestamp,
+                MESSAGE_EXPIRY_SECS,
+                &rp_source,
+                &rp_source,
+            )
+            .map_err(|e| match e {
+                replay_protection::ReplayError::NonceReused => Error::InvalidNonce,
+                replay_protection::ReplayError::MessageExpired => Error::MessageExpired,
+                replay_protection::ReplayError::ChainMismatch => Error::InvalidChain,
+                replay_protection::ReplayError::ExpiryOverflow => Error::Overflow,
+            })?;
 
             // Cryptographic verification of the submitting validator
             Self::verify_validator_nonce(&env, &v_info.public_key, request.v_nonce)?;
@@ -718,8 +743,6 @@ impl CrossChainBridgeContract {
                 request.v_nonce,
                 &request.v_signature,
             )?;
-
-            let timestamp = env.ledger().timestamp();
 
             let message = CrossChainMessage {
                 message_id: request.message_id.clone(),
@@ -743,8 +766,6 @@ impl CrossChainBridgeContract {
                 PERSISTENT_TTL_THRESHOLD,
                 PERSISTENT_TTL_EXTEND_TO,
             );
-
-            Self::update_nonce(&env, &request.sender, request.nonce);
 
             let count: u64 = env
                 .storage()


### PR DESCRIPTION
## Summary
CI on `main` is currently red — Tests, Build (wasm32), Documentation Coverage and Code Quality all fail at compile time in `contracts/cross_chain_bridge`.

The four jobs share the **same root cause**: `submit_message_batch` calls `Self::verify_nonce(...)` and `Self::update_nonce(...)`, but those helpers were removed by PR #873 (cross-chain replay protection library consolidation) and replaced with the shared `replay_protection::verify_replay_protection` library.

PR #845 originally added the batch function using the old helpers; PR #873 updated the singular `submit_message` to the new library but missed the batch path, so the workspace has been broken on `main` since `a5fd207`.

## Fix
Mirrors the `replay_protection::verify_replay_protection` pattern already used in `submit_message` (nonce uniqueness, expiration, chain binding, per-sender nonce advance) inside `submit_message_batch`. The now-redundant `Self::update_nonce` call is dropped because the library writes the new nonce to persistent storage on success.

## Semantics preserved
- All-or-nothing batch behavior: Soroban rolls back persistent writes on any `?`-propagated `Err`, so partial state cannot leak if a later message in the batch fails.
- Per-sender strict nonce ordering within a batch is now enforced (more strict than before, which is the correct replay-protection semantics).
- Validator nonce (`verify_validator_nonce`) and Ed25519 signature verification are unchanged.

## Tests
Existing `submit_message_batch` tests should continue to pass; if any test fed duplicate / non-strictly-increasing nonces per sender, it will need to be updated to the stricter semantics. `cargo test -p cross_chain_bridge` is the relevant command — I cannot run it locally in this environment (no rust toolchain) but CI will run it.

## Tape
\`\`\`
[before] error[E0599]: no function or associated item named `verify_nonce`
                  found for struct `CrossChainBridgeContract`
       error[E0599]: no function or associated item named `update_nonce`
                  found for struct `CrossChainBridgeContract`
\`\`\`

Refs: #868 (and the merge-conflict follow-up), PR #845, PR #873.