### PR TITLE
Add contributor guide for adding new contracts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,5 +108,223 @@ The project uses GitHub Actions for CI/CD. The pipeline includes:
 - Check open issues for known problems
 - Ask questions in pull request discussions
 
+## Adding a New Contract
+
+Step-by-step guide for adding a new Soroban smart contract to this workspace.
+
+### 1. Create the contract directory
+
+```
+contracts/<your_contract_name>/
+├── Cargo.toml
+└── src/
+    ├── lib.rs          # Contract entrypoint (must start with #![no_std])
+    ├── errors.rs       # Error enum (recommended)
+    └── test.rs         # Unit tests (recommended)
+```
+
+### 2. Cargo.toml
+
+Use workspace inheritance for shared metadata:
+
+```toml
+[package]
+name = "your_contract_name"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk.workspace = true
+# Add shared libs only if needed:
+# governance_commons = { workspace = true }
+# replay_protection = { workspace = true }
+# common_error = { path = "../common_error" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]
+```
+
+Key points:
+- `crate-type = ["cdylib"]` is required for Soroban WASM contracts.
+- `soroban-sdk = { workspace = true }` pulls from `[workspace.dependencies]`.
+- Dev-dependencies add `testutils` for tests.
+- Never pin your own soroban-sdk version; always use `workspace = true`.
+
+### 3. lib.rs skeleton
+
+```rust
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Env};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum DataKey {
+    // ...
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    // Follow the repo-wide range convention:
+    //   200–299: Input Validation
+    //   300–399: Lifecycle & State
+    //   400–499: Entity Existence
+    //   500–599: Financial & Resource
+    ExampleError = 300,
+}
+
+#[contract]
+pub struct YourContract;
+
+#[contractimpl]
+impl YourContract {
+    // pub fn your_method(env: &Env, ...) -> Result<_, Error> { ... }
+}
+```
+
+Required:
+- First line must be `#![no_std]` — CI enforces this for all workspace members.
+- Use `#[contracterror]` + `#[repr(u32)]` on your error enum.
+- Use `#[contracttype]` on all storage/data types.
+
+### 4. Error conventions
+
+- Range your error codes per the repo convention (see `contracts/governor/src/errors.rs` for a reference).
+- Implement `core::fmt::Display` for your error enum with human-readable variant messages.
+- Use the `common_error` crate (`contracts/common_error`) for shared error types if your contract needs the same validation/lifecycle errors as other contracts.
+- Never use `unwrap()` or `expect()` in contract code. CI runs `scripts/check_no_production_unwraps.sh`.
+
+### 5. Tests
+
+Place tests in `src/test.rs` (included via `#[cfg(test)] mod test;` in lib.rs) or inline:
+
+```rust
+use super::*;
+use soroban_sdk::{Env, String};
+
+#[test]
+fn test_basic_flow() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, YourContract);
+    let client = YourContractClient::new(&env, &contract_id);
+
+    // test your methods here
+    assert_eq!(client.try_your_method(), Ok(()));
+}
+```
+
+Run tests with:
+```bash
+cargo test --all
+```
+
+### 6. Workspace registration
+
+Contracts under `contracts/` are **automatically** included by the workspace glob `members = ["contracts/*", ...]` in the root `Cargo.toml`. You do NOT need to add your contract to the members list.
+
+If your contract cannot yet compile against the pinned `soroban-sdk = "=21.7.7"`, add it to the `[workspace] exclude` list in the root `Cargo.toml` with a comment referencing the tracking issue. This lets the rest of CI pass while you fix compilation.
+
+### 7. Shared libraries
+
+If your contract needs reusable types, errors, or utilities shared across contracts, add a library under `libs/`:
+
+```
+libs/<your_lib>/
+├── Cargo.toml       # crate-type = ["rlib"]
+└── src/
+    └── lib.rs
+```
+
+Reference it from your contract's `Cargo.toml`:
+```toml
+[dependencies]
+your_lib = { path = "../your_lib" }
+# or if added to workspace deps:
+# your_lib = { workspace = true }
+```
+
+Add the lib to the root workspace `members` list if it is not already covered by a glob.
+
+### 8. CI checks your PR must pass
+
+| Check | What it runs | Blocking? |
+|---|---|---|
+| **Tests** | `cargo test --all` + `scripts/check_error_codes.sh` + `scripts/check_no_production_unwraps.sh` | Yes |
+| **Build (wasm32)** | `cargo build --workspace --target wasm32-unknown-unknown --release` + `#![no_std]` check | Yes |
+| **Code Quality** | `cargo fmt --all -- --check` (non-blocking) + `cargo clippy --all-targets -- -D warnings` | Clippy yes, fmt non-blocking |
+| **Documentation Coverage** | `cargo check --workspace` + `scripts/coverage_report.sh docs` | Non-blocking (Phase 1) |
+| **SDK Bindings** | `node scripts/generate-sdk-types.mjs` — regenerates TypeScript/Python bindings | Yes (unless `[skip-sdk-gen]` in PR body) |
+
+#### Running CI checks locally
+
+```bash
+# Full test suite
+cargo test --all
+
+# WASM build
+cargo build --workspace --target wasm32-unknown-unknown --release
+
+# no_std check (run from repo root)
+for contract in contracts/*/; do
+  name=$(basename "$contract")
+  lib_file="${contract}src/lib.rs"
+  if [ -f "$lib_file" ]; then
+    grep -qF '#![no_std]' "$lib_file" || echo "MISSING #![no_std]: $lib_file"
+  fi
+done
+
+# Error code check
+bash ./scripts/check_error_codes.sh
+
+# No-production-unwraps check
+bash ./scripts/check_no_production_unwraps.sh
+
+# Clippy
+cargo clippy --all-targets -- -D warnings
+
+# Format check
+cargo fmt --all -- --check
+
+# Doc coverage
+./scripts/coverage_report.sh docs
+
+# SDK bindings (if your contract has public entrypoints)
+node scripts/generate-sdk-types.mjs
+```
+
+### 9. Documentation
+
+- Add doc comments (`///`) to all public types, functions, and entrypoints.
+- CI tracks missing-docs warnings via `scripts/coverage_report.sh docs`.
+- If your contract introduces new domain terms, add them to `docs/GLOSSARY.md`.
+- If your contract emits events, document them in `docs/EVENTS.md`.
+
+### 10. Checklist before opening a PR
+
+- [ ] `contracts/<name>/src/lib.rs` starts with `#![no_std]`
+- [ ] `Cargo.toml` uses `crate-type = ["cdylib"]` and `soroban-sdk = { workspace = true }`
+- [ ] Error enum uses `#[contracterror]`, `#[repr(u32)]`, `#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]`
+- [ ] Error codes follow the repo range convention (200–299 validation, 300–399 lifecycle, etc.)
+- [ ] `core::fmt::Display` implemented for error enum
+- [ ] No `unwrap()` or `expect()` in contract code (check with `bash scripts/check_no_production_unwraps.sh`)
+- [ ] Tests exist and pass: `cargo test --all`
+- [ ] WASM build succeeds: `cargo build --workspace --target wasm32-unknown-unknown --release`
+- [ ] Clippy clean: `cargo clippy --all-targets -- -D warnings`
+- [ ] Doc comments on public API items
+- [ ] Contract is NOT in the `exclude` list, OR a comment explains why with a tracking issue number
+- [ ] Run `node scripts/generate-sdk-types.mjs` if your contract adds new public entrypoints
+
 ## License
 By contributing, you agree that your contributions will be licensed under the project's MIT license.

--- a/README.md
+++ b/README.md
@@ -667,6 +667,8 @@ For more help, check the [GitHub Issues](https://github.com/your-org/Uzima-Contr
 
 ## 🤝 Contribution Guidelines
 
+> **Adding a new contract?** See [CONTRIBUTING.md](CONTRIBUTING.md) for the step-by-step guide covering workspace registration, CI checks, and the review checklist.
+
 We welcome contributions from the community! Please follow these guidelines to ensure smooth collaboration.
 
 ### Getting Started


### PR DESCRIPTION
## Summary
- Extend `CONTRIBUTING.md` with a complete step-by-step guide for adding new Soroban contracts to the workspace
- Cover directory structure, `Cargo.toml` setup, `#![no_std]` requirement, error conventions, test patterns, workspace registration, shared libraries, CI checks, documentation expectations, and a pre-PR checklist
- Add a cross-reference from `README.md` Contribution Guidelines section to the new guide

Fixes #986.

## Verification
- `git diff --check` passed (220 insertions, 0 deletions)
- All content derived from actual repo patterns: existing contracts (`health_check`, `governor`), workspace `Cargo.toml`, CI workflows (`.github/workflows/ci.yml`), and shared libs (`governance_commons`, `replay_protection`, `common_error`)
