### PR TITLE
ci: add WASM artifact upload and PR size labeling workflows

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,0 +1,110 @@
+# PR Size Labeling (issue #899)
+# Labels every PR by total lines changed (XS/S/M/L/XL),
+# posts a review reminder for large PRs, and requests extra reviewers
+# proportional to PR size.
+
+name: PR Size
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label-size:
+    name: Label PR by size
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute changed lines and apply label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const lines = files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
+
+            const sizeLabel =
+              lines < 10  ? 'size/XS' :
+              lines < 50  ? 'size/S'  :
+              lines < 200 ? 'size/M'  :
+              lines < 500 ? 'size/L'  : 'size/XL';
+
+            // Ensure all size labels exist, then swap to the correct one
+            const allSizeLabels = ['size/XS', 'size/S', 'size/M', 'size/L', 'size/XL'];
+            for (const name of allSizeLabels) {
+              try {
+                await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name });
+              } catch {
+                const colors = { 'size/XS': '3cbf00', 'size/S': '5d9801', 'size/M': 'e4c100', 'size/L': 'eb6420', 'size/XL': 'ee0701' };
+                await github.rest.issues.createLabel({ owner: context.repo.owner, repo: context.repo.repo, name, color: colors[name] });
+              }
+            }
+
+            // Remove stale size labels, add current one
+            const { data: current } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number,
+            });
+            for (const lbl of current.filter(l => allSizeLabels.includes(l.name) && l.name !== sizeLabel)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: context.issue.number, name: lbl.name,
+              });
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number, labels: [sizeLabel],
+            });
+
+            core.setOutput('lines', lines);
+            core.setOutput('size_label', sizeLabel);
+
+      - name: Post reminder for large PRs (> 500 lines)
+        if: ${{ always() }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+            const lines = files.reduce((sum, f) => sum + f.additions + f.deletions, 0);
+            if (lines <= 500) return;
+
+            const reviewers = lines < 1000 ? 2 : 3;
+
+            // Check if reminder already posted to avoid duplicates
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = '<!-- pr-size-reminder -->';
+            if (comments.some(c => c.body.includes(marker))) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                marker,
+                `## :warning: Large PR — ${lines} lines changed`,
+                '',
+                `This PR is labelled **size/XL** (> 500 lines). Large PRs are harder to review and more likely to introduce bugs.`,
+                '',
+                `**Please request at least ${reviewers} reviewers** before merging.`,
+                '',
+                'Consider splitting this PR into smaller, focused changes if possible.',
+              ].join('\n'),
+            });

--- a/.github/workflows/wasm-artifacts.yml
+++ b/.github/workflows/wasm-artifacts.yml
@@ -1,0 +1,38 @@
+# WASM Artifact Upload (issue #897)
+# Builds optimized WASM binaries on every push to main,
+# logs per-contract sizes for trending, and retains artifacts for 30 days.
+
+name: WASM Artifacts
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-upload:
+    name: Build & Upload WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Build optimized WASM (make build-opt)
+        run: cargo build --workspace --target wasm32-unknown-unknown --release
+
+      - name: Log WASM artifact sizes
+        run: |
+          echo "=== WASM artifact sizes ==="
+          find target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm" | sort | while read f; do
+            size=$(wc -c < "$f")
+            echo "$(basename "$f"): ${size} bytes"
+          done
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-contracts-${{ github.sha }}
+          path: target/wasm32-unknown-unknown/release/*.wasm
+          retention-days: 30


### PR DESCRIPTION
## Summary

Closes #897 and closes #899.

## Changes

### WASM Artifact Upload (`.github/workflows/wasm-artifacts.yml`) - #897
- Triggers on every push to `main`
- Builds optimized WASM via `cargo build --workspace --target wasm32-unknown-unknown --release`
- Logs per-contract byte sizes for trending
- Uploads all `*.wasm` files as a named artifact (`wasm-contracts-<sha>`) with **30-day retention**

### PR Size Labeling (`.github/workflows/pr-size.yml`) - #899
- Triggers on PR open / synchronize / reopen
- Computes total lines changed (additions + deletions) and applies one of: `size/XS` / `size/S` / `size/M` / `size/L` / `size/XL`
- Auto-creates labels with colour coding if they don't exist; removes stale size labels on each update
- Posts a single (non-duplicate) reminder comment on PRs > 500 lines, specifying the required reviewer count (2 for 500–1000 lines, 3 for > 1000 lines)

## Testing
Both workflows are pure GitHub Actions YAML - no source code changes. They can be verified by:
1. Merging to `main` → check the **WASM Artifacts** run and download the artifact.
2. Opening any PR → check the **PR Size** run for the correct label and (if > 500 lines) the reminder comment.