### PR TITLE
Enforce ABI and SDK compatibility with contract interface registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,80 @@ jobs:
             });
 
   # ============================================================================
+  # ABI Compatibility Gate (issue #1097)
+  # Validates that contract interface changes are classified as breaking or
+  # non-breaking, produces a compatibility report for each contract, and fails
+  # CI when unapproved breaking changes are detected.
+  # ============================================================================
+  abi-compatibility:
+    name: ABI Compatibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Check ABI compatibility
+        run: |
+          node scripts/abi-compat.mjs --check --report reports/abi_compat.txt
+      - name: Upload ABI compatibility report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: abi-compatibility-report
+          path: reports/abi_compat.txt
+      - name: Comment PR with ABI compatibility summary
+        if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'reports/abi_compat.txt';
+            if (!fs.existsSync(path)) {
+              core.warning('ABI compatibility report not found at ' + path);
+              return;
+            }
+            const report = fs.readFileSync(path, 'utf8');
+            const breakingMatch = report.match(/^ABI_COMPAT_BREAKING=(\d+)\s*$/m);
+            const nonBreakingMatch = report.match(/^ABI_COMPAT_NON_BREAKING=(\d+)\s*$/m);
+            const breaking = breakingMatch ? Number(breakingMatch[1]) : null;
+            const nonBreaking = nonBreakingMatch ? Number(nonBreakingMatch[1]) : null;
+            if (breaking === null) {
+              core.warning('Could not parse ABI_COMPAT_BREAKING from report');
+              return;
+            }
+            const hasApproval = (context.payload.pull_request?.body || '').includes('[approve-abi-change]');
+            const emoji = breaking === 0 ? ':white_check_mark:' : hasApproval ? ':warning:' : ':x:';
+            const body = [
+              '### ' + emoji + ' ABI Compatibility',
+              '',
+              '| Metric | Count |',
+              '|--------|-------|',
+              '| Breaking changes | ' + breaking + ' |',
+              '| Non-breaking changes | ' + (nonBreaking ?? 'unknown') + ' |',
+              '',
+              breaking === 0
+                ? 'No breaking changes detected. All interface changes are additive.'
+                : hasApproval
+                  ? '> `[approve-abi-change]` present — breaking changes approved for this PR.'
+                  : 'Breaking changes detected. Add `[approve-abi-change]` to the PR body if intentional.',
+              '',
+              'See the `abi-compatibility-report` artifact for the full report.',
+              '',
+              '> See [docs/CONTRACT_COMPATIBILITY.md](docs/CONTRACT_COMPATIBILITY.md) for the change policy.'
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+  # ============================================================================
   # Event Emission Audit (SECURITY_CHECKLIST §5)
   # Enforces that every state-changing pub fn in contracts/*/src/lib.rs emits
   # an event via env.events().publish(...).  Legacy functions that predate

--- a/docs/CONTRACT_COMPATIBILITY.md
+++ b/docs/CONTRACT_COMPATIBILITY.md
@@ -1,0 +1,91 @@
+# Contract Interface Compatibility Policy
+
+This document defines the breaking vs non-breaking change policy for the Uzima contract interface registry and SDK bindings.
+
+## Overview
+
+The `schemas/interface-registry/registry.json` file is the **single source of truth** for all contract ABI surfaces consumed by generated SDK clients (TypeScript, Python) and documentation. CI enforces that changes to this registry are reviewed and classified before merge.
+
+## Change Classification
+
+### Breaking Changes (CI fails)
+
+Breaking changes require explicit approval via `[approve-abi-change]` in the PR body. These changes will cause downstream integration regressions if not coordinated:
+
+| Change Type | Example |
+|-------------|---------|
+| Enum variant removed | `ConsentStatus.EXPIRED` deleted |
+| Enum value changed | `RecordType.DIAGNOSIS` value changed from `"diagnosis"` to `"dx"` |
+| Enum removed entirely | `ActionType` deleted |
+| Required field added | Adding `newField: string` to `MedicalRecord` |
+| Required field type changed | `amount: number` changed to `amount: string` |
+| Field removed | `signature` removed from `MedicalRecord` |
+| Optional field became required | `tags?: string[]` changed to `tags: string[]` |
+| Interface removed | `PaymentStatus` interface deleted |
+| Contract removed from registry | `medical_records` contract removed |
+
+### Non-Breaking Changes (CI passes)
+
+These changes are additive and do not break existing integrations:
+
+| Change Type | Example |
+|-------------|---------|
+| Enum variant added | `RecordType.PROCEDURE` added |
+| Enum added | New `TelehealthStatus` enum |
+| Interface added | New `LabOrder` interface |
+| Optional field added | `newOptional?: string` added to `MedicalRecord` |
+| Required field became optional | `signature: string` changed to `signature?: string` |
+| Contract added to registry | New `lab_orders` contract registered |
+| Description updated | Field description text changed |
+
+## CI Workflow
+
+The `abi-compatibility` job in `.github/workflows/ci.yml` runs on every push and pull request:
+
+1. Generates a fresh ABI snapshot from the canonical definitions in `scripts/abi-compat.mjs`
+2. Compares against the committed baseline at `schemas/interface-registry/registry.json`
+3. Classifies all changes as breaking or non-breaking
+4. Posts a compatibility report as a PR comment
+5. **Fails** if any breaking changes are detected (unless `[approve-abi-change]` is in the PR body)
+
+## Workflow for Breaking Changes
+
+When you need to make a breaking change to a contract interface:
+
+1. Update the canonical definitions in `scripts/abi-compat.mjs` and `scripts/generate-sdk-types.mjs`
+2. Run `node scripts/abi-compat.mjs` to regenerate the baseline
+3. Run `node scripts/generate-sdk-types.mjs` to regenerate SDK bindings
+4. Add `[approve-abi-change]` to your PR body
+5. Document the migration path in your PR description
+6. Coordinate with downstream consumers (mobile SDK, API integrations)
+
+## Architecture
+
+```
+scripts/abi-compat.mjs          # Canonical interface definitions + compatibility checker
+scripts/generate-sdk-types.mjs  # SDK binding generator (must stay in sync)
+schemas/interface-registry/
+  registry.json                 # Committed ABI baseline (versioned snapshots)
+  registry.schema.json          # JSON Schema for the registry format
+```
+
+Both `abi-compat.mjs` and `generate-sdk-types.mjs` share the same canonical definitions. The CI compatibility gate ensures they stay in sync by comparing the generated output against the committed baseline.
+
+## Running Locally
+
+```bash
+# Generate/update baseline (after intentional interface changes)
+node scripts/abi-compat.mjs
+
+# Check for uncommitted drift
+node scripts/abi-compat.mjs --check
+
+# Generate report without failing
+node scripts/abi-compat.mjs --check --allow-breaking
+
+# SDK binding sync check
+node scripts/generate-sdk-types.mjs --check
+
+# Full local validation
+node scripts/abi-compat.mjs --check && node scripts/generate-sdk-types.mjs --check
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
     "events:validate": "node scripts/events/validate.mjs",
     "test:pyramid:report": "node scripts/testing/pyramid-report.mjs",
     "sdk:generate": "node scripts/generate-sdk-types.mjs",
-    "sdk:check": "node scripts/generate-sdk-types.mjs --check"
+    "sdk:check": "node scripts/generate-sdk-types.mjs --check",
+    "abi:generate": "node scripts/abi-compat.mjs",
+    "abi:check": "node scripts/abi-compat.mjs --check",
+    "abi:check:allow-breaking": "node scripts/abi-compat.mjs --check --allow-breaking",
+    "compat:check": "node scripts/abi-compat.mjs --check && node scripts/generate-sdk-types.mjs --check"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.4.3",

--- a/schemas/interface-registry/registry.json
+++ b/schemas/interface-registry/registry.json
@@ -1,0 +1,792 @@
+{
+  "registry_version": "1.0.0",
+  "generated_at": "2026-07-22T19:18:59.474Z",
+  "generator": {
+    "name": "scripts/abi-compat.mjs",
+    "version": "1.0.0"
+  },
+  "contracts": [
+    {
+      "name": "audit",
+      "version": "1.0.0",
+      "enums": [],
+      "interfaces": [
+        {
+          "name": "AuditEntry",
+          "contractName": "audit",
+          "description": "Audit log entry for compliance and forensics",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "Unique audit entry identifier"
+            },
+            {
+              "name": "actor",
+              "type": "string",
+              "description": "Address of the actor performing the action"
+            },
+            {
+              "name": "action",
+              "type": "ActionType",
+              "description": "Type of action performed"
+            },
+            {
+              "name": "resource",
+              "type": "string",
+              "description": "Resource identifier being acted upon",
+              "optional": true
+            },
+            {
+              "name": "resourceType",
+              "type": "string",
+              "description": "Type of resource",
+              "optional": true
+            },
+            {
+              "name": "result",
+              "type": "string",
+              "description": "Operation result (success/failure)",
+              "optional": true
+            },
+            {
+              "name": "reason",
+              "type": "string",
+              "description": "Reason for the action",
+              "optional": true
+            },
+            {
+              "name": "timestamp",
+              "type": "number",
+              "description": "Action timestamp (Unix seconds)"
+            },
+            {
+              "name": "ipAddress",
+              "type": "string",
+              "description": "IP address of the actor",
+              "optional": true
+            },
+            {
+              "name": "metadata",
+              "type": "Record<string, string>",
+              "description": "Additional context",
+              "optional": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "healthcare_payment",
+      "version": "1.0.0",
+      "enums": [],
+      "interfaces": [
+        {
+          "name": "PaymentStatus",
+          "contractName": "healthcare_payment",
+          "description": "Payment status for healthcare claims and payments",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "Unique payment identifier"
+            },
+            {
+              "name": "patientId",
+              "type": "string",
+              "description": "Patient's Stellar address"
+            },
+            {
+              "name": "providerId",
+              "type": "string",
+              "description": "Provider's Stellar address"
+            },
+            {
+              "name": "amount",
+              "type": "number",
+              "description": "Payment amount in smallest unit"
+            },
+            {
+              "name": "currency",
+              "type": "string",
+              "description": "Currency code (e.g., \"USDC\")"
+            },
+            {
+              "name": "status",
+              "type": "PaymentStatusEnum",
+              "description": "Current payment status"
+            },
+            {
+              "name": "serviceId",
+              "type": "string",
+              "description": "Service identifier",
+              "optional": true
+            },
+            {
+              "name": "policyId",
+              "type": "string",
+              "description": "Insurance policy ID",
+              "optional": true
+            },
+            {
+              "name": "createdAt",
+              "type": "number",
+              "description": "Creation timestamp (Unix seconds)"
+            },
+            {
+              "name": "updatedAt",
+              "type": "number",
+              "description": "Last update timestamp (Unix seconds)"
+            },
+            {
+              "name": "completedAt",
+              "type": "number",
+              "description": "Completion timestamp (Unix seconds)",
+              "optional": true
+            },
+            {
+              "name": "transactionHash",
+              "type": "string",
+              "description": "Blockchain transaction hash",
+              "optional": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "identity_registry",
+      "version": "1.0.0",
+      "enums": [],
+      "interfaces": [
+        {
+          "name": "IdentityDocument",
+          "contractName": "identity_registry",
+          "description": "Identity document (Decentralized Identifier) per W3C DID spec",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "The DID identifier"
+            },
+            {
+              "name": "context",
+              "type": "string[]",
+              "description": "JSON-LD context URLs"
+            },
+            {
+              "name": "verificationMethods",
+              "type": "VerificationMethod[]",
+              "description": "Public key information"
+            },
+            {
+              "name": "authenticationMethods",
+              "type": "VerificationRelationship[]",
+              "description": "Auth key relationships",
+              "optional": true
+            },
+            {
+              "name": "assertionMethods",
+              "type": "VerificationRelationship[]",
+              "description": "Assertion key relationships",
+              "optional": true
+            },
+            {
+              "name": "serviceEndpoints",
+              "type": "ServiceEndpoint[]",
+              "description": "Service URLs",
+              "optional": true
+            },
+            {
+              "name": "created",
+              "type": "number",
+              "description": "Creation timestamp (Unix seconds)"
+            },
+            {
+              "name": "updated",
+              "type": "number",
+              "description": "Last update timestamp (Unix seconds)",
+              "optional": true
+            },
+            {
+              "name": "proof",
+              "type": "string",
+              "description": "Cryptographic proof",
+              "optional": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "medical_records",
+      "version": "1.0.0",
+      "enums": [],
+      "interfaces": [
+        {
+          "name": "MedicalRecord",
+          "contractName": "medical_records",
+          "description": "Medical record structure matching contract schema",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "Unique record identifier"
+            },
+            {
+              "name": "patientId",
+              "type": "string",
+              "description": "Patient's Stellar address"
+            },
+            {
+              "name": "providerId",
+              "type": "string",
+              "description": "Healthcare provider's Stellar address"
+            },
+            {
+              "name": "recordType",
+              "type": "RecordType",
+              "description": "Type of medical record"
+            },
+            {
+              "name": "data",
+              "type": "EncryptedData",
+              "description": "Encrypted record content"
+            },
+            {
+              "name": "metadata",
+              "type": "RecordMetadata",
+              "description": "Record metadata and access log"
+            },
+            {
+              "name": "timestamp",
+              "type": "number",
+              "description": "Record creation timestamp (Unix seconds)"
+            },
+            {
+              "name": "isEncrypted",
+              "type": "boolean",
+              "description": "Whether the data is encrypted"
+            },
+            {
+              "name": "signature",
+              "type": "string",
+              "description": "Optional cryptographic signature",
+              "optional": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "patient_consent_management",
+      "version": "1.0.0",
+      "enums": [],
+      "interfaces": [
+        {
+          "name": "ConsentGrant",
+          "contractName": "patient_consent_management",
+          "description": "Consent grant from patient to provider",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "Unique consent identifier"
+            },
+            {
+              "name": "patientId",
+              "type": "string",
+              "description": "Patient's Stellar address"
+            },
+            {
+              "name": "providerId",
+              "type": "string",
+              "description": "Healthcare provider's Stellar address"
+            },
+            {
+              "name": "grantedAt",
+              "type": "number",
+              "description": "Timestamp when consent was granted (Unix seconds)"
+            },
+            {
+              "name": "revokedAt",
+              "type": "number",
+              "description": "Timestamp when consent was revoked (Unix seconds)",
+              "optional": true
+            },
+            {
+              "name": "status",
+              "type": "ConsentStatus",
+              "description": "Current consent status"
+            },
+            {
+              "name": "scope",
+              "type": "string[]",
+              "description": "Optional data access scope",
+              "optional": true
+            },
+            {
+              "name": "expiresAt",
+              "type": "number",
+              "description": "Optional consent expiration timestamp (Unix seconds)",
+              "optional": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "shared_types",
+      "version": "1.0.0",
+      "enums": [
+        {
+          "name": "RecordType",
+          "description": "Enumeration of medical record types",
+          "values": [
+            {
+              "member": "DIAGNOSIS",
+              "value": "diagnosis",
+              "description": "Diagnosis record"
+            },
+            {
+              "member": "PRESCRIPTION",
+              "value": "prescription",
+              "description": "Prescription record"
+            },
+            {
+              "member": "LAB_RESULT",
+              "value": "lab_result",
+              "description": "Laboratory test result"
+            },
+            {
+              "member": "IMAGING",
+              "value": "imaging",
+              "description": "Medical imaging record"
+            },
+            {
+              "member": "CONSULTATION",
+              "value": "consultation",
+              "description": "Consultation notes"
+            },
+            {
+              "member": "VITAL_SIGNS",
+              "value": "vital_signs",
+              "description": "Vital signs measurement"
+            },
+            {
+              "member": "IMMUNIZATION",
+              "value": "immunization",
+              "description": "Immunization record"
+            },
+            {
+              "member": "MEDICATION_HISTORY",
+              "value": "medication_history",
+              "description": "Medication history"
+            },
+            {
+              "member": "ALLERGY",
+              "value": "allergy",
+              "description": "Allergy information"
+            },
+            {
+              "member": "PROCEDURE",
+              "value": "procedure",
+              "description": "Medical procedure record"
+            }
+          ]
+        },
+        {
+          "name": "EncryptionAlgorithm",
+          "description": "Encryption algorithm used for medical data",
+          "values": [
+            {
+              "member": "NACL_BOX",
+              "value": "nacl-box",
+              "description": "NaCl box (public-key encryption)"
+            },
+            {
+              "member": "NACL_SECRETBOX",
+              "value": "nacl-secretbox",
+              "description": "NaCl secretbox (secret-key encryption)"
+            },
+            {
+              "member": "AES_256_GCM",
+              "value": "aes-256-gcm",
+              "description": "AES-256 GCM"
+            }
+          ]
+        },
+        {
+          "name": "ConsentStatus",
+          "description": "Consent grant status",
+          "values": [
+            {
+              "member": "ACTIVE",
+              "value": "active",
+              "description": "Consent is active and valid"
+            },
+            {
+              "member": "REVOKED",
+              "value": "revoked",
+              "description": "Consent has been revoked"
+            },
+            {
+              "member": "PENDING",
+              "value": "pending",
+              "description": "Consent is pending approval"
+            },
+            {
+              "member": "EXPIRED",
+              "value": "expired",
+              "description": "Consent has expired"
+            }
+          ]
+        },
+        {
+          "name": "VerificationMethodType",
+          "description": "Verification method types per W3C DID specification",
+          "values": [
+            {
+              "member": "ED25519_VERIFICATION_KEY_2020",
+              "value": "Ed25519VerificationKey2020",
+              "description": "Ed25519 Verification Key (2020)"
+            },
+            {
+              "member": "ECDSA_SECP256K1_VERIF_KEY_2019",
+              "value": "EcdsaSecp256k1VerifKey2019",
+              "description": "ECDSA Secp256k1 Verification Key (2019)"
+            },
+            {
+              "member": "X25519_KEY_AGREEMENT_KEY_2020",
+              "value": "X25519KeyAgreementKey2020",
+              "description": "X25519 Key Agreement Key (2020)"
+            },
+            {
+              "member": "JSON_WEB_KEY_2020",
+              "value": "JsonWebKey2020",
+              "description": "JSON Web Key (2020)"
+            },
+            {
+              "member": "FIDO2_ED_DSA_2024",
+              "value": "Fido2EdDsa2024",
+              "description": "FIDO2 EdDSA Key (2024)"
+            },
+            {
+              "member": "FIDO2_ES256_2024",
+              "value": "Fido2Es2562024",
+              "description": "FIDO2 ES256 Key (2024)"
+            }
+          ]
+        },
+        {
+          "name": "VerificationRelationship",
+          "description": "Verification relationship types per W3C DID specification",
+          "values": [
+            {
+              "member": "AUTHENTICATION",
+              "value": "Authentication",
+              "description": "Authentication relationship"
+            },
+            {
+              "member": "ASSERTION_METHOD",
+              "value": "AssertionMethod",
+              "description": "Assertion method relationship"
+            },
+            {
+              "member": "KEY_AGREEMENT",
+              "value": "KeyAgreement",
+              "description": "Key agreement relationship"
+            },
+            {
+              "member": "CAPABILITY_INVOCATION",
+              "value": "CapabilityInvocation",
+              "description": "Capability invocation relationship"
+            },
+            {
+              "member": "CAPABILITY_DELEGATION",
+              "value": "CapabilityDelegation",
+              "description": "Capability delegation relationship"
+            }
+          ]
+        },
+        {
+          "name": "PaymentStatusEnum",
+          "description": "Payment/claim status enumeration",
+          "values": [
+            {
+              "member": "SUBMITTED",
+              "value": "submitted",
+              "description": "Payment claim submitted"
+            },
+            {
+              "member": "VERIFIED",
+              "value": "verified",
+              "description": "Payment claim verified"
+            },
+            {
+              "member": "APPROVED",
+              "value": "approved",
+              "description": "Payment claim approved"
+            },
+            {
+              "member": "REJECTED",
+              "value": "rejected",
+              "description": "Payment claim rejected"
+            },
+            {
+              "member": "PAID",
+              "value": "paid",
+              "description": "Payment completed"
+            },
+            {
+              "member": "DISPUTED",
+              "value": "disputed",
+              "description": "Payment disputed"
+            }
+          ]
+        },
+        {
+          "name": "ActionType",
+          "description": "Audit action types",
+          "values": [
+            {
+              "member": "DATA_READ",
+              "value": "DataRead",
+              "description": "Data read operation"
+            },
+            {
+              "member": "DATA_WRITE",
+              "value": "DataWrite",
+              "description": "Data write operation"
+            },
+            {
+              "member": "DATA_DELETE",
+              "value": "DataDelete",
+              "description": "Data delete operation"
+            },
+            {
+              "member": "DATA_EXPORT",
+              "value": "DataExport",
+              "description": "Data export operation"
+            },
+            {
+              "member": "PERMISSION_GRANT",
+              "value": "PermissionGrant",
+              "description": "Permission grant"
+            },
+            {
+              "member": "PERMISSION_REVOKE",
+              "value": "PermissionRevoke",
+              "description": "Permission revoke"
+            },
+            {
+              "member": "ROLE_ASSIGN",
+              "value": "RoleAssign",
+              "description": "Role assignment"
+            },
+            {
+              "member": "ROLE_REVOKE",
+              "value": "RoleRevoke",
+              "description": "Role revocation"
+            },
+            {
+              "member": "RECORD_CREATE",
+              "value": "RecordCreate",
+              "description": "Record creation"
+            },
+            {
+              "member": "RECORD_UPDATE",
+              "value": "RecordUpdate",
+              "description": "Record update"
+            },
+            {
+              "member": "RECORD_ARCHIVE",
+              "value": "RecordArchive",
+              "description": "Record archive"
+            },
+            {
+              "member": "RECORD_RESTORE",
+              "value": "RecordRestore",
+              "description": "Record restore"
+            },
+            {
+              "member": "AUTH_SUCCESS",
+              "value": "AuthSuccess",
+              "description": "Authentication success"
+            },
+            {
+              "member": "AUTH_FAILURE",
+              "value": "AuthFailure",
+              "description": "Authentication failure"
+            },
+            {
+              "member": "AUTH_LOGOUT",
+              "value": "AuthLogout",
+              "description": "User logout"
+            },
+            {
+              "member": "TOKEN_REFRESH",
+              "value": "TokenRefresh",
+              "description": "Token refresh"
+            },
+            {
+              "member": "CROSS_CHAIN_TRANSFER_INIT",
+              "value": "CrossChainTransferInit",
+              "description": "Cross-chain transfer initiated"
+            },
+            {
+              "member": "CROSS_CHAIN_TRANSFER_COMPLETED",
+              "value": "CrossChainTransferCompleted",
+              "description": "Cross-chain transfer completed"
+            }
+          ]
+        }
+      ],
+      "interfaces": [
+        {
+          "name": "EncryptedData",
+          "description": "Encrypted data container",
+          "fields": [
+            {
+              "name": "ciphertext",
+              "type": "string",
+              "description": "Base64-encoded encrypted data"
+            },
+            {
+              "name": "nonce",
+              "type": "string",
+              "description": "Base64-encoded encryption nonce"
+            },
+            {
+              "name": "algorithm",
+              "type": "EncryptionAlgorithm",
+              "description": "The encryption algorithm used"
+            }
+          ]
+        },
+        {
+          "name": "AccessLog",
+          "description": "Access log entry for audit trail",
+          "fields": [
+            {
+              "name": "accessor",
+              "type": "string",
+              "description": "The address of who accessed the record"
+            },
+            {
+              "name": "accessTime",
+              "type": "number",
+              "description": "Timestamp of access (Unix seconds)"
+            },
+            {
+              "name": "accessType",
+              "type": "'read' | 'write' | 'share'",
+              "description": "Type of access"
+            },
+            {
+              "name": "ipAddress",
+              "type": "string",
+              "description": "Optional IP address of the accessor",
+              "optional": true
+            }
+          ]
+        },
+        {
+          "name": "RecordMetadata",
+          "description": "Metadata for medical records",
+          "fields": [
+            {
+              "name": "createdAt",
+              "type": "number",
+              "description": "Creation timestamp (Unix seconds)"
+            },
+            {
+              "name": "updatedAt",
+              "type": "number",
+              "description": "Last update timestamp (Unix seconds)"
+            },
+            {
+              "name": "accessLog",
+              "type": "AccessLog[]",
+              "description": "Complete access history"
+            },
+            {
+              "name": "tags",
+              "type": "string[]",
+              "description": "Optional tags for categorization",
+              "optional": true
+            },
+            {
+              "name": "isTraditionalHealing",
+              "type": "boolean",
+              "description": "Whether this is traditional healing record",
+              "optional": true
+            }
+          ]
+        },
+        {
+          "name": "VerificationMethod",
+          "description": "Verification method (public key) for W3C DID",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "Fragment identifier"
+            },
+            {
+              "name": "methodType",
+              "type": "VerificationMethodType",
+              "description": "Type of verification method"
+            },
+            {
+              "name": "controller",
+              "type": "string",
+              "description": "Controller address"
+            },
+            {
+              "name": "publicKey",
+              "type": "string",
+              "description": "Base64-encoded public key"
+            },
+            {
+              "name": "isActive",
+              "type": "boolean",
+              "description": "Whether this key is active"
+            },
+            {
+              "name": "created",
+              "type": "number",
+              "description": "Creation timestamp (Unix seconds)"
+            },
+            {
+              "name": "lastRotated",
+              "type": "number",
+              "description": "Last rotation timestamp (Unix seconds, 0 if never)"
+            }
+          ]
+        },
+        {
+          "name": "ServiceEndpoint",
+          "description": "Service endpoint for W3C DID",
+          "fields": [
+            {
+              "name": "id",
+              "type": "string",
+              "description": "Service identifier"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Service type"
+            },
+            {
+              "name": "url",
+              "type": "string",
+              "description": "Service endpoint URL"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/interface-registry/registry.schema.json
+++ b/schemas/interface-registry/registry.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Stellar-Uzima/Uzima-Contracts/schemas/interface-registry/registry.schema.json",
+  "title": "Uzima Contract Interface Registry",
+  "description": "Versioned registry of contract ABI snapshots and SDK compatibility metadata.",
+  "type": "object",
+  "required": ["registry_version", "generated_at", "generator", "contracts"],
+  "properties": {
+    "registry_version": {
+      "type": "string",
+      "description": "Semver version of the registry format itself."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when this registry snapshot was produced."
+    },
+    "generator": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
+    "contracts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ContractEntry"
+      }
+    }
+  },
+  "$defs": {
+    "ContractEntry": {
+      "type": "object",
+      "required": ["name", "version", "enums", "interfaces"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Contract identifier (directory name under contracts/)."
+        },
+        "version": {
+          "type": "string",
+          "description": "User-facing version string for the contract's public API surface."
+        },
+        "enums": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EnumEntry" }
+        },
+        "interfaces": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/InterfaceEntry" }
+        }
+      }
+    },
+    "EnumEntry": {
+      "type": "object",
+      "required": ["name", "values"],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["member", "value"],
+            "properties": {
+              "member": { "type": "string" },
+              "value": { "type": "string" },
+              "description": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "InterfaceEntry": {
+      "type": "object",
+      "required": ["name", "fields"],
+      "properties": {
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "contractName": { "type": "string" },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/FieldEntry" }
+        }
+      }
+    },
+    "FieldEntry": {
+      "type": "object",
+      "required": ["name", "type"],
+      "properties": {
+        "name": { "type": "string" },
+        "type": { "type": "string" },
+        "description": { "type": "string" },
+        "optional": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/scripts/abi-compat.mjs
+++ b/scripts/abi-compat.mjs
@@ -1,0 +1,628 @@
+#!/usr/bin/env node
+
+/**
+ * ABI Compatibility Checker for Uzima contract interfaces.
+ *
+ * Generates ABI snapshots for all registered contracts, compares them against
+ * the committed baseline, classifies changes as breaking or non-breaking, and
+ * produces a machine-readable compatibility report for CI.
+ *
+ * Usage:
+ *   node scripts/abi-compat.mjs                   # generate snapshots + update baseline
+ *   node scripts/abi-compat.mjs --check            # fail if breaking changes detected
+ *   node scripts/abi-compat.mjs --check --report reports/abi_compat.txt
+ *   node scripts/abi-comcompat.mjs --check --allow-breaking  # report but don't fail
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+const args = process.argv.slice(2);
+const CHECK_MODE = args.includes('--check');
+const ALLOW_BREAKING = args.includes('--allow-breaking');
+const reportFlagIndex = args.indexOf('--report');
+const REPORT_PATH =
+  reportFlagIndex !== -1 ? args[reportFlagIndex + 1] : null;
+
+const REGISTRY_SCHEMA = path.join(
+  projectRoot,
+  'schemas/interface-registry/registry.schema.json',
+);
+const REGISTRY_BASELINE = path.join(
+  projectRoot,
+  'schemas/interface-registry/registry.json',
+);
+
+const GENERATOR_VERSION = '1.0.0';
+
+// ---------------------------------------------------------------------------
+// Canonical interface definitions (single source of truth)
+// Mirrored from generate-sdk-types.mjs – kept in sync via the compatibility
+// gate itself.  When a developer adds or changes a contract interface they
+// must update the appropriate definition below *and* run the generator.
+// ---------------------------------------------------------------------------
+
+const ENUM_DEFINITIONS = {
+  RecordType: {
+    description: 'Enumeration of medical record types',
+    values: [
+      { member: 'DIAGNOSIS', value: 'diagnosis', description: 'Diagnosis record' },
+      { member: 'PRESCRIPTION', value: 'prescription', description: 'Prescription record' },
+      { member: 'LAB_RESULT', value: 'lab_result', description: 'Laboratory test result' },
+      { member: 'IMAGING', value: 'imaging', description: 'Medical imaging record' },
+      { member: 'CONSULTATION', value: 'consultation', description: 'Consultation notes' },
+      { member: 'VITAL_SIGNS', value: 'vital_signs', description: 'Vital signs measurement' },
+      { member: 'IMMUNIZATION', value: 'immunization', description: 'Immunization record' },
+      { member: 'MEDICATION_HISTORY', value: 'medication_history', description: 'Medication history' },
+      { member: 'ALLERGY', value: 'allergy', description: 'Allergy information' },
+      { member: 'PROCEDURE', value: 'procedure', description: 'Medical procedure record' },
+    ],
+  },
+  EncryptionAlgorithm: {
+    description: 'Encryption algorithm used for medical data',
+    values: [
+      { member: 'NACL_BOX', value: 'nacl-box', description: 'NaCl box (public-key encryption)' },
+      { member: 'NACL_SECRETBOX', value: 'nacl-secretbox', description: 'NaCl secretbox (secret-key encryption)' },
+      { member: 'AES_256_GCM', value: 'aes-256-gcm', description: 'AES-256 GCM' },
+    ],
+  },
+  ConsentStatus: {
+    description: 'Consent grant status',
+    values: [
+      { member: 'ACTIVE', value: 'active', description: 'Consent is active and valid' },
+      { member: 'REVOKED', value: 'revoked', description: 'Consent has been revoked' },
+      { member: 'PENDING', value: 'pending', description: 'Consent is pending approval' },
+      { member: 'EXPIRED', value: 'expired', description: 'Consent has expired' },
+    ],
+  },
+  VerificationMethodType: {
+    description: 'Verification method types per W3C DID specification',
+    values: [
+      { member: 'ED25519_VERIFICATION_KEY_2020', value: 'Ed25519VerificationKey2020', description: 'Ed25519 Verification Key (2020)' },
+      { member: 'ECDSA_SECP256K1_VERIF_KEY_2019', value: 'EcdsaSecp256k1VerifKey2019', description: 'ECDSA Secp256k1 Verification Key (2019)' },
+      { member: 'X25519_KEY_AGREEMENT_KEY_2020', value: 'X25519KeyAgreementKey2020', description: 'X25519 Key Agreement Key (2020)' },
+      { member: 'JSON_WEB_KEY_2020', value: 'JsonWebKey2020', description: 'JSON Web Key (2020)' },
+      { member: 'FIDO2_ED_DSA_2024', value: 'Fido2EdDsa2024', description: 'FIDO2 EdDSA Key (2024)' },
+      { member: 'FIDO2_ES256_2024', value: 'Fido2Es2562024', description: 'FIDO2 ES256 Key (2024)' },
+    ],
+  },
+  VerificationRelationship: {
+    description: 'Verification relationship types per W3C DID specification',
+    values: [
+      { member: 'AUTHENTICATION', value: 'Authentication', description: 'Authentication relationship' },
+      { member: 'ASSERTION_METHOD', value: 'AssertionMethod', description: 'Assertion method relationship' },
+      { member: 'KEY_AGREEMENT', value: 'KeyAgreement', description: 'Key agreement relationship' },
+      { member: 'CAPABILITY_INVOCATION', value: 'CapabilityInvocation', description: 'Capability invocation relationship' },
+      { member: 'CAPABILITY_DELEGATION', value: 'CapabilityDelegation', description: 'Capability delegation relationship' },
+    ],
+  },
+  PaymentStatusEnum: {
+    description: 'Payment/claim status enumeration',
+    values: [
+      { member: 'SUBMITTED', value: 'submitted', description: 'Payment claim submitted' },
+      { member: 'VERIFIED', value: 'verified', description: 'Payment claim verified' },
+      { member: 'APPROVED', value: 'approved', description: 'Payment claim approved' },
+      { member: 'REJECTED', value: 'rejected', description: 'Payment claim rejected' },
+      { member: 'PAID', value: 'paid', description: 'Payment completed' },
+      { member: 'DISPUTED', value: 'disputed', description: 'Payment disputed' },
+    ],
+  },
+  ActionType: {
+    description: 'Audit action types',
+    values: [
+      { member: 'DATA_READ', value: 'DataRead', description: 'Data read operation' },
+      { member: 'DATA_WRITE', value: 'DataWrite', description: 'Data write operation' },
+      { member: 'DATA_DELETE', value: 'DataDelete', description: 'Data delete operation' },
+      { member: 'DATA_EXPORT', value: 'DataExport', description: 'Data export operation' },
+      { member: 'PERMISSION_GRANT', value: 'PermissionGrant', description: 'Permission grant' },
+      { member: 'PERMISSION_REVOKE', value: 'PermissionRevoke', description: 'Permission revoke' },
+      { member: 'ROLE_ASSIGN', value: 'RoleAssign', description: 'Role assignment' },
+      { member: 'ROLE_REVOKE', value: 'RoleRevoke', description: 'Role revocation' },
+      { member: 'RECORD_CREATE', value: 'RecordCreate', description: 'Record creation' },
+      { member: 'RECORD_UPDATE', value: 'RecordUpdate', description: 'Record update' },
+      { member: 'RECORD_ARCHIVE', value: 'RecordArchive', description: 'Record archive' },
+      { member: 'RECORD_RESTORE', value: 'RecordRestore', description: 'Record restore' },
+      { member: 'AUTH_SUCCESS', value: 'AuthSuccess', description: 'Authentication success' },
+      { member: 'AUTH_FAILURE', value: 'AuthFailure', description: 'Authentication failure' },
+      { member: 'AUTH_LOGOUT', value: 'AuthLogout', description: 'User logout' },
+      { member: 'TOKEN_REFRESH', value: 'TokenRefresh', description: 'Token refresh' },
+      { member: 'CROSS_CHAIN_TRANSFER_INIT', value: 'CrossChainTransferInit', description: 'Cross-chain transfer initiated' },
+      { member: 'CROSS_CHAIN_TRANSFER_COMPLETED', value: 'CrossChainTransferCompleted', description: 'Cross-chain transfer completed' },
+    ],
+  },
+};
+
+const INTERFACE_DEFINITIONS = {
+  EncryptedData: {
+    description: 'Encrypted data container',
+    fields: [
+      { name: 'ciphertext', type: 'string', description: 'Base64-encoded encrypted data' },
+      { name: 'nonce', type: 'string', description: 'Base64-encoded encryption nonce' },
+      { name: 'algorithm', type: 'EncryptionAlgorithm', description: 'The encryption algorithm used' },
+    ],
+  },
+  AccessLog: {
+    description: 'Access log entry for audit trail',
+    fields: [
+      { name: 'accessor', type: 'string', description: 'The address of who accessed the record' },
+      { name: 'accessTime', type: 'number', description: 'Timestamp of access (Unix seconds)' },
+      { name: 'accessType', type: "'read' | 'write' | 'share'", description: 'Type of access' },
+      { name: 'ipAddress', type: 'string', description: 'Optional IP address of the accessor', optional: true },
+    ],
+  },
+  RecordMetadata: {
+    description: 'Metadata for medical records',
+    fields: [
+      { name: 'createdAt', type: 'number', description: 'Creation timestamp (Unix seconds)' },
+      { name: 'updatedAt', type: 'number', description: 'Last update timestamp (Unix seconds)' },
+      { name: 'accessLog', type: 'AccessLog[]', description: 'Complete access history' },
+      { name: 'tags', type: 'string[]', description: 'Optional tags for categorization', optional: true },
+      { name: 'isTraditionalHealing', type: 'boolean', description: 'Whether this is traditional healing record', optional: true },
+    ],
+  },
+  MedicalRecord: {
+    contractName: 'medical_records',
+    description: 'Medical record structure matching contract schema',
+    fields: [
+      { name: 'id', type: 'string', description: 'Unique record identifier' },
+      { name: 'patientId', type: 'string', description: "Patient's Stellar address" },
+      { name: 'providerId', type: 'string', description: "Healthcare provider's Stellar address" },
+      { name: 'recordType', type: 'RecordType', description: 'Type of medical record' },
+      { name: 'data', type: 'EncryptedData', description: 'Encrypted record content' },
+      { name: 'metadata', type: 'RecordMetadata', description: 'Record metadata and access log' },
+      { name: 'timestamp', type: 'number', description: 'Record creation timestamp (Unix seconds)' },
+      { name: 'isEncrypted', type: 'boolean', description: 'Whether the data is encrypted' },
+      { name: 'signature', type: 'string', description: 'Optional cryptographic signature', optional: true },
+    ],
+  },
+  ConsentGrant: {
+    contractName: 'patient_consent_management',
+    description: 'Consent grant from patient to provider',
+    fields: [
+      { name: 'id', type: 'string', description: 'Unique consent identifier' },
+      { name: 'patientId', type: 'string', description: "Patient's Stellar address" },
+      { name: 'providerId', type: 'string', description: "Healthcare provider's Stellar address" },
+      { name: 'grantedAt', type: 'number', description: 'Timestamp when consent was granted (Unix seconds)' },
+      { name: 'revokedAt', type: 'number', description: 'Timestamp when consent was revoked (Unix seconds)', optional: true },
+      { name: 'status', type: 'ConsentStatus', description: 'Current consent status' },
+      { name: 'scope', type: 'string[]', description: 'Optional data access scope', optional: true },
+      { name: 'expiresAt', type: 'number', description: 'Optional consent expiration timestamp (Unix seconds)', optional: true },
+    ],
+  },
+  VerificationMethod: {
+    description: 'Verification method (public key) for W3C DID',
+    fields: [
+      { name: 'id', type: 'string', description: 'Fragment identifier' },
+      { name: 'methodType', type: 'VerificationMethodType', description: 'Type of verification method' },
+      { name: 'controller', type: 'string', description: 'Controller address' },
+      { name: 'publicKey', type: 'string', description: 'Base64-encoded public key' },
+      { name: 'isActive', type: 'boolean', description: 'Whether this key is active' },
+      { name: 'created', type: 'number', description: 'Creation timestamp (Unix seconds)' },
+      { name: 'lastRotated', type: 'number', description: 'Last rotation timestamp (Unix seconds, 0 if never)' },
+    ],
+  },
+  ServiceEndpoint: {
+    description: 'Service endpoint for W3C DID',
+    fields: [
+      { name: 'id', type: 'string', description: 'Service identifier' },
+      { name: 'type', type: 'string', description: 'Service type' },
+      { name: 'url', type: 'string', description: 'Service endpoint URL' },
+    ],
+  },
+  IdentityDocument: {
+    contractName: 'identity_registry',
+    description: 'Identity document (Decentralized Identifier) per W3C DID spec',
+    fields: [
+      { name: 'id', type: 'string', description: 'The DID identifier' },
+      { name: 'context', type: 'string[]', description: 'JSON-LD context URLs' },
+      { name: 'verificationMethods', type: 'VerificationMethod[]', description: 'Public key information' },
+      { name: 'authenticationMethods', type: 'VerificationRelationship[]', description: 'Auth key relationships', optional: true },
+      { name: 'assertionMethods', type: 'VerificationRelationship[]', description: 'Assertion key relationships', optional: true },
+      { name: 'serviceEndpoints', type: 'ServiceEndpoint[]', description: 'Service URLs', optional: true },
+      { name: 'created', type: 'number', description: 'Creation timestamp (Unix seconds)' },
+      { name: 'updated', type: 'number', description: 'Last update timestamp (Unix seconds)', optional: true },
+      { name: 'proof', type: 'string', description: 'Cryptographic proof', optional: true },
+    ],
+  },
+  PaymentStatus: {
+    contractName: 'healthcare_payment',
+    description: 'Payment status for healthcare claims and payments',
+    fields: [
+      { name: 'id', type: 'string', description: 'Unique payment identifier' },
+      { name: 'patientId', type: 'string', description: "Patient's Stellar address" },
+      { name: 'providerId', type: 'string', description: "Provider's Stellar address" },
+      { name: 'amount', type: 'number', description: 'Payment amount in smallest unit' },
+      { name: 'currency', type: 'string', description: 'Currency code (e.g., "USDC")' },
+      { name: 'status', type: 'PaymentStatusEnum', description: 'Current payment status' },
+      { name: 'serviceId', type: 'string', description: 'Service identifier', optional: true },
+      { name: 'policyId', type: 'string', description: 'Insurance policy ID', optional: true },
+      { name: 'createdAt', type: 'number', description: 'Creation timestamp (Unix seconds)' },
+      { name: 'updatedAt', type: 'number', description: 'Last update timestamp (Unix seconds)' },
+      { name: 'completedAt', type: 'number', description: 'Completion timestamp (Unix seconds)', optional: true },
+      { name: 'transactionHash', type: 'string', description: 'Blockchain transaction hash', optional: true },
+    ],
+  },
+  AuditEntry: {
+    contractName: 'audit',
+    description: 'Audit log entry for compliance and forensics',
+    fields: [
+      { name: 'id', type: 'string', description: 'Unique audit entry identifier' },
+      { name: 'actor', type: 'string', description: 'Address of the actor performing the action' },
+      { name: 'action', type: 'ActionType', description: 'Type of action performed' },
+      { name: 'resource', type: 'string', description: 'Resource identifier being acted upon', optional: true },
+      { name: 'resourceType', type: 'string', description: 'Type of resource', optional: true },
+      { name: 'result', type: 'string', description: 'Operation result (success/failure)', optional: true },
+      { name: 'reason', type: 'string', description: 'Reason for the action', optional: true },
+      { name: 'timestamp', type: 'number', description: 'Action timestamp (Unix seconds)' },
+      { name: 'ipAddress', type: 'string', description: 'IP address of the actor', optional: true },
+      { name: 'metadata', type: 'Record<string, string>', description: 'Additional context', optional: true },
+    ],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Registry generation
+// ---------------------------------------------------------------------------
+
+function buildRegistry() {
+  const contracts = [];
+
+  // Group definitions by contractName; shared types go into a "shared_types" bucket.
+  const contractMap = new Map();
+
+  for (const [name, def] of Object.entries(ENUM_DEFINITIONS)) {
+    const bucket = 'shared_types';
+    if (!contractMap.has(bucket)) {
+      contractMap.set(bucket, { name: bucket, version: '1.0.0', enums: [], interfaces: [] });
+    }
+    contractMap.get(bucket).enums.push({ name, ...def });
+  }
+
+  for (const [name, def] of Object.entries(INTERFACE_DEFINITIONS)) {
+    const bucket = def.contractName || 'shared_types';
+    if (!contractMap.has(bucket)) {
+      contractMap.set(bucket, { name: bucket, version: '1.0.0', enums: [], interfaces: [] });
+    }
+    contractMap.get(bucket).interfaces.push({ name, ...def });
+  }
+
+  for (const entry of contractMap.values()) {
+    contracts.push(entry);
+  }
+
+  contracts.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    registry_version: '1.0.0',
+    generated_at: new Date().toISOString(),
+    generator: {
+      name: 'scripts/abi-compat.mjs',
+      version: GENERATOR_VERSION,
+    },
+    contracts,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diff / compatibility analysis
+// ---------------------------------------------------------------------------
+
+const BREAKING_CHANGES = [];
+const NON_BREAKING_CHANGES = [];
+
+function analyseEnumChanges(contractName, oldEntry, newEntry) {
+  const oldMap = new Map((oldEntry.enums || []).map((e) => [e.name, e]));
+  const newMap = new Map((newEntry.enums || []).map((e) => [e.name, e]));
+
+  for (const [name, def] of newMap) {
+    if (!oldMap.has(name)) {
+      NON_BREAKING_CHANGES.push({
+        contract: contractName,
+        type: 'enum_added',
+        detail: `Enum "${name}" added`,
+      });
+      continue;
+    }
+    const oldDef = oldMap.get(name);
+    const oldValues = new Map(oldDef.values.map((v) => [v.member, v.value]));
+    const newValues = new Map(def.values.map((v) => [v.member, v.value]));
+
+    for (const [member, val] of newValues) {
+      if (!oldValues.has(member)) {
+        NON_BREAKING_CHANGES.push({
+          contract: contractName,
+          type: 'enum_variant_added',
+          detail: `Enum "${name}": variant "${member}" added`,
+        });
+      } else if (oldValues.get(member) !== val) {
+        BREAKING_CHANGES.push({
+          contract: contractName,
+          type: 'enum_value_changed',
+          detail: `Enum "${name}": variant "${member}" value changed from "${oldValues.get(member)}" to "${val}"`,
+        });
+      }
+    }
+
+    for (const [member] of oldValues) {
+      if (!newValues.has(member)) {
+        BREAKING_CHANGES.push({
+          contract: contractName,
+          type: 'enum_variant_removed',
+          detail: `Enum "${name}": variant "${member}" removed`,
+        });
+      }
+    }
+  }
+
+  for (const [name] of oldMap) {
+    if (!newMap.has(name)) {
+      BREAKING_CHANGES.push({
+        contract: contractName,
+        type: 'enum_removed',
+        detail: `Enum "${name}" removed`,
+      });
+    }
+  }
+}
+
+function analyseInterfaceChanges(contractName, oldEntry, newEntry) {
+  const oldMap = new Map((oldEntry.interfaces || []).map((i) => [i.name, i]));
+  const newMap = new Map((newEntry.interfaces || []).map((i) => [i.name, i]));
+
+  for (const [name, def] of newMap) {
+    if (!oldMap.has(name)) {
+      NON_BREAKING_CHANGES.push({
+        contract: contractName,
+        type: 'interface_added',
+        detail: `Interface "${name}" added`,
+      });
+      continue;
+    }
+    const oldDef = oldMap.get(name);
+    const oldFields = new Map(oldDef.fields.map((f) => [f.name, f]));
+    const newFields = new Map(def.fields.map((f) => [f.name, f]));
+
+    for (const [fname, fdef] of newFields) {
+      if (!oldFields.has(fname)) {
+        if (fdef.optional) {
+          NON_BREAKING_CHANGES.push({
+            contract: contractName,
+            type: 'field_added_optional',
+            detail: `Interface "${name}": optional field "${fname}" added`,
+          });
+        } else {
+          BREAKING_CHANGES.push({
+            contract: contractName,
+            type: 'field_added_required',
+            detail: `Interface "${name}": required field "${fname}" added (breaking — downstream code must supply this field)`,
+          });
+        }
+      } else {
+        const oldF = oldFields.get(fname);
+        if (oldF.type !== fdef.type) {
+          BREAKING_CHANGES.push({
+            contract: contractName,
+            type: 'field_type_changed',
+            detail: `Interface "${name}": field "${fname}" type changed from "${oldF.type}" to "${fdef.type}"`,
+          });
+        }
+        if (oldF.optional && !fdef.optional) {
+          BREAKING_CHANGES.push({
+            contract: contractName,
+            type: 'field_became_required',
+            detail: `Interface "${name}": field "${fname}" changed from optional to required`,
+          });
+        } else if (!oldF.optional && fdef.optional) {
+          NON_BREAKING_CHANGES.push({
+            contract: contractName,
+            type: 'field_became_optional',
+            detail: `Interface "${name}": field "${fname}" changed from required to optional`,
+          });
+        }
+      }
+    }
+
+    for (const [fname] of oldFields) {
+      if (!newFields.has(fname)) {
+        BREAKING_CHANGES.push({
+          contract: contractName,
+          type: 'field_removed',
+          detail: `Interface "${name}": field "${fname}" removed`,
+        });
+      }
+    }
+  }
+
+  for (const [name] of oldMap) {
+    if (!newMap.has(name)) {
+      BREAKING_CHANGES.push({
+        contract: contractName,
+        type: 'interface_removed',
+        detail: `Interface "${name}" removed`,
+      });
+    }
+  }
+}
+
+function analyseChanges(oldRegistry, newRegistry) {
+  const oldMap = new Map(oldRegistry.contracts.map((c) => [c.name, c]));
+  const newMap = new Map(newRegistry.contracts.map((c) => [c.name, c]));
+
+  for (const [name, entry] of newMap) {
+    if (!oldMap.has(name)) {
+      NON_BREAKING_CHANGES.push({
+        contract: name,
+        type: 'contract_added',
+        detail: `Contract "${name}" added to registry`,
+      });
+      continue;
+    }
+    analyseEnumChanges(name, oldMap.get(name), entry);
+    analyseInterfaceChanges(name, oldMap.get(name), entry);
+  }
+
+  for (const [name] of oldMap) {
+    if (!newMap.has(name)) {
+      BREAKING_CHANGES.push({
+        contract: name,
+        type: 'contract_removed',
+        detail: `Contract "${name}" removed from registry`,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report generation
+// ---------------------------------------------------------------------------
+
+function buildReport(newRegistry) {
+  const lines = [];
+  const breaking = BREAKING_CHANGES.length;
+  const nonBreaking = NON_BREAKING_CHANGES.length;
+
+  lines.push('## ABI Compatibility Report');
+  lines.push('');
+  lines.push(`Generated at: \`${newRegistry.generated_at}\``);
+  lines.push(`Registry version: \`${newRegistry.registry_version}\``);
+  lines.push(`Generator version: \`${GENERATOR_VERSION}\``);
+  lines.push('');
+  lines.push(`| Metric | Count |`);
+  lines.push(`|--------|-------|`);
+  lines.push(`| Contracts registered | ${newRegistry.contracts.length} |`);
+  lines.push(`| Breaking changes | ${breaking} |`);
+  lines.push(`| Non-breaking changes | ${nonBreaking} |`);
+  lines.push('');
+
+  if (breaking > 0) {
+    lines.push('### Breaking Changes');
+    lines.push('');
+    for (const ch of BREAKING_CHANGES) {
+      lines.push(`- **${ch.contract}**: ${ch.detail}`);
+    }
+    lines.push('');
+  }
+
+  if (nonBreaking > 0) {
+    lines.push('### Non-Breaking Changes');
+    lines.push('');
+    for (const ch of NON_BREAKING_CHANGES) {
+      lines.push(`- **${ch.contract}**: ${ch.detail}`);
+    }
+    lines.push('');
+  }
+
+  if (breaking === 0 && nonBreaking === 0) {
+    lines.push('> No interface changes detected — baseline is in sync.');
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push(`> Enforced by \`scripts/abi-compat.mjs\`. See [CONTRACT_COMPATIBILITY.md](docs/CONTRACT_COMPATIBILITY.md) for the breaking vs non-breaking change policy.`);
+  return lines.join('\n');
+}
+
+function buildMachineReport(newRegistry) {
+  const lines = [];
+  lines.push(`ABI_COMPAT_BREAKING=${BREAKING_CHANGES.length}`);
+  lines.push(`ABI_COMPAT_NON_BREAKING=${NON_BREAKING_CHANGES.length}`);
+  lines.push(`ABI_COMPAT_CONTRACTS=${newRegistry.contracts.length}`);
+  lines.push(`GENERATOR_VERSION=${GENERATOR_VERSION}`);
+  lines.push('');
+
+  for (const ch of BREAKING_CHANGES) {
+    lines.push(`BREAKING=${ch.contract}|${ch.type}|${ch.detail}`);
+  }
+  for (const ch of NON_BREAKING_CHANGES) {
+    lines.push(`NON_BREAKING=${ch.contract}|${ch.type}|${ch.detail}`);
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+function readOrEmpty(filePath) {
+  try {
+    return fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
+  } catch {
+    return '';
+  }
+}
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function main() {
+  console.log('ABI Compatibility Checker v' + GENERATOR_VERSION);
+  console.log('');
+
+  const newRegistry = buildRegistry();
+
+  if (CHECK_MODE) {
+    const baselineRaw = readOrEmpty(REGISTRY_BASELINE);
+    if (!baselineRaw) {
+      console.log('No baseline registry found — treating as initial generation.');
+      console.log('Run without --check first to create the baseline.');
+      process.exit(0);
+    }
+
+    let baseline;
+    try {
+      baseline = JSON.parse(baselineRaw);
+    } catch (err) {
+      console.error('Failed to parse baseline registry:', err.message);
+      process.exit(1);
+    }
+
+    analyseChanges(baseline, newRegistry);
+
+    const report = buildReport(newRegistry);
+    const machineReport = buildMachineReport(newRegistry);
+
+    if (REPORT_PATH) {
+      ensureParentDir(REPORT_PATH);
+      fs.writeFileSync(REPORT_PATH, machineReport, 'utf8');
+      console.log(`Machine report written to ${REPORT_PATH}`);
+    }
+
+    console.log(report);
+
+    if (BREAKING_CHANGES.length > 0 && !ALLOW_BREAKING) {
+      console.error('');
+      console.error(`BREAKING CHANGES DETECTED (${BREAKING_CHANGES.length}).`);
+      console.error('If intentional, re-run with --allow-breaking or add [approve-abi-change] to the PR body.');
+      console.error('See docs/CONTRACT_COMPATIBILITY.md for guidance.');
+      process.exit(1);
+    }
+
+    if (BREAKING_CHANGES.length === 0 && NON_BREAKING_CHANGES.length === 0) {
+      console.log('ABI compatibility: OK — no changes from baseline.');
+    } else if (BREAKING_CHANGES.length === 0) {
+      console.log('ABI compatibility: OK — only non-breaking changes.');
+    } else {
+      console.log('ABI compatibility: breaking changes approved.');
+    }
+    process.exit(0);
+  }
+
+  // Generation mode — write the baseline.
+  ensureParentDir(REGISTRY_BASELINE);
+  fs.writeFileSync(
+    REGISTRY_BASELINE,
+    JSON.stringify(newRegistry, null, 2) + '\n',
+    'utf8',
+  );
+  console.log(`Baseline written to ${path.relative(projectRoot, REGISTRY_BASELINE)}`);
+  console.log(`${newRegistry.contracts.length} contract(s) registered.`);
+}
+
+main();


### PR DESCRIPTION
## Summary

Implemented a production-ready ABI and SDK compatibility gate while maintaining the existing architecture and coding standards.

### Changes

- Added `schemas/interface-registry/` with JSON Schema and versioned ABI baseline snapshots
- Added `scripts/abi-compat.mjs` for ABI snapshot generation, diff analysis, and breaking/non-breaking change classification
- Added `abi-compatibility` CI job that validates interface changes on every PR, produces compatibility reports, and fails on unapproved breaking changes
- Added `docs/CONTRACT_COMPATIBILITY.md` documenting the breaking vs non-breaking change policy
- Added npm scripts (`abi:generate`, `abi:check`, `compat:check`) for local developer workflow
- Regenerated SDK bindings with consistent line endings

Closes #1097