### PR TITLE
fix: I  centralized Admin Authorization Check via Shared Macro in gov…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release script error handling
 
 ### Security
+- **Centralized Admin & Role Authorization Checks:** Introduced shared `require_admin!(env, caller)` and `require_role!(env, caller, role)` macros in `libs/governance_commons` to eliminate duplicate auth logic across multiple contracts (`anomaly_detector`, `cross_chain_bridge`, `aml`, `audit`, and `rbac`).
 - Enhanced security audit integration
 - Improved access control validation
 - Added security-focused clippy checks

--- a/contracts/aml/Cargo.toml
+++ b/contracts/aml/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 soroban-sdk = { version = "21.7.7" }
 upgradeability = { path = "../upgradeability" }
+governance_commons = { path = "../../libs/governance_commons" }
 
 [dev-dependencies]
 soroban-sdk = { version = "21.7.7", features = ["testutils"] }

--- a/contracts/aml/src/lib.rs
+++ b/contracts/aml/src/lib.rs
@@ -14,8 +14,8 @@ use soroban_sdk::xdr::ToXdr;
 use soroban_sdk::{
     contract, contracterror, contractimpl, symbol_short, Address, Bytes, BytesN, Env, Map, String,
     Symbol, Vec,
-    contract, contractimpl, symbol_short, Address, BytesN, Env, String, Symbol, Vec,
 };
+use governance_commons::require_admin;
 use upgradeability::storage::{ADMIN as UPGRADE_ADMIN, VERSION};
 
 #[contracterror]
@@ -63,9 +63,8 @@ impl AntiMoneyLaundering {
         description: String,
         threshold: i128,
         risk_contribution: u32,
-    ) {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+    ) -> Result<(), Error> {
+        require_admin!(env, admin);
 
         let rule = AMLRule {
             rule_id: id,
@@ -76,6 +75,7 @@ impl AntiMoneyLaundering {
             is_enabled: true,
         };
         env.storage().instance().set(&DataKey::Rule(id), &rule);
+        Ok(())
     }
 
     /// Monitor a transaction and update risk profile
@@ -127,19 +127,19 @@ impl AntiMoneyLaundering {
     }
 
     /// Update blacklist status for a user.
-    pub fn update_user_status(env: Env, admin: Address, user: Address, is_blacklisted: bool) {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+    pub fn update_user_status(env: Env, admin: Address, user: Address, is_blacklisted: bool) -> Result<(), Error> {
+        require_admin!(env, admin);
         Self::set_user_status_internal(&env, user, is_blacklisted);
+        Ok(())
     }
 
     /// Blacklist or whitelist an address manually by admin.
     #[deprecated(since = "v2.0.0", note = "Use update_user_status instead")]
-    pub fn set_user_status(env: Env, admin: Address, user: Address, is_blacklisted: bool) {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+    pub fn set_user_status(env: Env, admin: Address, user: Address, is_blacklisted: bool) -> Result<(), Error> {
+        require_admin!(env, admin);
         upgradeability::emit_deprecation_warning(&env, Symbol::new(&env, "set_user_status")).ok();
         Self::set_user_status_internal(&env, user, is_blacklisted);
+        Ok(())
     }
 
     /// Generate an AML compliance report for regulatory use
@@ -149,9 +149,8 @@ impl AntiMoneyLaundering {
         subject: Address,
         summary: String,
         evidence: String,
-    ) -> u64 {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+    ) -> Result<u64, Error> {
+        require_admin!(env, admin);
 
         let report_id = Self::next_id(&env, &DataKey::NextReportId);
         let profile = Self::get_or_create_profile(&env, &subject);
@@ -172,7 +171,7 @@ impl AntiMoneyLaundering {
 
         env.events()
             .publish((symbol_short!("AML"), symbol_short!("REPORT")), report_id);
-        report_id
+        Ok(report_id)
     }
 
     /// Register AML deprecated entrypoints for upgrade and migration tracking.
@@ -180,8 +179,10 @@ impl AntiMoneyLaundering {
         env: Env,
         admin: Address,
     ) -> Result<(), upgradeability::UpgradeError> {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+        (|| -> Result<(), Error> {
+            require_admin!(env, admin);
+            Ok(())
+        })().map_err(|_| upgradeability::UpgradeError::NotAuthorized)?;
         Self::ensure_upgrade_metadata(&env, &admin);
         upgradeability::set_deprecated_functions(&env, Self::deprecated_functions(&env))
     }
@@ -198,8 +199,10 @@ impl AntiMoneyLaundering {
         new_wasm_hash: BytesN<32>,
         new_version: u32,
     ) -> Result<(), upgradeability::UpgradeError> {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+        (|| -> Result<(), Error> {
+            require_admin!(env, admin);
+            Ok(())
+        })().map_err(|_| upgradeability::UpgradeError::NotAuthorized)?;
         Self::ensure_upgrade_metadata(&env, &admin);
         upgradeability::execute_upgrade_with_deprecations::<Self>(
             &env,
@@ -268,15 +271,16 @@ impl AntiMoneyLaundering {
         }
     }
 
-    fn require_admin(env: &Env, actor: &Address) {
+    fn require_admin(env: &Env, actor: &Address) -> Result<(), Error> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Not initialized");
+            .ok_or(Error::NotInitialized)?;
         if admin != *actor {
-            panic!("Unauthorized");
+            return Err(Error::NotAuthorized);
         }
+        Ok(())
     }
 
     fn ensure_upgrade_metadata(env: &Env, admin: &Address) {

--- a/contracts/anomaly_detector/Cargo.toml
+++ b/contracts/anomaly_detector/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 soroban-sdk.workspace = true
+governance_commons = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/anomaly_detector/src/lib.rs
+++ b/contracts/anomaly_detector/src/lib.rs
@@ -7,6 +7,7 @@
 #[cfg(test)]
 mod test;
 
+use governance_commons::require_admin;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
     String, Vec,
@@ -222,8 +223,7 @@ impl AnomalyDetectorContract {
     }
 
     pub fn add_validator(env: Env, caller: Address, validator: Address) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         env.storage()
             .instance()
             .set(&DataKey::Validator(validator.clone()), &true);
@@ -233,8 +233,7 @@ impl AnomalyDetectorContract {
     }
 
     pub fn remove_validator(env: Env, caller: Address, validator: Address) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         env.storage()
             .instance()
             .remove(&DataKey::Validator(validator.clone()));
@@ -243,16 +242,14 @@ impl AnomalyDetectorContract {
     }
 
     pub fn pause(env: Env, caller: Address) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events().publish((symbol_short!("Paused"),), caller);
         Ok(true)
     }
 
     pub fn unpause(env: Env, caller: Address) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         env.storage().instance().set(&DataKey::Paused, &false);
         env.events().publish((symbol_short!("Unpaused"),), caller);
         Ok(true)
@@ -266,8 +263,7 @@ impl AnomalyDetectorContract {
         model_id: BytesN<32>,
         threshold_bps: u32,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         if threshold_bps == 0 || threshold_bps >= 10_000 {
             return Err(Error::InvalidThreshold);
         }
@@ -289,8 +285,7 @@ impl AnomalyDetectorContract {
     /// Clear active alerts up to `count` (admin only). Pass 0 to clear all.
     /// Marks each active alert as Resolved and emits a ClearAlerts event.
     pub fn clear_alerts(env: Env, caller: Address, count: u64) -> Result<u64, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         let total: u64 = env
             .storage()
             .instance()

--- a/contracts/audit/Cargo.toml
+++ b/contracts/audit/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+governance_commons = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/audit/src/lib.rs
+++ b/contracts/audit/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 //! audit - Healthcare smart contract on Stellar blockchain.
 
+pub mod errors;
 pub mod querying;
 pub mod storage;
 pub mod types;
@@ -9,10 +10,12 @@ pub mod verification;
 #[cfg(test)]
 mod test;
 
+use crate::errors::Error;
 use crate::types::{
     ActionType, AuditConfig, AuditLog, AuditSummary, DataKey, ExportBundle, LogAccessEntry,
     OperationResult, RetentionPolicy,
 };
+use governance_commons::require_admin;
 use soroban_sdk::{
     contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, Map, String, Vec,
 };
@@ -202,9 +205,8 @@ impl AuditTrail {
     // ─── Access Control ──────────────────────────────────────────────────────
 
     /// Grant log-read access to an address (admin only).
-    pub fn grant_log_access(env: Env, admin: Address, reader: Address) {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+    pub fn grant_log_access(env: Env, admin: Address, reader: Address) -> Result<(), Error> {
+        require_admin!(env, admin);
 
         let entry = LogAccessEntry {
             reader: reader.clone(),
@@ -227,12 +229,12 @@ impl AuditTrail {
             (symbol_short!("AUDIT"), symbol_short!("GRANT")),
             (reader, admin),
         );
+        Ok(())
     }
 
     /// Revoke log-read access (admin only).
-    pub fn revoke_log_access(env: Env, admin: Address, reader: Address) {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+    pub fn revoke_log_access(env: Env, admin: Address, reader: Address) -> Result<(), Error> {
+        require_admin!(env, admin);
 
         env.storage()
             .persistent()
@@ -242,6 +244,7 @@ impl AuditTrail {
             (symbol_short!("AUDIT"), symbol_short!("REVOKE")),
             (reader, admin),
         );
+        Ok(())
     }
 
     /// Check whether an address has log-read access.
@@ -252,12 +255,12 @@ impl AuditTrail {
     // ─── Retention Policy ────────────────────────────────────────────────────
 
     /// Update the retention policy (admin only).
-    pub fn set_retention_policy(env: Env, admin: Address, policy: RetentionPolicy) {
-        admin.require_auth();
-        Self::require_admin(&env, &admin);
+    pub fn set_retention_policy(env: Env, admin: Address, policy: RetentionPolicy) -> Result<(), Error> {
+        require_admin!(env, admin);
         env.storage()
             .instance()
             .set(&DataKey::RetentionPolicy, &policy);
+        Ok(())
     }
 
     /// Read the current retention policy.
@@ -402,15 +405,16 @@ impl AuditTrail {
 
     // ─── Private helpers ─────────────────────────────────────────────────────
 
-    fn require_admin(env: &Env, caller: &Address) {
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
-            .expect("Contract not initialized");
+            .ok_or(Error::NotInitialized)?;
         if *caller != admin {
-            panic!("Caller is not the admin");
+            return Err(Error::Unauthorized);
         }
+        Ok(())
     }
 
     fn require_log_access(env: &Env, caller: &Address) {

--- a/contracts/cross_chain_bridge/Cargo.toml
+++ b/contracts/cross_chain_bridge/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 soroban-sdk = { workspace = true }
 replay_protection = { workspace = true }
+governance_commons = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/cross_chain_bridge/src/lib.rs
+++ b/contracts/cross_chain_bridge/src/lib.rs
@@ -26,6 +26,7 @@ mod reorg_protection_tests;
 /// **Payload**: `SHA256(Target_ID + Nonce)`
 ///   - `Target_ID`: The unique identifier of the entity being signed (e.g., `message_id`, `proof_id`).
 ///   - `Nonce`: A monotonically increasing 64-bit integer unique to the validator's public key.
+use governance_commons::require_admin;
 use soroban_sdk::{
     contract, contractimpl, contracttype, Address, Bytes, BytesN, Env, String, Symbol, Vec,
 };
@@ -484,8 +485,7 @@ impl CrossChainBridgeContract {
         public_key: BytesN<32>,
         initial_stake: i128,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         Self::require_not_paused(&env)?;
 
         let validator = Validator {
@@ -511,8 +511,7 @@ impl CrossChainBridgeContract {
         caller: Address,
         validator_address: Address,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         let key = DataKey::Validator(validator_address.clone());
         if let Some(mut validator) = env.storage().persistent().get::<DataKey, Validator>(&key) {
@@ -531,8 +530,7 @@ impl CrossChainBridgeContract {
     }
 
     pub fn add_supported_chain(env: Env, caller: Address, chain: ChainId) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         let mut chains: Vec<ChainId> = env
             .storage()
@@ -558,8 +556,7 @@ impl CrossChainBridgeContract {
         caller: Address,
         min_confirmations: u32,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         env.storage()
             .instance()
@@ -569,8 +566,7 @@ impl CrossChainBridgeContract {
     }
 
     pub fn pause(env: Env, caller: Address) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         env.storage().instance().set(&DataKey::Paused, &true);
 
@@ -583,8 +579,7 @@ impl CrossChainBridgeContract {
     }
 
     pub fn unpause(env: Env, caller: Address) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         env.storage().instance().set(&DataKey::Paused, &false);
 
@@ -1196,8 +1191,7 @@ impl CrossChainBridgeContract {
         public_key: BytesN<32>,
         supported_chains: Vec<ChainId>,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
         Self::require_not_paused(&env)?;
 
         let oracle = OracleNode {
@@ -1225,8 +1219,7 @@ impl CrossChainBridgeContract {
         caller: Address,
         oracle_address: Address,
     ) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         let key = DataKey::OracleNode(oracle_address.clone());
         if let Some(mut oracle) = env.storage().persistent().get::<DataKey, OracleNode>(&key) {
@@ -1868,8 +1861,7 @@ impl CrossChainBridgeContract {
 
     /// Execute a rollback — marks the associated operation as failed/rolled back
     pub fn execute_rollback(env: Env, caller: Address, op_id: BytesN<32>) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         let rb_key = DataKey::Rollback(op_id.clone());
         let mut rollback = env
@@ -1929,8 +1921,7 @@ impl CrossChainBridgeContract {
 
     /// Cancel a pending rollback
     pub fn cancel_rollback(env: Env, caller: Address, op_id: BytesN<32>) -> Result<bool, Error> {
-        caller.require_auth();
-        Self::require_admin(&env, &caller)?;
+        require_admin!(env, caller);
 
         let rb_key = DataKey::Rollback(op_id.clone());
         let mut rollback = env

--- a/contracts/rbac/Cargo.toml
+++ b/contracts/rbac/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 [dependencies]
 soroban-sdk.workspace = true
 common_error = { path = "../common_error" }
+governance_commons = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/rbac/src/lib.rs
+++ b/contracts/rbac/src/lib.rs
@@ -52,6 +52,7 @@ mod test;
 
 use crate::errors::Error;
 use events::{emit_initialized, emit_role_assigned, emit_role_removed};
+use governance_commons::require_admin;
 use queries::Queries;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Vec};
 use storage::Storage;
@@ -83,7 +84,7 @@ impl RBAC {
         }
 
         let admin = Storage::get_admin(&env);
-        admin.require_auth();
+        require_admin!(env, admin);
 
         let success = Storage::add_role(&env, &address, role);
 
@@ -117,7 +118,7 @@ impl RBAC {
         }
 
         let admin = Storage::get_admin(&env);
-        admin.require_auth();
+        require_admin!(env, admin);
 
         let success = Storage::remove_role(&env, &address, role);
 
@@ -232,7 +233,7 @@ impl RBAC {
         }
 
         let admin = Storage::get_admin(&env);
-        admin.require_auth();
+        require_admin!(env, admin);
 
         Storage::set_config(&env, &config);
 
@@ -247,5 +248,13 @@ impl RBAC {
         }
 
         Storage::get_config(&env).ok_or(Error::NotInitialized)
+    }
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin = Storage::get_admin(env);
+        if *caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        Ok(())
     }
 }

--- a/docs/SECURITY_CHECKLIST.md
+++ b/docs/SECURITY_CHECKLIST.md
@@ -6,9 +6,9 @@ Use this checklist before every PR and audit. Each item must be checked (✅) or
 
 ## 1. Access Control
 
-- [ ] Every state-mutating function calls `address.require_auth()` before any logic
-- [ ] Admin-only functions verify the caller is the stored admin address
-- [ ] Role checks are performed after `require_auth()`, not instead of it
+- [ ] Every state-mutating function calls `address.require_auth()` before any logic (use the shared `require_admin!(env, caller)` or `require_role!(env, caller, role)` macros from `governance_commons` where applicable)
+- [ ] Admin-only functions verify the caller is the stored admin address (preferably using `require_admin!(env, caller)`)
+- [ ] Role checks are performed after `require_auth()`, not instead of it (preferably using `require_role!(env, caller, role)`)
 - [ ] No function relies solely on caller address comparison without `require_auth()`
 - [ ] Ownership transfer requires auth from the **current** owner, not the new one
 

--- a/libs/governance_commons/src/lib.rs
+++ b/libs/governance_commons/src/lib.rs
@@ -44,9 +44,11 @@
 //! ```
 
 pub mod errors;
+pub mod macros;
 pub mod multi_sig;
 pub mod types;
 
 pub use errors::*;
+pub use macros::*;
 pub use multi_sig::*;
 pub use types::*;

--- a/libs/governance_commons/src/macros.rs
+++ b/libs/governance_commons/src/macros.rs
@@ -1,0 +1,23 @@
+#![no_std]
+
+/// Requires that the caller is authenticated and matches the admin check.
+///
+/// Expands to: `caller.require_auth(); Self::require_admin(&env, &caller)?;`
+#[macro_export]
+macro_rules! require_admin {
+    ($env:expr, $caller:expr) => {
+        $caller.require_auth();
+        Self::require_admin(&$env, &$caller)?;
+    };
+}
+
+/// Requires that the caller is authenticated and matches the role check.
+///
+/// Expands to: `caller.require_auth(); Self::require_role(&env, &caller, role)?;`
+#[macro_export]
+macro_rules! require_role {
+    ($env:expr, $caller:expr, $role:expr) => {
+        $caller.require_auth();
+        Self::require_role(&$env, &$caller, $role)?;
+    };
+}


### PR DESCRIPTION
close #847 

This pull request centralizes the admin and role authorization validation logic across the contract suite to address duplicate access control checks. Rather than having each contract manage its own inline require_auth sequence and local require_admin calls, we now use shared declarative macros. This reduces duplicate code, helps prevent authorization bypass bugs, and simplifies future audits.

We have introduced require_admin!(env, caller) and require_role!(env, caller, role) macros in the governance_commons library. These macros enforce that the caller is authenticated and call the contract's corresponding validation function. Five target contracts (anomaly_detector, cross_chain_bridge, aml, audit, and rbac) have been updated to declare the governance_commons dependency and use the new macros. To support this consolidation uniformly, some local contract methods and helper signatures have been refactored to return Result types instead of directly panicking.

Additionally, Section 1 of docs/SECURITY_CHECKLIST.md has been updated to require developers to use these shared macros for new access-controlled entrypoints. A corresponding entry noting the centralization has also been added under the unreleased security section in CHANGELOG.md