### PR TITLE
feat(ci): detect unused dependencies with cargo-machete (#883)

### DIFF
--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -1,0 +1,38 @@
+# Unused Dependencies (issue #883)
+#
+# Runs `cargo machete` across every crate in the repo to catch dependencies
+# declared in a Cargo.toml but never used. Unused deps slow compiles and inflate
+# WASM size, which matters for on-chain Soroban contracts.
+#
+# cargo-machete is STATIC analysis (it parses manifests and greps source), so it
+# does not build the workspace and runs in seconds. The job fails (blocking the
+# merge when marked required) on any unused dependency. Genuine false positives
+# (e.g. a crate used only through a macro) are suppressed per-crate via
+# `[package.metadata.cargo-machete] ignored = [...]` — see docs/DEPENDENCY_HYGIENE.md.
+name: Unused Dependencies
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
+
+concurrency:
+  group: unused-deps-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-machete:
+    name: cargo-machete
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-machete
+        run: cargo install cargo-machete --locked
+      - name: Check for unused dependencies
+        run: cargo machete

--- a/contract_optimizer/Cargo.toml
+++ b/contract_optimizer/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [features]
 default = []
-# CLI pulls in tokio/network crates that do not build for wasm32-unknown-unknown.
-cli = ["dep:clap", "dep:tokio", "dep:reqwest", "dep:octocrab"]
+# CLI pulls in tokio, which does not build for wasm32-unknown-unknown.
+cli = ["dep:clap", "dep:tokio"]
 
 [[bin]]
 name = "contract_optimizer"
@@ -16,13 +16,8 @@ required-features = ["cli"]
 [dependencies]
 syn = { version = "2.0", features = ["full", "extra-traits", "visit"] }
 quote = "1.0"
-proc-macro2 = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-anyhow = "1.0"
 walkdir = "2.3"
-regex = "1.5"
 clap = { version = "4.0", features = ["derive"], optional = true }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"], optional = true }
-reqwest = { version = "0.11", features = ["json"], optional = true }
-octocrab = { version = "0.32", optional = true }

--- a/contracts/appointment_booking_escrow/Cargo.toml
+++ b/contracts/appointment_booking_escrow/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
-upgradeability = { path = "../upgradeability" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/clinical_nlp/Cargo.toml
+++ b/contracts/clinical_nlp/Cargo.toml
@@ -11,8 +11,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
-upgradeability = { path = "../upgradeability" }
-medical_records = { path = "../medical_records" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/cross_chain_bridge/Cargo.toml
+++ b/contracts/cross_chain_bridge/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
-replay_protection = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/provider_directory/Cargo.toml
+++ b/contracts/provider_directory/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk.workspace = true
-uzima-sanitization = { path = "../sanitization" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/docs/DEPENDENCY_HYGIENE.md
+++ b/docs/DEPENDENCY_HYGIENE.md
@@ -1,0 +1,72 @@
+# Dependency Hygiene Policy
+
+Keeps `Cargo.toml` dependency lists lean. Unused dependencies slow compile
+times and inflate WASM binary size — which directly affects on-chain Soroban
+contract deploy cost — so they are treated as a CI failure. Implements issue
+#883.
+
+## Rule
+
+Every dependency declared in a `Cargo.toml` must actually be used by that crate.
+No "just in case" or copy-pasted dependencies.
+
+## Automated check
+
+CI runs [`cargo machete`](https://github.com/bnjbvr/cargo-machete) on every push
+and PR (`.github/workflows/unused-deps.yml`). It is static analysis — it parses
+manifests and scans source, it does **not** build the workspace — so it is fast
+and the job **fails on any unused dependency**.
+
+Run it locally before pushing:
+
+```bash
+cargo install cargo-machete --locked   # once
+cargo machete                          # from the repo root
+```
+
+Optionally wire it into the pre-commit hook alongside the secret scanner:
+
+```yaml
+# .pre-commit-config.yaml
+- repo: local
+  hooks:
+    - id: cargo-machete
+      name: cargo-machete (unused deps)
+      entry: cargo machete
+      language: system
+      pass_filenames: false
+```
+
+## Handling a finding
+
+1. **Genuinely unused?** Remove the dependency from `Cargo.toml`. If it is an
+   `optional` dependency, also remove it from any `[features]` entry that
+   references it via `dep:<name>`. Rebuild the affected crate to confirm.
+2. **False positive?** (used only through a macro, a build script, or a
+   `cfg`-gated path that the scanner can't see.) Add it to the per-crate ignore
+   list and explain why:
+
+   ```toml
+   [package.metadata.cargo-machete]
+   ignored = ["prost"]   # used only via prost-derive macros
+   ```
+
+   Prefer per-crate ignores with a justification over leaving real dead weight.
+
+## Baseline (issue #883)
+
+The initial sweep removed 12 unused dependencies across 6 crates:
+
+| Crate | Removed |
+| --- | --- |
+| `contract_optimizer` | `anyhow`, `octocrab`, `proc-macro2`, `regex`, `reqwest` |
+| `clinical_nlp` | `medical_records`, `upgradeability` |
+| `cross_chain_bridge` | `replay_protection` |
+| `appointment_booking_escrow` | `upgradeability` |
+| `provider_directory` | `uzima-sanitization` |
+| `uzima-tests` (`tests/`) | `reputation`, `healthcare_payment` |
+
+Removing `octocrab`/`reqwest` from `contract_optimizer` (they were referenced
+only in a comment) also drops the `rustls 0.21` / `rustls-webpki 0.101` chain
+from the dependency graph, eliminating the advisories tracked in the cargo-audit
+allowlist (#913).

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,8 +9,6 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 medical_records = { path = "../contracts/medical_records" }
 sut_token = { path = "../contracts/sut_token" }
 healthcare_oracle_network = { path = "../contracts/healthcare_oracle_network" }
-reputation = { path = "../contracts/reputation" }
-healthcare_payment = { path = "../contracts/healthcare_payment" }
 meta_tx_forwarder = { path = "../contracts/meta_tx_forwarder" }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Closes #883. Adds a [`cargo-machete`](https://github.com/bnjbvr/cargo-machete) CI job to catch dependencies declared in a `Cargo.toml` but never used (they slow compiles and inflate WASM size), and removes the 12 unused deps it found so the check passes at **zero**.

## Files

- **`.github/workflows/unused-deps.yml`** — runs `cargo machete` on every push/PR. It's static analysis (parses manifests + scans source, no build), so it runs in seconds and fails on any unused dependency.
- **`docs/DEPENDENCY_HYGIENE.md`** — the policy, local usage, and how to suppress genuine false positives via `[package.metadata.cargo-machete]`.
- **6 `Cargo.toml` files** — removed the unused deps below.

## Removed dependencies

| Crate | Removed |
|---|---|
| `contract_optimizer` | `anyhow`, `octocrab`, `proc-macro2`, `regex`, `reqwest` |
| `clinical_nlp` | `medical_records`, `upgradeability` |
| `cross_chain_bridge` | `replay_protection` |
| `appointment_booking_escrow` | `upgradeability` |
| `provider_directory` | `uzima-sanitization` |
| `uzima-tests` (`tests/`) | `reputation`, `healthcare_payment` |

`octocrab`/`reqwest` in `contract_optimizer` were optional deps behind the `cli` feature, referenced only in a comment — removed from both `[dependencies]` and the feature list. **Bonus:** dropping them removes the `rustls 0.21` / `rustls-webpki 0.101` chain from the graph, eliminating the advisories tracked in the cargo-audit allowlist (#913).

## Maps to the issue

- [x] Add `cargo-machete` to CI — `unused-deps.yml`
- [x] Run check across all workspace members — runs at repo root over all crates
- [x] Fix detected unused dependencies — 12 removed
- [x] Document dependency hygiene policy — `docs/DEPENDENCY_HYGIENE.md`
- [x] **Acceptance:** CI job passes with zero unused dependencies reported

## Testing

Verified locally with cargo-machete 0.9.2:
- `cargo machete` → **"didn't find any unused dependencies. Good job!"** (exit 0)
- Full workspace compiles (`cargo test --workspace --no-run`) and the affected member contracts build for `wasm32-unknown-unknown` — verified with the #937 build fix applied (see note below).
- `cargo build -p contract_optimizer --features cli` still builds after the octocrab/reqwest removal.

> The `cargo-machete` check on this PR is green. The other inherited checks (Build/Tests/etc.) are red for a reason **unrelated to this PR**: `cross_chain_bridge` doesn't compile on `main` (fixed separately in #937). Merging #937 first, then rebasing this PR, turns those green too.
