### PR TITLE
fix(cross_chain_bridge): remove duplicate Nonce key and nonce helpers (unblocks CI)

### DIFF
--- a/contracts/cross_chain_bridge/src/lib.rs
+++ b/contracts/cross_chain_bridge/src/lib.rs
@@ -347,7 +347,6 @@ pub enum DataKey {
     Nonce(String),
     Validator(Address),
     Message(BytesN<32>),
-    Nonce(String),
     RecordRef(u64, ChainId),
     AtomicTx(BytesN<32>),
     OracleNode(Address),
@@ -357,7 +356,6 @@ pub enum DataKey {
     Rollback(BytesN<32>),
     Event(u64),
     CrossChainOp(BytesN<32>),
-    Nonce(String),
     // Temporary storage keys (session/short-lived data)
     Confirmations(BytesN<32>),
     AuthorizedRelayer(Address),
@@ -2301,25 +2299,6 @@ impl CrossChainBridgeContract {
             .ed25519_verify(validator_pubkey, &message_hash.into(), signature);
 
         Ok(())
-    }
-
-    fn verify_nonce(env: &Env, sender: &String, nonce: u64) -> Result<(), Error> {
-        let last_nonce: u64 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Nonce(sender.clone()))
-            .unwrap_or(0);
-
-        if nonce <= last_nonce {
-            return Err(Error::InvalidNonce);
-        }
-        Ok(())
-    }
-
-    fn update_nonce(env: &Env, sender: &String, nonce: u64) {
-        env.storage()
-            .persistent()
-            .set(&DataKey::Nonce(sender.clone()), &nonce);
     }
 
     fn verify_validator_nonce(env: &Env, pubkey: &BytesN<32>, nonce: u64) -> Result<(), Error> {


### PR DESCRIPTION
## Summary

The `cross_chain_bridge` contract did not compile (9 errors), which aborted `cargo test --all` for the **entire workspace** in CI — that's why the `Tests` job is red on `main`. This is a minimal, no-behaviour-change fix that removes accidental duplicate definitions.

## Root cause

A previous change moved `verify_nonce` / `update_nonce` into the `#[contractimpl]` block (there's a comment to that effect at their new location) but **left the originals behind** in the private-helper `impl` block, and the `DataKey::Nonce(String)` variant was pasted **three times**. That produced:

| Error | Cause |
|---|---|
| `E0428` | `Nonce` defined multiple times in `DataKey` |
| `E0592` | duplicate `verify_nonce` / `update_nonce` definitions |
| `E0034` | ambiguous method calls at the call sites (lines 610/647/688/725) |
| `E0004` | non-exhaustive match generated by `#[contracttype]` over the duplicated variant |

## Fix

Keep a single `DataKey::Nonce(String)` variant and the moved `verify_nonce`/`update_nonce` (with their explanatory comment); delete the leftover duplicates. The removed copies were **byte-for-byte identical** to the ones kept, so there is no behavioural change — purely de-duplication. Net diff: 21 deletions in one file.

## Testing

All run locally against this branch:
- `cargo build -p cross_chain_bridge` — compiles
- `cargo clippy -p cross_chain_bridge --all-targets` — clean (CI uses `-D warnings`)
- `cargo test -p cross_chain_bridge` — **57 passed, 0 failed**
- `cargo build -p cross_chain_bridge --target wasm32-unknown-unknown --release` — succeeds
- `cargo test --workspace --no-run` — **the whole workspace's tests now compile** (exit 0); `cross_chain_bridge` was the only blocker

Unblocks the contract's other open issues (#905 re-org protection tests, #919 threat-model review) which require it to build.
