### PR TITLE
feat(ci): add unified performance budget and benchmark gate for all contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - run: bash ./scripts/check_error_codes.sh
       - run: bash ./scripts/check_no_production_unwraps.sh
+      - name: Performance budget gate self-test (Issue #1086)
+        run: bash ./tests/performance_budget_gate_test.sh
       - run: cargo test --all
 
   # ============================================================================
@@ -104,6 +106,23 @@ jobs:
             reports/storage_summary.json
       - name: Comment PR with storage measurement
         if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = 'reports/storage_pr_comment.txt';
+            if (!fs.existsSync(reportPath)) {
+              core.warning('Storage PR comment not found at ' + reportPath);
+              return;
+            }
+            const body = fs.readFileSync(reportPath, 'utf8');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
       - name: WASM size regression gate (Issue #846)
         # Compares each built contract against scripts/wasm_size_baselines.json
         # and fails the build on a >10% regression or a contract newly crossing
@@ -124,24 +143,55 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const path = 'reports/storage_pr_comment.txt';
-            if (!fs.existsSync(path)) {
-              core.warning('Storage PR comment not found at ' + path);
-              return;
-            }
-            const comment = fs.readFileSync(path, 'utf8');
-            const path = 'wasm_size_report.md';
-            if (!fs.existsSync(path)) {
+            const reportPath = 'wasm_size_report.md';
+            if (!fs.existsSync(reportPath)) {
               core.warning('WASM size report not found; an earlier step likely failed.');
               return;
             }
-            const body = fs.readFileSync(path, 'utf8');
-            github.rest.issues.createComment({
+            const body = fs.readFileSync(reportPath, 'utf8');
+            await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: comment
-              body
+              body,
+            });
+      - name: Performance budget gate (Issue #1086)
+        # Unified gate over WASM size, storage entries and CPU instructions,
+        # evaluated against scripts/performance_budgets.json. Enforces both
+        # absolute limits and relative regressions, and degrades to a size-only
+        # check when reports/storage_summary.json is absent. Re-record an
+        # intended change with `bash scripts/performance_budget_gate.sh --update`.
+        if: always()
+        env:
+          WASM_DIR: target/wasm32-unknown-unknown/release
+        run: |
+          bash ./scripts/performance_budget_gate.sh --check
+      - name: Upload performance budget report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance-budget-report
+          path: |
+            reports/performance_budget_report.md
+            reports/performance_budget_result.json
+      - name: Comment performance budget report on PR
+        if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = 'reports/performance_budget_report.md';
+            if (!fs.existsSync(reportPath)) {
+              core.warning('Performance budget report not found; an earlier step likely failed.');
+              return;
+            }
+            const body = fs.readFileSync(reportPath, 'utf8');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
             });
 
   # ============================================================================

--- a/docs/CONTRACT_RESOURCE_LIMITS.md
+++ b/docs/CONTRACT_RESOURCE_LIMITS.md
@@ -123,3 +123,27 @@ Applies to all contracts in `contracts/*` and all deployments built using the St
 
 - These limits are based on current Stellar/Soroban runtime constraints and the repository's deployment practices.
 - Always verify network-specific limits before production deployment, since network policies may evolve.
+
+## 9. Automated Enforcement
+
+The limits above are enforced automatically in CI by the performance budget
+framework, so a change that pushes a contract toward one of these limits is
+caught in review rather than at deployment time.
+
+| Tool | Enforces |
+|---|---|
+| `scripts/performance_budget_gate.sh` | Unified gate over WASM size, storage entries and CPU instructions, against both absolute limits and relative regressions |
+| `scripts/wasm_size_monitor.sh` | Size-only baseline regression gate |
+| `scripts/measure_storage.sh` | Measures storage entries and instruction counts |
+
+Budgets are versioned in `scripts/performance_budgets.json` and reviewed with the
+code that changes them. Run the gate locally with:
+
+```bash
+make perf-budget          # evaluate the current build
+make perf-budget-trend    # see movement over retained samples
+make perf-budget-update   # re-record after an intended change
+```
+
+See [`PERFORMANCE_BUDGETS.md`](./PERFORMANCE_BUDGETS.md) for the full framework,
+including how grandfathering and the regression noise floor work.

--- a/docs/PERFORMANCE_BUDGETS.md
+++ b/docs/PERFORMANCE_BUDGETS.md
@@ -1,0 +1,182 @@
+# Performance Budgets and Benchmark Gate
+
+Repository-wide framework that ties every code change to the three resource
+dimensions that decide whether a Soroban contract can be deployed and operated
+affordably:
+
+| Dimension | Source | Why it matters |
+|---|---|---|
+| **WASM size** | wasm32 release build | Hard 64 KB deploy limit. Over it, the contract cannot be installed at all. |
+| **Storage entries** | `scripts/measure_storage.sh` | Drives ledger rent. Unbounded growth makes a contract progressively more expensive to keep alive. |
+| **CPU instructions** | `bench_storage_*` benchmarks | Drives transaction fees and the risk of exceeding the per-transaction resource budget. |
+
+This complements the existing tooling rather than replacing it:
+
+- `scripts/wasm_size_monitor.sh` remains the size-only baseline gate (Issue #846).
+- `scripts/measure_storage.sh` remains the measurement engine for storage and CPU.
+- **`scripts/performance_budget_gate.sh`** is the unified gate introduced here: it
+  reads both sources, evaluates them against one versioned budget, and produces a
+  single actionable report.
+
+## Quick start
+
+```bash
+# Build the artifacts the gate measures
+cargo build --workspace --target wasm32-unknown-unknown --release
+
+# Optional but recommended: produce storage/CPU measurements
+bash scripts/measure_storage.sh
+
+# Evaluate the current build against the budgets
+bash scripts/performance_budget_gate.sh --check
+
+# See how tracked contracts have moved over retained samples
+bash scripts/performance_budget_gate.sh --trend
+```
+
+Or via make:
+
+```bash
+make perf-budget        # check
+make perf-budget-update # re-record budgets
+make perf-budget-trend  # trend view
+```
+
+## The budget file
+
+Budgets are versioned in `scripts/performance_budgets.json` and reviewed like any
+other source change.
+
+```jsonc
+{
+  "schema_version": 1,
+  "limits": {                        // absolute thresholds
+    "max_wasm_size_bytes": 65536,    // hard Soroban limit
+    "warn_wasm_size_bytes": 61440,
+    "max_storage_entries": 500,
+    "warn_storage_entries": 100,
+    "max_cpu_instructions": 10000000,
+    "warn_cpu_instructions": 5000000
+  },
+  "regression": {                    // relative tolerances
+    "wasm_size_pct": 10,
+    "storage_entries_pct": 15,
+    "cpu_instructions_pct": 15,
+    "min_wasm_delta_bytes": 512,           // noise floor
+    "min_cpu_delta_instructions": 50000    // noise floor
+  },
+  "excluded": ["load_testing"],
+  "contracts": {
+    "genomic_data": {
+      "tier": "critical",
+      "wasm_size": 61216,
+      "grandfathered_over_size_limit": false
+    }
+  }
+}
+```
+
+The absolute limits mirror the values already documented in
+[`CONTRACT_RESOURCE_LIMITS.md`](./CONTRACT_RESOURCE_LIMITS.md) and enforced by
+`measure_storage.sh`, so there is one source of truth for what "too big" means.
+
+## What fails the build
+
+The gate deliberately tracks **both** absolute thresholds and relative
+regressions, so that a contract cannot drift toward a hard limit unnoticed while
+still allowing necessary feature work.
+
+A contract **fails** when any of the following is true:
+
+1. A tracked metric grows more than its tolerance over the recorded budget
+   (default: size +10 %, entries +15 %, CPU +15 %), **and** the absolute change
+   exceeds the noise floor.
+2. A metric **newly crosses** a hard limit that it was previously under.
+3. A metric is over a hard limit and the contract is **not** grandfathered.
+4. A brand-new contract is introduced already over a hard limit.
+
+A contract **warns** (does not fail) when:
+
+- It is over a hard limit and `grandfathered_over_size_limit` is `true`.
+- It is over a warning threshold but still under the hard limit.
+
+### Grandfathering
+
+Several contracts already exceed 64 KB (for example `ihe_integration` at ~91 KB).
+Failing on those immediately would make the gate permanently red and therefore
+ignored. They are recorded with `"grandfathered_over_size_limit": true`, which
+reports them as `:warning:` and fails only if they regress **further**. As those
+contracts are optimised below the limit, flip the flag to `false` to lock the win
+in.
+
+### Noise floor
+
+A tolerance alone is misleading for small values: a 400-byte change on a 1 KB
+contract is +40 % but practically irrelevant. `min_wasm_delta_bytes` and
+`min_cpu_delta_instructions` require the absolute change to matter as well before
+a percentage regression is failed.
+
+## Updating a budget
+
+When an increase is intentional and reviewed:
+
+```bash
+cargo build --workspace --target wasm32-unknown-unknown --release
+bash scripts/measure_storage.sh
+bash scripts/performance_budget_gate.sh --update
+git add scripts/performance_budgets.json
+```
+
+Commit the change **with** the code that caused it, so review sees the size,
+storage and CPU cost of the feature alongside the feature itself. The `tier` of an
+already-tracked contract is preserved across updates.
+
+## CI behaviour
+
+The `Build (wasm32)` job runs the gate after the storage measurement step:
+
+- The markdown report is uploaded as the `performance-budget-report` artifact and
+  posted as a PR comment.
+- The gate fails the job on a budget violation.
+- `reports/performance_budget_result.json` is emitted for downstream tooling.
+
+If `reports/storage_summary.json` is absent (benchmarks did not run), the gate
+degrades gracefully to a **size-only** evaluation and says so in the report,
+rather than failing the build for a missing measurement.
+
+To roll the gate out in observation mode first, set `WARN_ONLY=1`: violations are
+reported without failing the build.
+
+## Coverage
+
+Per the incremental rollout, an explicit budget is recorded for the contracts
+closest to a hard limit (`tier: "critical"`) plus a set of large `standard`
+contracts. Built contracts without a recorded budget are counted as *untracked*
+in the report and are still gated against the absolute hard limits, so a new
+contract cannot land already over the limit.
+
+Expand coverage by running `--update` after a clean build, which records every
+built contract.
+
+## Trend view
+
+Each `--check` appends a sample to `.performance_budget_trends.json` (most recent
+50 retained). `--trend` compares the oldest retained sample with the newest and
+prints per-contract movement, so slow drift across many PRs is visible even when
+no single PR trips a tolerance.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Budget file not found` | `scripts/performance_budgets.json` missing | `bash scripts/performance_budget_gate.sh --update` |
+| `WASM dir not found` | Contracts not built for wasm32 | `cargo build --workspace --target wasm32-unknown-unknown --release` |
+| All metrics `:grey_question: not measured` | `reports/storage_summary.json` absent | `bash scripts/measure_storage.sh` |
+| Gate fails right after a dependency bump | Real size regression from the new dependency | `cargo tree -d`, then optimise or re-record the budget |
+
+## Related
+
+- [`CONTRACT_RESOURCE_LIMITS.md`](./CONTRACT_RESOURCE_LIMITS.md) — the underlying Soroban limits
+- `scripts/wasm_size_monitor.sh` — size-only baseline gate (Issue #846)
+- `scripts/measure_storage.sh` — storage and CPU measurement engine
+- `contract_optimizer/` — optimisation passes for oversized contracts

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@
 
 .PHONY: help build test clean fmt lint deploy-local start-local stop-local install-deps check-deps shellcheck dist dev-deploy monitor-wasm check-wasm-size optimize analyze-optimizations
 .PHONY: help build test clean fmt lint deploy-local start-local stop-local install-deps check-deps shellcheck dist dev-deploy monitor-wasm check-wasm-size estimate-gas estimate-gas-batch estimate-storage estimate-cross-chain
+.PHONY: perf-budget perf-budget-update perf-budget-trend test-perf-budget
 
 ##@ General
 
@@ -323,6 +324,20 @@ estimate-storage: dist ## Calculate storage costs for a given number of entries
 	@bash scripts/measure_storage.sh
 
 measure-storage: estimate-storage
+
+perf-budget: ## Check contracts against the performance budgets (Issue #1086)
+	@echo "Evaluating performance budgets..."
+	@bash scripts/performance_budget_gate.sh --check
+
+perf-budget-update: ## Re-record performance budgets from the current build
+	@echo "Recording performance budgets..."
+	@bash scripts/performance_budget_gate.sh --update
+
+perf-budget-trend: ## Show performance budget trend across retained samples
+	@bash scripts/performance_budget_gate.sh --trend
+
+test-perf-budget: ## Run the performance budget gate test suite
+	@bash tests/performance_budget_gate_test.sh
 
 estimate-cross-chain: ## Estimate cross-chain transaction fees
 	@echo "Source Chain Fee:      0.00045678 XLM"

--- a/scripts/performance_budget_gate.sh
+++ b/scripts/performance_budget_gate.sh
@@ -1,0 +1,495 @@
+#!/usr/bin/env bash
+#
+# Performance budget and benchmark gate for Soroban contracts (Issue #1086).
+#
+# Unifies the three resource dimensions that decide whether a contract can be
+# deployed and operated affordably:
+#
+#   1. WASM size          (from the wasm32 release build)
+#   2. Storage entries    (from scripts/measure_storage.sh)
+#   3. CPU instructions   (from scripts/measure_storage.sh benchmarks)
+#
+# against the versioned budget in scripts/performance_budgets.json.
+#
+# The gate enforces BOTH absolute thresholds and relative regressions, so a
+# contract cannot silently drift toward a hard Soroban limit, and necessary
+# feature work is not penalised for a small, in-budget increase.
+#
+# Contracts already over a hard limit when the budget was recorded are
+# "grandfathered": they are reported as warnings, and only fail the build if
+# they regress further. This keeps the gate actionable instead of permanently
+# red — see docs/PERFORMANCE_BUDGETS.md.
+#
+# Outputs:
+#   reports/performance_budget_report.md    — markdown report (PR comment)
+#   reports/performance_budget_result.json  — machine-readable result
+#   .performance_budget_trends.json         — appended trend history
+#
+# Usage:
+#   bash scripts/performance_budget_gate.sh --check    # CI gate
+#   bash scripts/performance_budget_gate.sh --update   # re-record budgets
+#   bash scripts/performance_budget_gate.sh --trend    # trend view
+#
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+BUDGET_FILE="${BUDGET_FILE:-$ROOT_DIR/scripts/performance_budgets.json}"
+CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT_DIR/target}"
+WASM_DIR="${WASM_DIR:-$CARGO_TARGET_DIR/wasm32-unknown-unknown/release}"
+REPORT_DIR="${REPORT_DIR:-$ROOT_DIR/reports}"
+STORAGE_SUMMARY="${STORAGE_SUMMARY:-$REPORT_DIR/storage_summary.json}"
+REPORT_MD="${REPORT_MD:-$REPORT_DIR/performance_budget_report.md}"
+RESULT_JSON="${RESULT_JSON:-$REPORT_DIR/performance_budget_result.json}"
+TREND_FILE="${TREND_FILE:-$ROOT_DIR/.performance_budget_trends.json}"
+TREND_KEEP="${TREND_KEEP:-50}"
+
+# Set to 1 to report violations without failing the build.
+WARN_ONLY="${WARN_ONLY:-0}"
+
+RED='\033[0;31m'; YELLOW='\033[1;33m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
+log() { echo -e "$1"; }
+
+# ── Dependencies ───────────────────────────────────────────────────────────
+
+require_deps() {
+  local missing=()
+  command -v jq >/dev/null 2>&1 || missing+=("jq")
+  command -v awk >/dev/null 2>&1 || missing+=("awk")
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    log "${RED}Missing required dependencies: ${missing[*]}${NC}"
+    log "${YELLOW}Install with: sudo apt-get install -y ${missing[*]}${NC}"
+    exit 1
+  fi
+  if [[ ! -f "$BUDGET_FILE" ]]; then
+    log "${RED}Budget file not found: $BUDGET_FILE${NC}"
+    log "${YELLOW}Create it with: bash scripts/performance_budget_gate.sh --update${NC}"
+    exit 1
+  fi
+}
+
+human_bytes() {
+  local b="$1"
+  if [[ "$b" -ge 1024 ]]; then echo "$((b / 1024)) KB"; else echo "${b} B"; fi
+}
+
+# Percentage change from $1 (base) to $2 (current), one decimal place.
+pct_change() {
+  local base="$1" cur="$2"
+  if [[ "$base" -eq 0 ]]; then
+    # No meaningful baseline: report 0 rather than a divide-by-zero.
+    echo "0.0"
+    return
+  fi
+  awk -v b="$base" -v c="$cur" 'BEGIN { printf "%.1f", (c - b) * 100 / b }'
+}
+
+# True when $1 > $2, comparing as decimals.
+gt() { awk -v a="$1" -v b="$2" 'BEGIN { exit !(a > b) }'; }
+
+is_excluded() {
+  jq -e --arg n "$1" '.excluded | index($n)' "$BUDGET_FILE" >/dev/null 2>&1
+}
+
+# ── Measurement collection ─────────────────────────────────────────────────
+
+# Emit "<contract> <bytes>" for each built wasm that is not excluded.
+collect_wasm_sizes() {
+  local f name
+  [[ -d "$WASM_DIR" ]] || return 0
+  shopt -s nullglob
+  for f in "$WASM_DIR"/*.wasm; do
+    name="$(basename "$f" .wasm)"
+    is_excluded "$name" && continue
+    printf '%s %s\n' "$name" "$(wc -c < "$f")"
+  done
+  shopt -u nullglob
+}
+
+# Look up a field for a contract in the storage summary produced by
+# scripts/measure_storage.sh. Echoes an empty string when unavailable, so the
+# gate degrades gracefully to size-only when benchmarks have not been run.
+storage_field() {
+  local contract="$1" field="$2"
+  [[ -f "$STORAGE_SUMMARY" ]] || { echo ""; return; }
+  jq -r --arg c "$contract" --arg f "$field" \
+    'map(select(.contract == $c)) | .[0][$f] // empty' \
+    "$STORAGE_SUMMARY" 2>/dev/null || echo ""
+}
+
+# ── Budget evaluation ──────────────────────────────────────────────────────
+
+# Evaluate one metric for one contract.
+#
+#   $1 contract   $2 metric label   $3 baseline   $4 current
+#   $5 warn limit $6 hard limit     $7 tolerance% $8 min delta  $9 grandfathered
+#
+# Sets EVAL_STATUS / EVAL_DETAIL and returns 1 when the metric fails the gate.
+EVAL_STATUS=""
+EVAL_DETAIL=""
+evaluate_metric() {
+  local contract="$1" label="$2" base="$3" cur="$4"
+  local warn_limit="$5" hard_limit="$6" tol="$7" min_delta="$8" grandfathered="$9"
+  local delta pct
+  EVAL_STATUS=":white_check_mark: ok"
+  EVAL_DETAIL=""
+
+  # No measurement for this dimension (benchmarks absent) — skip, do not fail.
+  if [[ -z "$cur" || "$cur" == "null" ]]; then
+    EVAL_STATUS=":grey_question: not measured"
+    return 0
+  fi
+
+  # New contract with no recorded budget: only the hard limit applies.
+  if [[ -z "$base" || "$base" == "null" ]]; then
+    if [[ "$cur" -gt "$hard_limit" ]]; then
+      EVAL_STATUS=":x: new contract over hard limit"
+      EVAL_DETAIL="${label} ${cur} exceeds hard limit ${hard_limit}"
+      return 1
+    fi
+    EVAL_STATUS=":new: new contract"
+    return 0
+  fi
+
+  delta=$((cur - base))
+  pct="$(pct_change "$base" "$cur")"
+
+  # Relative regression, ignoring changes below the noise floor.
+  if gt "$pct" "$tol" && [[ "$delta" -gt "$min_delta" ]]; then
+    EVAL_STATUS=":x: +${pct}% (budget +${tol}%)"
+    EVAL_DETAIL="${label} grew ${pct}% (${base} -> ${cur}), over the ${tol}% budget"
+    return 1
+  fi
+
+  # Newly crossing a hard limit is always a failure.
+  if [[ "$cur" -gt "$hard_limit" && "$base" -le "$hard_limit" ]]; then
+    EVAL_STATUS=":x: crossed hard limit"
+    EVAL_DETAIL="${label} crossed the hard limit ${hard_limit} (now ${cur})"
+    return 1
+  fi
+
+  # Already over a hard limit when the budget was recorded.
+  if [[ "$cur" -gt "$hard_limit" ]]; then
+    if [[ "$grandfathered" == "true" ]]; then
+      EVAL_STATUS=":warning: over hard limit (grandfathered)"
+      return 0
+    fi
+    EVAL_STATUS=":x: over hard limit"
+    EVAL_DETAIL="${label} ${cur} exceeds hard limit ${hard_limit}"
+    return 1
+  fi
+
+  # Newly crossing the warning threshold is surfaced but does not fail.
+  if [[ "$cur" -gt "$warn_limit" && "$base" -le "$warn_limit" ]]; then
+    EVAL_STATUS=":warning: crossed warn threshold"
+    return 0
+  fi
+  if [[ "$cur" -gt "$warn_limit" ]]; then
+    EVAL_STATUS=":warning: over warn threshold"
+    return 0
+  fi
+
+  [[ "$delta" -lt 0 ]] && EVAL_STATUS=":arrow_down: ${pct}%"
+  return 0
+}
+
+# Actionable guidance, keyed on which dimension actually regressed.
+recommendations_for() {
+  case "$1" in
+    wasm_size)
+      cat <<'EOF'
+- Run `cargo bloat --release --target wasm32-unknown-unknown -n 30` to find the largest functions.
+- Check for newly added dependencies or enabled features (`cargo tree -d` for duplicates).
+- Prefer `soroban_sdk::String`/`Bytes` over formatting helpers that pull in `core::fmt`.
+- Consider `contract_optimizer/` passes, or splitting the contract along a storage boundary.
+EOF
+      ;;
+    storage_entries)
+      cat <<'EOF'
+- Collapse related keys into a single struct value instead of one entry per field.
+- Confirm temporary data uses temporary storage, not persistent, so it does not accrue rent.
+- Batch writes: a single `set` of an aggregate is cheaper than N per-field writes.
+- Review whether historical/audit rows can be event-emitted instead of stored.
+EOF
+      ;;
+    cpu_instructions)
+      cat <<'EOF'
+- Look for loops whose bound grows with stored data; cap or paginate them.
+- Hoist repeated `storage().get()` calls out of loops into a local.
+- Avoid re-serialising large structs on hot paths.
+- Re-run `cargo test bench_storage_ -- --nocapture` locally to confirm the delta.
+EOF
+      ;;
+    *) echo "- Review the change against docs/PERFORMANCE_BUDGETS.md." ;;
+  esac
+}
+
+# ── Commands ───────────────────────────────────────────────────────────────
+
+cmd_update() {
+  require_deps
+  [[ -d "$WASM_DIR" ]] || {
+    log "${RED}WASM dir not found: $WASM_DIR — build first (cargo build --workspace --target wasm32-unknown-unknown --release)${NC}"
+    exit 1
+  }
+
+  local contracts="{}" name bytes entries cpu tier over
+  local hard_size
+  hard_size="$(jq -r '.limits.max_wasm_size_bytes' "$BUDGET_FILE")"
+
+  while read -r name bytes; do
+    entries="$(storage_field "$name" "estimated_entries")"
+    cpu="$(storage_field "$name" "max_cpu")"
+    # Preserve the tier if the contract is already tracked.
+    tier="$(jq -r --arg n "$name" '.contracts[$n].tier // "standard"' "$BUDGET_FILE")"
+    over=false
+    [[ "$bytes" -gt "$hard_size" ]] && over=true
+
+    contracts="$(jq \
+      --arg n "$name" --argjson b "$bytes" --arg t "$tier" --argjson o "$over" \
+      --arg e "${entries:-}" --arg c "${cpu:-}" '
+        .[$n] = ({ tier: $t, wasm_size: $b, grandfathered_over_size_limit: $o }
+          + (if $e == "" then {} else { storage_entries: ($e | tonumber) } end)
+          + (if $c == "" then {} else { cpu_instructions: ($c | tonumber) } end))
+      ' <<<"$contracts")"
+  done < <(collect_wasm_sizes)
+
+  if [[ "$contracts" == "{}" ]]; then
+    log "${RED}No wasm files found in $WASM_DIR${NC}"
+    exit 1
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  jq --argjson c "$contracts" '.contracts = $c' "$BUDGET_FILE" > "$tmp"
+  mv "$tmp" "$BUDGET_FILE"
+  log "${GREEN}Recorded budgets for $(jq '.contracts | length' "$BUDGET_FILE") contract(s) in $BUDGET_FILE${NC}"
+}
+
+cmd_check() {
+  require_deps
+  mkdir -p "$REPORT_DIR"
+
+  if [[ ! -d "$WASM_DIR" ]]; then
+    log "${RED}WASM dir not found: $WASM_DIR${NC}"
+    exit 1
+  fi
+
+  local warn_size hard_size warn_entries hard_entries warn_cpu hard_cpu
+  local tol_size tol_entries tol_cpu min_size_delta min_cpu_delta
+  warn_size="$(jq -r '.limits.warn_wasm_size_bytes' "$BUDGET_FILE")"
+  hard_size="$(jq -r '.limits.max_wasm_size_bytes' "$BUDGET_FILE")"
+  warn_entries="$(jq -r '.limits.warn_storage_entries' "$BUDGET_FILE")"
+  hard_entries="$(jq -r '.limits.max_storage_entries' "$BUDGET_FILE")"
+  warn_cpu="$(jq -r '.limits.warn_cpu_instructions' "$BUDGET_FILE")"
+  hard_cpu="$(jq -r '.limits.max_cpu_instructions' "$BUDGET_FILE")"
+  tol_size="$(jq -r '.regression.wasm_size_pct' "$BUDGET_FILE")"
+  tol_entries="$(jq -r '.regression.storage_entries_pct' "$BUDGET_FILE")"
+  tol_cpu="$(jq -r '.regression.cpu_instructions_pct' "$BUDGET_FILE")"
+  min_size_delta="$(jq -r '.regression.min_wasm_delta_bytes' "$BUDGET_FILE")"
+  min_cpu_delta="$(jq -r '.regression.min_cpu_delta_instructions' "$BUDGET_FILE")"
+
+  local fail=0 warns=0 tracked=0 untracked=0
+  local rows="" failed_dims="" results="[]"
+
+  local name bytes base_size entries base_entries cpu base_cpu grand
+  local s_status e_status c_status row_fail
+
+  while read -r name bytes; do
+    base_size="$(jq -r --arg n "$name" '.contracts[$n].wasm_size // empty' "$BUDGET_FILE")"
+    if [[ -z "$base_size" ]]; then
+      untracked=$((untracked + 1))
+    else
+      tracked=$((tracked + 1))
+    fi
+    grand="$(jq -r --arg n "$name" '.contracts[$n].grandfathered_over_size_limit // false' "$BUDGET_FILE")"
+    base_entries="$(jq -r --arg n "$name" '.contracts[$n].storage_entries // empty' "$BUDGET_FILE")"
+    base_cpu="$(jq -r --arg n "$name" '.contracts[$n].cpu_instructions // empty' "$BUDGET_FILE")"
+    entries="$(storage_field "$name" "estimated_entries")"
+    cpu="$(storage_field "$name" "max_cpu")"
+    row_fail=0
+
+    if evaluate_metric "$name" "wasm_size" "$base_size" "$bytes" \
+        "$warn_size" "$hard_size" "$tol_size" "$min_size_delta" "$grand"; then
+      s_status="$EVAL_STATUS"
+    else
+      s_status="$EVAL_STATUS"; row_fail=1
+      failed_dims+="wasm_size"$'\n'
+      log "${RED}FAIL ${name}: ${EVAL_DETAIL}${NC}"
+    fi
+
+    if evaluate_metric "$name" "storage_entries" "$base_entries" "$entries" \
+        "$warn_entries" "$hard_entries" "$tol_entries" "0" "false"; then
+      e_status="$EVAL_STATUS"
+    else
+      e_status="$EVAL_STATUS"; row_fail=1
+      failed_dims+="storage_entries"$'\n'
+      log "${RED}FAIL ${name}: ${EVAL_DETAIL}${NC}"
+    fi
+
+    if evaluate_metric "$name" "cpu_instructions" "$base_cpu" "$cpu" \
+        "$warn_cpu" "$hard_cpu" "$tol_cpu" "$min_cpu_delta" "false"; then
+      c_status="$EVAL_STATUS"
+    else
+      c_status="$EVAL_STATUS"; row_fail=1
+      failed_dims+="cpu_instructions"$'\n'
+      log "${RED}FAIL ${name}: ${EVAL_DETAIL}${NC}"
+    fi
+
+    [[ "$row_fail" -eq 1 ]] && fail=1
+    case "$s_status$e_status$c_status" in *":warning:"*) warns=$((warns + 1));; esac
+
+    # Only tracked contracts and failures go in the table, to keep the PR
+    # comment readable across ~80 contracts.
+    if [[ -n "$base_size" || "$row_fail" -eq 1 ]]; then
+      rows+="| \`${name}\` | $(human_bytes "$bytes") | ${s_status} | ${entries:-–} | ${e_status} | ${cpu:-–} | ${c_status} |"$'\n'
+    fi
+
+    results="$(jq --arg n "$name" --argjson b "$bytes" \
+      --arg e "${entries:-}" --arg c "${cpu:-}" --argjson f "$row_fail" '
+      . += [{ contract: $n, wasm_size: $b, failed: ($f == 1) }
+        + (if $e == "" then {} else { storage_entries: ($e | tonumber) } end)
+        + (if $c == "" then {} else { cpu_instructions: ($c | tonumber) } end)]
+    ' <<<"$results")"
+  done < <(collect_wasm_sizes)
+
+  if [[ "$tracked" -eq 0 && "$untracked" -eq 0 ]]; then
+    log "${YELLOW}No wasm artifacts found in $WASM_DIR — nothing to gate.${NC}"
+    echo "### Performance Budget Report" > "$REPORT_MD"
+    echo "" >> "$REPORT_MD"
+    echo "No WASM artifacts were found, so no budgets were evaluated." >> "$REPORT_MD"
+    return 0
+  fi
+
+  local bench_note=""
+  [[ -f "$STORAGE_SUMMARY" ]] || bench_note=$'\n> **Note:** `reports/storage_summary.json` was not found, so storage-entry and instruction budgets were not evaluated. Run `bash scripts/measure_storage.sh` to enable the full gate.\n'
+
+  {
+    echo "### Performance Budget Report"
+    echo
+    echo "Unified budget gate for **WASM size**, **storage entries** and **CPU instructions** (Issue #1086)."
+    echo "Budgets: \`scripts/performance_budgets.json\` · Docs: \`docs/PERFORMANCE_BUDGETS.md\`"
+    echo "$bench_note"
+    echo "Gate: fails on a relative regression over budget (size +${tol_size}%, entries +${tol_entries}%, CPU +${tol_cpu}%) or on newly crossing a hard limit. Contracts already over a hard limit are grandfathered (:warning:)."
+    echo
+    echo "| Contract | Size | Size status | Entries | Entry status | CPU | CPU status |"
+    echo "|---|---|---|---|---|---|---|"
+    printf '%s' "$rows"
+    echo
+    echo "**Tracked:** ${tracked} · **Untracked built contracts:** ${untracked} · **Warnings:** ${warns}"
+    echo
+    if [[ "$fail" -eq 1 ]]; then
+      echo "#### ❌ Performance budget gate failed"
+      echo
+      echo "Recommended actions:"
+      echo
+      local dim
+      while read -r dim; do
+        [[ -z "$dim" ]] && continue
+        echo "**${dim}**"
+        recommendations_for "$dim"
+        echo
+      done < <(printf '%s' "$failed_dims" | sort -u)
+      echo "If the increase is intentional and reviewed, re-record the budget with:"
+      echo
+      echo '```bash'
+      echo 'bash scripts/performance_budget_gate.sh --update'
+      echo '```'
+    else
+      echo "#### ✅ All contracts within their performance budgets"
+    fi
+  } | tee "$REPORT_MD"
+
+  jq -n --argjson r "$results" --argjson fail "$fail" \
+    --argjson tracked "$tracked" --argjson warns "$warns" \
+    '{ passed: ($fail == 0), tracked: $tracked, warnings: $warns, contracts: $r }' \
+    > "$RESULT_JSON"
+
+  record_trend "$results"
+
+  if [[ "$fail" -eq 1 && "$WARN_ONLY" != "1" ]]; then
+    return 1
+  fi
+  if [[ "$fail" -eq 1 ]]; then
+    log "${YELLOW}WARN_ONLY=1 set — violations reported but not failing the build.${NC}"
+  fi
+  return 0
+}
+
+# Append the current measurement set to the trend history, keeping the most
+# recent $TREND_KEEP samples so the file does not grow without bound.
+record_trend() {
+  local results="$1" ts tmp
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  [[ -f "$TREND_FILE" ]] || echo '{"samples":[]}' > "$TREND_FILE"
+  tmp="$(mktemp)"
+  jq --argjson r "$results" --arg ts "$ts" --argjson keep "$TREND_KEEP" \
+    '.samples += [{ timestamp: $ts, contracts: $r }] | .samples |= (.[-$keep:])' \
+    "$TREND_FILE" > "$tmp" && mv "$tmp" "$TREND_FILE"
+}
+
+cmd_trend() {
+  require_deps
+  if [[ ! -f "$TREND_FILE" ]]; then
+    log "${YELLOW}No trend history yet at $TREND_FILE — run --check first.${NC}"
+    return 0
+  fi
+  local count
+  count="$(jq '.samples | length' "$TREND_FILE")"
+  log "${BLUE}=== Performance Budget Trend (${count} sample(s)) ===${NC}"
+  if [[ "$count" -lt 2 ]]; then
+    log "${YELLOW}Need at least 2 samples to show a trend.${NC}"
+    return 0
+  fi
+  # Compare the oldest retained sample against the newest, per contract.
+  jq -r '
+    (.samples[0].contracts   | map({ (.contract): .wasm_size }) | add) as $first |
+    (.samples[-1].contracts  | map({ (.contract): .wasm_size }) | add) as $last  |
+    ($last | keys_unsorted[]) as $k |
+    select($first[$k] != null and $last[$k] != null and $first[$k] != $last[$k]) |
+    "\($k)\t\($first[$k])\t\($last[$k])\t\(((($last[$k] - $first[$k]) * 1000 / $first[$k]) | floor) / 10)"
+  ' "$TREND_FILE" | sort -k4 -rn | while IFS=$'\t' read -r name a b pct; do
+    if gt "$pct" "0"; then
+      log "${YELLOW}  ${name}: ${a} -> ${b} bytes (+${pct}%)${NC}"
+    else
+      log "${GREEN}  ${name}: ${a} -> ${b} bytes (${pct}%)${NC}"
+    fi
+  done
+  log "${BLUE}Full history: $TREND_FILE${NC}"
+}
+
+show_help() {
+  cat <<EOF
+Usage: $0 [--check|--update|--trend|--help]
+
+Unified performance budget gate for Soroban contracts (Issue #1086).
+Evaluates WASM size, storage entries and CPU instructions against
+scripts/performance_budgets.json.
+
+Options:
+  --check    Evaluate the current build against the budgets. Exits 1 on a
+             regression over budget or a newly crossed hard limit. Writes
+             reports/performance_budget_report.md and
+             reports/performance_budget_result.json.
+  --update   Re-record budgets from the current build (after an intended,
+             reviewed change).
+  --trend    Show how tracked contracts have moved across retained samples.
+  --help     Show this message.
+
+Environment:
+  WASM_DIR          Built .wasm directory (default: target/wasm32-unknown-unknown/release)
+  STORAGE_SUMMARY   measure_storage.sh JSON summary (default: reports/storage_summary.json)
+  BUDGET_FILE       Budget file (default: scripts/performance_budgets.json)
+  WARN_ONLY=1       Report violations without failing the build.
+
+Requirements: jq, awk
+EOF
+}
+
+case "${1:---check}" in
+  --help|-h) show_help ;;
+  --update)  cmd_update ;;
+  --trend)   cmd_trend ;;
+  --check)   if cmd_check; then exit 0; else exit 1; fi ;;
+  *) log "${RED}Unknown option: $1${NC}"; show_help; exit 1 ;;
+esac

--- a/scripts/performance_budgets.json
+++ b/scripts/performance_budgets.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 1,
+  "description": "Repository-wide performance budgets for Soroban contracts. Ties code changes to WASM size, storage growth and instruction cost. Regenerate with `bash scripts/performance_budget_gate.sh --update` after an intended, reviewed change.",
+  "docs": "docs/PERFORMANCE_BUDGETS.md",
+  "limits": {
+    "max_wasm_size_bytes": 65536,
+    "warn_wasm_size_bytes": 61440,
+    "max_storage_entries": 500,
+    "warn_storage_entries": 100,
+    "max_cpu_instructions": 10000000,
+    "warn_cpu_instructions": 5000000
+  },
+  "regression": {
+    "wasm_size_pct": 10,
+    "storage_entries_pct": 15,
+    "cpu_instructions_pct": 15,
+    "min_wasm_delta_bytes": 512,
+    "min_cpu_delta_instructions": 50000
+  },
+  "excluded": [
+    "load_testing"
+  ],
+  "tiers": {
+    "critical": "Tracked contract at or near a hard Soroban limit. Any regression is gated.",
+    "standard": "Tracked contract with headroom. Gated on relative regression only."
+  },
+  "contracts": {
+    "ihe_integration": {
+      "tier": "critical",
+      "wasm_size": 92975,
+      "grandfathered_over_size_limit": true
+    },
+    "identity_registry": {
+      "tier": "critical",
+      "wasm_size": 92141,
+      "grandfathered_over_size_limit": true
+    },
+    "zkp_registry": {
+      "tier": "critical",
+      "wasm_size": 76333,
+      "grandfathered_over_size_limit": true
+    },
+    "medical_record_backup": {
+      "tier": "critical",
+      "wasm_size": 73628,
+      "grandfathered_over_size_limit": true
+    },
+    "cross_chain_bridge": {
+      "tier": "critical",
+      "wasm_size": 71722,
+      "grandfathered_over_size_limit": true
+    },
+    "emr_integration": {
+      "tier": "critical",
+      "wasm_size": 69343,
+      "grandfathered_over_size_limit": true
+    },
+    "public_health_surveillance": {
+      "tier": "critical",
+      "wasm_size": 63828,
+      "grandfathered_over_size_limit": false
+    },
+    "notification_system": {
+      "tier": "critical",
+      "wasm_size": 61909,
+      "grandfathered_over_size_limit": false
+    },
+    "genomic_data": {
+      "tier": "critical",
+      "wasm_size": 61216,
+      "grandfathered_over_size_limit": false
+    },
+    "healthcare_payment": {
+      "tier": "critical",
+      "wasm_size": 54365,
+      "grandfathered_over_size_limit": false
+    },
+    "homomorphic_registry": {
+      "tier": "standard",
+      "wasm_size": 48876,
+      "grandfathered_over_size_limit": false
+    },
+    "explainable_ai": {
+      "tier": "standard",
+      "wasm_size": 44708,
+      "grandfathered_over_size_limit": false
+    },
+    "cross_chain_access": {
+      "tier": "standard",
+      "wasm_size": 43934,
+      "grandfathered_over_size_limit": false
+    },
+    "audit_forensics": {
+      "tier": "standard",
+      "wasm_size": 43684,
+      "grandfathered_over_size_limit": false
+    }
+  }
+}

--- a/tests/performance_budget_gate_test.sh
+++ b/tests/performance_budget_gate_test.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/performance_budget_gate.sh (Issue #1086).
+#
+# Self-contained: builds synthetic .wasm fixtures and a synthetic storage
+# summary in a temp dir, so it needs no cargo build and runs in seconds.
+#
+# Usage: bash tests/performance_budget_gate_test.sh
+#
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATE="$ROOT_DIR/scripts/performance_budget_gate.sh"
+
+PASS=0
+FAIL=0
+
+ok()   { echo "  ok   - $1"; PASS=$((PASS + 1)); }
+nope() { echo "  FAIL - $1"; FAIL=$((FAIL + 1)); }
+
+expect_exit() {
+  local want="$1" got="$2" what="$3"
+  if [[ "$got" -eq "$want" ]]; then ok "$what (exit $got)"; else nope "$what (want exit $want, got $got)"; fi
+}
+
+expect_contains() {
+  local file="$1" needle="$2" what="$3"
+  if grep -qF -- "$needle" "$file"; then ok "$what"; else nope "$what (missing: $needle)"; fi
+}
+
+# Build a sandbox with the given budget JSON, then create fixtures.
+setup() {
+  SANDBOX="$(mktemp -d)"
+  mkdir -p "$SANDBOX/scripts" "$SANDBOX/wasm" "$SANDBOX/reports"
+  cp "$GATE" "$SANDBOX/scripts/"
+  cat > "$SANDBOX/scripts/performance_budgets.json"
+}
+
+teardown() { [[ -n "${SANDBOX:-}" ]] && rm -rf "$SANDBOX"; }
+
+mkwasm() { head -c "$2" /dev/zero > "$SANDBOX/wasm/$1.wasm"; }
+
+run_gate() {
+  ( cd "$SANDBOX" && WASM_DIR="$SANDBOX/wasm" REPORT_DIR="$SANDBOX/reports" \
+      BUDGET_FILE="$SANDBOX/scripts/performance_budgets.json" \
+      TREND_FILE="$SANDBOX/.trends.json" \
+      bash scripts/performance_budget_gate.sh "$@" >"$SANDBOX/out.txt" 2>&1 )
+}
+
+BASE_BUDGET='{
+  "schema_version": 1,
+  "limits": { "max_wasm_size_bytes": 65536, "warn_wasm_size_bytes": 61440,
+    "max_storage_entries": 500, "warn_storage_entries": 100,
+    "max_cpu_instructions": 10000000, "warn_cpu_instructions": 5000000 },
+  "regression": { "wasm_size_pct": 10, "storage_entries_pct": 15, "cpu_instructions_pct": 15,
+    "min_wasm_delta_bytes": 512, "min_cpu_delta_instructions": 50000 },
+  "excluded": ["load_testing"],
+  "contracts": {
+    "steady":      { "tier": "standard", "wasm_size": 20000, "grandfathered_over_size_limit": false },
+    "regressor":   { "tier": "standard", "wasm_size": 20000, "grandfathered_over_size_limit": false },
+    "grandfather": { "tier": "critical", "wasm_size": 92000, "grandfathered_over_size_limit": true },
+    "crosser":     { "tier": "critical", "wasm_size": 64000, "grandfathered_over_size_limit": false }
+  }
+}'
+
+echo "performance_budget_gate.sh"
+
+# ── 1. Size dimension: regression, hard-limit crossing, grandfathering ──────
+echo "size budgets"
+setup <<<"$BASE_BUDGET"
+mkwasm steady 20000          # unchanged        -> ok
+mkwasm regressor 25000       # +25%             -> fail
+mkwasm grandfather 92000     # over limit       -> warn only
+mkwasm crosser 66000         # crosses 64 KB    -> fail
+mkwasm load_testing 99999    # excluded         -> ignored
+run_gate --check
+expect_exit 1 $? "fails when a contract regresses beyond budget"
+REPORT="$SANDBOX/reports/performance_budget_report.md"
+expect_contains "$REPORT" "+25.0%" "reports the regression percentage"
+expect_contains "$REPORT" "crossed hard limit" "flags a newly crossed hard limit"
+expect_contains "$REPORT" "grandfathered" "grandfathers a pre-existing breach"
+if grep -q 'load_testing' "$REPORT"; then nope "excludes contracts on the exclude list"; else ok "excludes contracts on the exclude list"; fi
+expect_contains "$REPORT" "cargo bloat" "emits actionable size recommendations"
+teardown
+
+# ── 2. All contracts within budget ─────────────────────────────────────────
+echo "passing build"
+setup <<<"$BASE_BUDGET"
+mkwasm steady 20000
+mkwasm regressor 20100       # +0.5%, under both tolerance and noise floor
+mkwasm grandfather 92000
+mkwasm crosser 64000
+run_gate --check
+expect_exit 0 $? "passes when every contract is within budget"
+expect_contains "$SANDBOX/reports/performance_budget_report.md" \
+  "within their performance budgets" "reports success"
+teardown
+
+# ── 3. Noise floor suppresses trivial absolute changes ─────────────────────
+echo "noise floor"
+setup <<<'{
+  "schema_version": 1,
+  "limits": { "max_wasm_size_bytes": 65536, "warn_wasm_size_bytes": 61440,
+    "max_storage_entries": 500, "warn_storage_entries": 100,
+    "max_cpu_instructions": 10000000, "warn_cpu_instructions": 5000000 },
+  "regression": { "wasm_size_pct": 10, "storage_entries_pct": 15, "cpu_instructions_pct": 15,
+    "min_wasm_delta_bytes": 512, "min_cpu_delta_instructions": 50000 },
+  "excluded": [],
+  "contracts": { "tiny": { "tier": "standard", "wasm_size": 1000, "grandfathered_over_size_limit": false } }
+}'
+mkwasm tiny 1400             # +40% but only +400 B, below the 512 B noise floor
+run_gate --check
+expect_exit 0 $? "does not fail a large percentage below the absolute noise floor"
+teardown
+
+# ── 4. Storage-entry and CPU dimensions ────────────────────────────────────
+echo "storage and cpu budgets"
+setup <<<'{
+  "schema_version": 1,
+  "limits": { "max_wasm_size_bytes": 65536, "warn_wasm_size_bytes": 61440,
+    "max_storage_entries": 500, "warn_storage_entries": 100,
+    "max_cpu_instructions": 10000000, "warn_cpu_instructions": 5000000 },
+  "regression": { "wasm_size_pct": 10, "storage_entries_pct": 15, "cpu_instructions_pct": 15,
+    "min_wasm_delta_bytes": 512, "min_cpu_delta_instructions": 50000 },
+  "excluded": [],
+  "contracts": {
+    "entry_creep": { "tier": "standard", "wasm_size": 20000, "storage_entries": 40, "cpu_instructions": 1000000 },
+    "cpu_creep":   { "tier": "standard", "wasm_size": 20000, "storage_entries": 40, "cpu_instructions": 1000000 }
+  }
+}'
+mkwasm entry_creep 20000
+mkwasm cpu_creep 20000
+cat > "$SANDBOX/reports/storage_summary.json" <<'EOF'
+[
+ {"contract":"entry_creep","estimated_entries":60,"max_cpu":1000000},
+ {"contract":"cpu_creep","estimated_entries":40,"max_cpu":1400000}
+]
+EOF
+run_gate --check
+expect_exit 1 $? "fails on storage-entry and CPU regressions"
+REPORT="$SANDBOX/reports/performance_budget_report.md"
+expect_contains "$REPORT" "+50.0%" "reports the storage-entry regression"
+expect_contains "$REPORT" "+40.0%" "reports the CPU regression"
+expect_contains "$REPORT" "temporary storage" "emits storage recommendations"
+expect_contains "$REPORT" "paginate" "emits CPU recommendations"
+teardown
+
+# ── 5. Graceful degradation without benchmark data ─────────────────────────
+echo "missing benchmark data"
+setup <<<"$BASE_BUDGET"
+mkwasm steady 20000
+run_gate --check
+expect_exit 0 $? "degrades to size-only when storage_summary.json is absent"
+expect_contains "$SANDBOX/reports/performance_budget_report.md" \
+  "was not found" "explains that budgets were not fully evaluated"
+teardown
+
+# ── 6. WARN_ONLY observation mode ──────────────────────────────────────────
+echo "warn-only mode"
+setup <<<"$BASE_BUDGET"
+mkwasm regressor 25000
+( cd "$SANDBOX" && WARN_ONLY=1 WASM_DIR="$SANDBOX/wasm" REPORT_DIR="$SANDBOX/reports" \
+    BUDGET_FILE="$SANDBOX/scripts/performance_budgets.json" TREND_FILE="$SANDBOX/.trends.json" \
+    bash scripts/performance_budget_gate.sh --check >/dev/null 2>&1 )
+expect_exit 0 $? "WARN_ONLY=1 reports without failing the build"
+teardown
+
+# ── 7. --update re-records the budget ──────────────────────────────────────
+echo "budget update"
+setup <<<"$BASE_BUDGET"
+mkwasm steady 20000
+mkwasm regressor 25000
+mkwasm grandfather 92000
+mkwasm crosser 64000
+run_gate --update
+expect_exit 0 $? "--update succeeds"
+run_gate --check
+expect_exit 0 $? "build passes against the freshly recorded budget"
+teardown
+
+# ── 8. New contract over a hard limit is rejected ──────────────────────────
+echo "new contracts"
+setup <<<"$BASE_BUDGET"
+mkwasm steady 20000
+mkwasm brand_new 70000       # untracked and already over the 64 KB hard limit
+run_gate --check
+expect_exit 1 $? "rejects a new contract introduced over a hard limit"
+teardown
+
+# ── 9. Trend view ──────────────────────────────────────────────────────────
+echo "trend view"
+setup <<<"$BASE_BUDGET"
+mkwasm steady 20000
+run_gate --check
+mkwasm steady 24000
+run_gate --check
+run_gate --trend
+expect_exit 0 $? "--trend succeeds"
+expect_contains "$SANDBOX/out.txt" "steady" "trend view lists a moved contract"
+teardown
+
+echo
+echo "passed: $PASS, failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
closes #1086

## Overview

Adds a repository-wide performance-budget and benchmark gate that ties every code change to the three resource dimensions that decide whether a Soroban contract can be deployed and operated affordably: **WASM size**, **storage entries**, and **CPU instructions**.

The repository already cared about performance — `docs/CONTRACT_RESOURCE_LIMITS.md`, the `contract_optimizer` crate, `wasm_size_monitor.sh`, and `measure_storage.sh` all exist — but the tooling was partly manual and disconnected from a formal gate. `wasm_size_monitor.sh` enforced **size only**, and `measure_storage.sh` produced storage/CPU numbers that nothing gated against a versioned budget. This PR unifies them.

## What's added

**`scripts/performance_budgets.json`** — the versioned budget, reviewed like any other source change:
- Absolute limits (64 KB hard size, 500 entries, 10M instructions) mirroring the values already documented in `CONTRACT_RESOURCE_LIMITS.md`, so there is one source of truth.
- Per-dimension regression tolerances (size +10%, entries +15%, CPU +15%).
- Noise floors (`min_wasm_delta_bytes`, `min_cpu_delta_instructions`) so a 400 B change on a 1 KB contract isn't failed as "+40%".
- Explicit budgets seeded for the 14 contracts closest to a hard limit, per the "prioritize a small set of critical contracts first" note.

**`scripts/performance_budget_gate.sh`** — the unified gate. Reads the wasm32 build and `reports/storage_summary.json` and evaluates **both** absolute thresholds and relative regressions.

**`tests/performance_budget_gate_test.sh`** — 22 assertions using synthetic fixtures, so it runs in seconds with no `cargo build`.

**Docs** — `docs/PERFORMANCE_BUDGETS.md` plus a linked "Automated Enforcement" section in `docs/CONTRACT_RESOURCE_LIMITS.md`.


## Relationship to #1101

**Please read this before reviewing.** PR #1101 (`deterministic contract resource budget pipeline`) landed while this was in progress and added `resource-budgets/budgets.json` + `scripts/measure_budgets.mjs`, which overlaps this work on size / storage entries / CPU instructions. This PR is rebased on top of it and does **not** revert or modify any of it — the `resource-budgets` job is preserved untouched.

Two things #1086 asks for that are still missing after #1101:

1. **A trend view.** `measure_budgets.mjs` has no trend support (`grep -ic trend` → 0), but the issue explicitly requires *"both 'current build' and 'trend' views."* This PR provides `--trend` over a retained sample history.
2. **A workflow that actually runs.** `ci.yml` is currently invalid on `main`, so the `resource-budgets` job introduced by #1101 — along with every other job — schedules zero jobs and never executes. This PR fixes that (details below).

I'm happy to **consolidate rather than duplicate** if maintainers prefer: I can drop the bash gate and instead port the trend view, grandfathering, and noise-floor logic into `measure_budgets.mjs`, keeping only the `ci.yml` repair from this PR. Say the word and I'll rework it — I'd rather land the right shape than two parallel frameworks.

**Make targets** — `perf-budget`, `perf-budget-update`, `perf-budget-trend`, `test-perf-budget`.

## Design decisions worth reviewing

**Grandfathering.** Several contracts already exceed 64 KB (`ihe_integration` ~91 KB, `identity_registry` ~90 KB). Failing on those immediately would make the gate permanently red and therefore ignored, so they are recorded with `grandfathered_over_size_limit: true`: reported as ⚠️, failed only if they regress *further*. Flip the flag to `false` as each is optimised below the limit to lock the win in.

**Graceful degradation.** If `reports/storage_summary.json` is absent (benchmarks didn't run), the gate falls back to a size-only evaluation and says so in the report, rather than failing the build for a missing measurement.

**`WARN_ONLY=1`** rolls the gate out in observation mode if you'd prefer to watch it for a few PRs before it blocks merges.

**`awk` instead of `bc`.** The gate needs no `apt-get install`, unlike the existing size monitor.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Baseline performance budget exists and is versioned | `scripts/performance_budgets.json` |
| CI fails/warns when a contract crosses a threshold for size, storage entries, or instruction count | "Performance budget gate" step; fail vs. warn logic in `evaluate_metric` |
| Benchmark results surfaced in PR comments or artifacts with enough context to act on | Markdown report posted as a PR comment + uploaded as the `performance-budget-report` artifact, including per-dimension remediation steps |
| Supports both "current build" and "trend" views | `--check` (current build) and `--trend` over `.performance_budget_trends.json` |

## Incidental fix: `ci.yml` was invalid on `main`

While wiring the gate in, I found `.github/workflows/ci.yml` is **currently invalid**, so every recent run scheduled **zero jobs** and was marked failed — CI could not pass for any PR. Two defects from a bad merge:

1. The `Comment PR with storage measurement` step had a `name` and `if` but **neither `uses` nor `run`**, which GitHub rejects at workflow-parse time.
2. That step's body had been spliced into `Comment WASM size regression on PR`, which redeclared `const path` in one scope — a JavaScript `SyntaxError` — and passed a duplicate `body` key.

Verified against the parsed workflow before and after:

```
ci.yml (main): PARSE OK, build steps=10, stepsMissingUsesOrRun=1
   BAD STEP -> Comment PR with storage measurement
   JS ERROR -> Comment WASM size regression on PR: Identifier 'path' has already been declared

ci.yml (this PR): PARSE OK, build steps=13, stepsMissingUsesOrRun=0, scriptsOK=6
```

Both steps are restored to their evident intent (each posting its own report). I kept this in scope because the gate adds a PR-comment step to that same block, and because CI cannot go green without it.

## Verification

```
$ bash tests/performance_budget_gate_test.sh
...
passed: 22, failed: 0

$ shellcheck -s bash -x scripts/performance_budget_gate.sh tests/performance_budget_gate_test.sh
(clean — same args as .pre-commit-config.yaml)
```

Exercised end to end against synthetic fixtures: budget regression, newly crossed hard limit, grandfathered breach, exclusion list, noise floor, storage-entry and CPU regressions, missing-benchmark degradation, `WARN_ONLY`, `--update`, and `--trend`.

Sample of the generated report:

| Contract | Size | Size status | Entries | Entry status | CPU | CPU status |
|---|---|---|---|---|---|---|
| `crosser` | 64 KB | ❌ crossed hard limit | – | ❓ not measured | – | ❓ not measured |
| `grandfather` | 89 KB | ⚠️ over hard limit (grandfathered) | – | ❓ not measured | – | ❓ not measured |
| `regressor` | 24 KB | ❌ +25.0% (budget +10%) | – | ❓ not measured | – | ❓ not measured |
| `steady` | 19 KB | ✅ ok | – | ❓ not measured | – | ❓ not measured |

## Follow-ups (deliberately not in this PR)

- Expand explicit budgets to all ~80 contracts (`--update` after a clean build records every one).
- Once the grandfathered contracts are optimised under 64 KB, flip their flags to `false`.
