### PR TITLE
ci: enforce cargo-audit on every PR + add advisory ignore list (#913)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,45 @@
+# cargo-audit configuration (issue #913)
+#
+# Auto-loaded by `cargo audit` (cargo-audit >= 0.18) when run from the repo
+# root. The `ignore` list below silences advisories that are KNOWN to be
+# non-applicable to this project. Every entry MUST carry a justification and,
+# where one exists, a remediation/tracking note. New advisories that are not
+# listed here will fail CI (see .github/workflows/security-audit.yml).
+#
+# Review cadence: the daily scheduled audit re-runs against the live advisory
+# DB, so a justification that becomes stale (e.g. an upgrade path opens up)
+# will resurface here for removal.
+
+[advisories]
+ignore = [
+    # --- rustls-webpki 0.101.7 (transitive, off-chain tooling only) ----------
+    # Dependency path:
+    #   rustls-webpki 0.101.7
+    #     <- rustls 0.21  <- hyper-rustls / tokio-rustls
+    #       <- octocrab 0.32 / reqwest 0.11
+    #         <- contract_optimizer  (feature = "cli", a std HOST binary)
+    #
+    # These advisories concern TLS certificate / CRL parsing. They are reachable
+    # ONLY from the off-chain `contract_optimizer` CLI when it makes HTTPS calls
+    # to the GitHub API. None of the on-chain Soroban contracts can link this
+    # code: contracts are `#![no_std]`, compile to wasm32-unknown-unknown, and
+    # have zero dependency on octocrab/reqwest/rustls (the `cli` feature is
+    # explicitly gated off for the wasm build). So the on-chain attack surface
+    # is unaffected.
+    #
+    # Remediation requires a major bump of octocrab (0.32 -> 0.53+) and reqwest
+    # (0.11 -> 0.12+) to pull rustls 0.23 / rustls-webpki 0.103. That is a
+    # breaking change to contract_optimizer's GitHub client and is intentionally
+    # OUT OF SCOPE for the CI-integration work in #913; it should be tracked as
+    # its own dependency-upgrade issue. Remove these ignores once that lands.
+    "RUSTSEC-2026-0104", # rustls-webpki: reachable panic in CRL parsing
+    "RUSTSEC-2026-0098", # rustls-webpki: name constraints for URI names wrongly accepted
+    "RUSTSEC-2026-0099", # rustls-webpki: name constraints accepted for wildcard certs
+]
+
+# NOTE: the `unmaintained` informational advisories currently reported
+# (RUSTSEC-2024-0436 paste, RUSTSEC-2025-0134 rustls-pemfile) are deliberately
+# NOT ignored. cargo-audit treats them as non-blocking warnings, so they stay
+# visible in CI output for tracking without failing the build. Add a
+# `deny = ["unmaintained"]` policy here only when the project is ready to gate
+# on them.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,62 @@
+# Security Audit (issue #913)
+#
+# Runs `cargo audit` (RustSec advisory database) against the resolved
+# dependency graph. The existing `scripts/security-scan.sh` already shells out
+# to `cargo audit`, but nothing wired it into CI, so dependency advisories were
+# never enforced on a PR. This workflow closes that gap.
+#
+# Scope of enforcement:
+#   - Every pull request and every push to `main`/`develop` runs the audit and
+#     FAILS the job on any active, non-ignored advisory. With this job marked
+#     "required" in branch protection, that blocks the merge.
+#   - A daily scheduled run re-audits already-merged code so advisories
+#     published *after* a merge are surfaced; GitHub emails the maintainers when
+#     a scheduled run fails, which is the "alert on new advisories" path.
+#
+# Known, non-applicable advisories are documented with a justification in
+# `.cargo/audit.toml` (auto-loaded by cargo-audit). That keeps the gate green
+# for transitive advisories we cannot act on while still blocking new ones.
+#
+# A dedicated workflow (rather than a job inside ci.yml) is deliberate: the
+# `schedule:` trigger should run ONLY the audit, not the full test/build/quality
+# matrix in ci.yml.
+name: Security Audit
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Daily at 06:00 UTC.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref to save CI minutes. The daily
+# scheduled run uses a distinct group so a push cannot cancel it.
+concurrency:
+  group: security-audit-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Generate Cargo.lock
+        # Cargo.lock is intentionally git-ignored for this workspace (see
+        # .gitignore), so the advisory scan resolves a fresh lockfile from the
+        # committed manifests before auditing.
+        run: cargo generate-lockfile
+      - name: Run cargo audit
+        # Reads `.cargo/audit.toml` for the documented ignore list and exits
+        # non-zero on any non-ignored advisory, failing the job and blocking the
+        # merge.
+        run: cargo audit


### PR DESCRIPTION
## Summary

Closes #913.

Wires dependency vulnerability scanning into CI. `scripts/security-scan.sh` already shells out to `cargo audit`, but nothing ran it on a PR, so RustSec advisories were never enforced on contributions. The only mention of audit in CI today is a comment in `ci.yml`.

## What this does

**`.github/workflows/security-audit.yml`** — a dedicated *Security Audit* workflow that runs `cargo audit` on:
- every **pull request** and every **push** to `main`/`develop` — fails the job on any active, non-ignored advisory (mark it required in branch protection to block merges);
- a **daily schedule** (`0 6 * * *` UTC) — re-audits already-merged code so advisories published *after* a merge are surfaced (GitHub emails maintainers on a scheduled-run failure → the "alert on new advisories" path);
- **manual dispatch** (`workflow_dispatch`).

It's a dedicated workflow (not a job in `ci.yml`) so the daily `schedule:` doesn't re-run the full test/build/quality matrix. `Cargo.lock` is git-ignored for this workspace, so the job runs `cargo generate-lockfile` before auditing.

**`.cargo/audit.toml`** — documented ignore list (auto-loaded by cargo-audit) for the three transitive `rustls-webpki 0.101.7` advisories (RUSTSEC-2026-0098 / 0099 / 0104). Dependency path:

```
rustls-webpki 0.101.7 <- rustls 0.21 <- hyper-rustls/tokio-rustls
  <- octocrab 0.32 / reqwest 0.11 <- contract_optimizer (feature = "cli")
```

These TLS cert/CRL advisories are reachable only from the **off-chain `contract_optimizer` CLI** (a `std` host binary). No on-chain Soroban contract links them — contracts are `#![no_std]`, compile to `wasm32-unknown-unknown`, and the `cli` feature is gated off for the wasm build. Each ignore carries a justification and a remediation note (a major octocrab/reqwest bump, tracked separately). The unmaintained-crate warnings (`paste`, `rustls-pemfile`) are left visible and non-blocking.

## Maps to the issue

- [x] Verify `cargo-audit` runs on every PR and push to main — workflow triggers
- [x] Add `audit.toml` ignore file for known non-applicable advisories — `.cargo/audit.toml`
- [x] Configure alerts for new advisories — daily scheduled run (failure → maintainer email) + `workflow_dispatch`
- [x] Schedule daily audit run — `cron: '0 6 * * *'`

**Acceptance criteria**
- [x] `cargo-audit` blocks merges with active vulnerabilities — job exits non-zero on any non-ignored advisory
- [x] Advisory ignore list has justification comments — see `.cargo/audit.toml`

## Testing

Ran locally with cargo-audit 0.22.2 against a freshly generated lockfile (436 crate deps):
- **Before** the ignore list: `error: 3 vulnerabilities found!` → exit 1 (gate blocks, as intended).
- **After** `.cargo/audit.toml`: the 3 rustls-webpki advisories are ignored; audit exits **0** with only the 2 non-blocking `unmaintained` warnings shown.

Workflow YAML validated.
