### PR TITLE
docs: add governance ADR index and records

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,12 @@ Please provide a clear and concise description of the feature or bug fix. Explai
 
 Link to any relevant issues. For example, `Closes #123`.
 
+## Architecture Decision Records
+
+- [ ] I checked `docs/adr/README.md` for relevant existing ADRs.
+- [ ] This PR does not require a new ADR.
+- [ ] This PR adds or updates an ADR because it changes a durable architecture decision.
+
 ---
 
 ## 🛡️ Security Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,13 @@
 # Contributing
 
+## Architecture Decisions
+
+Governance architecture decisions are tracked in
+[`docs/adr/README.md`](docs/adr/README.md). Before changing governance
+contracts, shared governance helpers, ZKP verification, or workspace membership
+for excluded contracts, check the ADR index and add or update an ADR when the
+change introduces a durable architectural decision.
+
 ## Event Topic Naming Convention
 
 All contract event topics **must** use `snake_case` naming. This applies to both

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,24 @@
+# ADR-0000: Title
+
+**Status:** Proposed
+**Date:** YYYY-MM-DD
+
+## Context
+
+Describe the forces that led to this decision. Include the problem, constraints,
+trade-offs, and links to relevant issues, pull requests, or design documents.
+
+## Decision
+
+State the decision in direct language. If alternatives were considered, list the
+chosen option first and explain why the rejected options were not selected.
+
+## Consequences
+
+Describe the expected positive and negative outcomes. Include follow-up work,
+risks, migration notes, and what future maintainers should watch for.
+
+## References
+
+- Related issue or pull request:
+- Related documentation:

--- a/docs/adr/ADR-001-governance-commons-migration.md
+++ b/docs/adr/ADR-001-governance-commons-migration.md
@@ -1,0 +1,71 @@
+# ADR-001: Governance Commons Migration
+
+**Status:** Accepted
+**Date:** 2025-06-29
+
+## Context
+
+The governance system includes multiple contracts with overlapping approval
+patterns. `UpgradeManager` coordinates contract upgrades with validator
+approvals, while `EmergencyAccessOverride` grants emergency medical access with
+approver consent and rate limiting. Before the governance separation work, each
+contract carried its own multi-signature approval tracking and threshold logic.
+
+Issue #769 documented the broader concern: governance responsibilities were hard
+to distinguish, and duplicated approval logic made future changes more expensive
+to audit.
+
+The relevant existing documentation is:
+
+- `docs/ISSUE_769_RESOLUTION.md`
+- `docs/GOVERNANCE_ARCHITECTURE.md`
+- `docs/GOVERNANCE_REFACTORING_GUIDE.md`
+- `libs/governance_commons/README.md`
+
+## Decision
+
+Create and use `libs/governance_commons` as the shared home for reusable
+governance primitives, starting with multi-signature approval helpers, common
+types, and common errors.
+
+The `governance_commons::multi_sig` module is the canonical implementation for:
+
+- approval set validation
+- approver validation
+- duplicate-safe approval insertion
+- threshold status calculation
+
+`UpgradeManager` and `EmergencyAccessOverride` remain separate contracts with
+separate responsibilities. They should use the shared approval helpers where the
+approval mechanics are common, while retaining domain-specific behavior in their
+own contracts.
+
+## Consequences
+
+Shared multi-signature logic reduces duplicate code and gives reviewers one
+place to inspect approval semantics.
+
+Contract-specific responsibilities remain explicit:
+
+- `UpgradeManager` owns contract upgrade orchestration.
+- `EmergencyAccessOverride` owns emergency medical access, expiry, and
+  rate-limiting behavior.
+- `Governor` owns token-holder proposal voting.
+- `DisputeResolution` owns proposal challenge and arbitration.
+
+Future changes to approval behavior must consider every caller of
+`governance_commons`. Contract-specific constraints, such as emergency-access
+rate limits, must not be moved into the shared library unless they become truly
+generic.
+
+The initial migration created the shared library and documented the intended
+refactoring path. Follow-up PRs can migrate remaining contract-local approval
+logic into the shared helpers when doing so does not change behavior.
+
+## References
+
+- `docs/ISSUE_769_RESOLUTION.md`
+- `docs/GOVERNANCE_ARCHITECTURE.md`
+- `docs/GOVERNANCE_REFACTORING_GUIDE.md`
+- `libs/governance_commons/README.md`
+- Original governance separation issue: #769

--- a/docs/adr/ADR-002-real-zkp-verification.md
+++ b/docs/adr/ADR-002-real-zkp-verification.md
@@ -1,0 +1,54 @@
+# ADR-002: Real ZKP Verification
+
+**Status:** Accepted
+**Date:** 2025-06-29
+
+## Context
+
+The repository contains a `zkp_registry` contract and related test suites for
+range proof behavior. Governance and healthcare workflows rely on privacy claims
+being verifiable rather than simulated.
+
+Simulated verification is useful during early scaffolding, but it creates a
+misleading security boundary: callers may believe a cryptographic proof was
+validated when only placeholder logic ran. That is especially risky in a
+healthcare-oriented protocol, where privacy claims and access decisions need a
+clear audit trail.
+
+Issue #829, "Replace Simulated ZKP Verification with Real Cryptographic
+Verification", is the decision point this ADR records.
+
+## Decision
+
+ZKP verification paths must use real cryptographic verification instead of
+simulation or test-only acceptance logic.
+
+The production contract boundary should distinguish three cases:
+
+- valid proof accepted
+- invalid proof rejected with a typed error
+- malformed or unsupported proof rejected before it can affect state
+
+Tests should cover positive and negative proof paths, including range proof
+negative cases, so future changes cannot silently reintroduce permissive
+placeholder behavior.
+
+## Consequences
+
+Security expectations become clearer for off-chain clients and auditors: a
+successful verification result means the proof was actually checked.
+
+The implementation becomes more complex than simulated logic. Developers need to
+maintain deterministic tests, fixtures, and negative cases so proof validation
+remains reviewable.
+
+Contract size, cost, and dependency constraints must be monitored. If a proof
+system cannot be supported within Soroban limits, that constraint should be
+captured in a new ADR rather than bypassed with simulation.
+
+## References
+
+- `contracts/zkp_registry/`
+- `contracts/zkp_registry/tests/range_proof_negatives_tests.rs`
+- `contracts/zkp_registry/tests/range_proof_property_tests.rs`
+- Related issue: #829

--- a/docs/adr/ADR-003-excluded-contracts-triage.md
+++ b/docs/adr/ADR-003-excluded-contracts-triage.md
@@ -1,0 +1,48 @@
+# ADR-003: Excluded Contracts Triage
+
+**Status:** Accepted
+**Date:** 2025-06-29
+
+## Context
+
+The repository has accumulated contracts that are excluded from the active
+workspace or not fully integrated into the standard build and test flow. Issue
+#828, "Reintegrate 36 Excluded Contracts -- Fix, Test, and Add to Workspace",
+identified the need to bring these contracts back under consistent maintenance.
+
+Reintegrating every excluded contract in one unreviewed batch would make review
+hard, risk hiding unrelated behavior changes, and make it unclear which
+contracts are production-ready.
+
+## Decision
+
+Use an explicit triage process before reintegrating excluded contracts.
+
+Each excluded contract should be classified into one of these buckets:
+
+- `Reintegrate now`: builds, has tests, and fits the active architecture.
+- `Fix first`: valuable contract, but blocked by compile errors, missing tests,
+  or outdated interfaces.
+- `Archive`: obsolete, duplicate, or superseded by another contract.
+- `Needs design decision`: requires a separate ADR or issue before code changes.
+
+Only contracts in `Reintegrate now` should be added back to the workspace
+directly. Contracts in other buckets need focused follow-up issues or PRs.
+
+## Consequences
+
+The workspace stays reviewable and avoids a high-risk bulk reintegration.
+
+Maintainers get a durable record of why each contract was restored, delayed, or
+archived. This reduces repeated debate when future contributors encounter the
+same excluded-contract list.
+
+This process adds upfront documentation work, but it makes CI failures and
+contract ownership clearer. Follow-up PRs should reference the triage bucket
+they are resolving.
+
+## References
+
+- Related issue: #828
+- `docs/GOVERNANCE_ARCHITECTURE.md`
+- `docs/GOVERNANCE_REFACTORING_GUIDE.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,44 @@
+# Architecture Decision Records
+
+This directory keeps a chronological record of governance-related architecture
+decisions for Uzima Contracts.
+
+ADRs are intended to answer: "Why did we choose this direction?" They complement
+the longer governance guides by preserving the context, decision, and
+consequences of accepted or rejected proposals.
+
+## Numbering
+
+- ADR numbers are monotonically increasing.
+- Numbers are never reused, even if an ADR is later superseded.
+- New ADRs should use the next available number in this directory.
+- Existing ADR filenames are preserved for compatibility with older links.
+
+## Status Values
+
+Use one of these statuses:
+
+- `Proposed`
+- `Accepted`
+- `Rejected`
+- `Deprecated`
+- `Superseded by ADR-XXXX`
+
+## Index
+
+| ADR | Status | Title |
+| --- | --- | --- |
+| [ADR-001](ADR-001-governance-commons-migration.md) | Accepted | Governance Commons Migration |
+| [ADR-002](ADR-002-real-zkp-verification.md) | Accepted | Real ZKP Verification |
+| [ADR-003](ADR-003-excluded-contracts-triage.md) | Accepted | Excluded Contracts Triage |
+| [ADR-006](ADR-006-governance-proposal-lifecycle.md) | Accepted | Governance Proposal Lifecycle |
+| [ADR-007](ADR-007-on-chain-vs-offchain-governance-data.md) | Accepted | On-Chain vs Off-Chain Storage of Governance Data |
+
+## Creating a New ADR
+
+1. Copy [`0000-template.md`](0000-template.md).
+2. Rename it to the next available number and a short kebab-case title, for
+   example `ADR-008-upgrade-quorum-policy.md`.
+3. Fill in the Context, Decision, and Consequences sections.
+4. Add the ADR to the index above.
+5. Link the ADR from the related issue or pull request.


### PR DESCRIPTION
Closes #853

## Summary
- add docs/adr/README.md with ADR numbering rules, status values, and an index
- add a reusable ADR template using Context / Decision / Consequences
- add retrospective ADR-001 through ADR-003 for governance commons migration, real ZKP verification, and excluded-contract triage
- link the ADR index from CONTRIBUTING.md and add an ADR checklist to the PR template

## Validation
- git diff --check -- .github/PULL_REQUEST_TEMPLATE.md CONTRIBUTING.md docs/adr/README.md docs/adr/0000-template.md docs/adr/ADR-001-governance-commons-migration.md docs/adr/ADR-002-real-zkp-verification.md docs/adr/ADR-003-excluded-contracts-triage.md
- docs-only change; no contract tests required
