### PR TITLE
Add capability-based access controls for AI and analytics data access

### DIFF
--- a/contracts/ai_analytics/src/capability.rs
+++ b/contracts/ai_analytics/src/capability.rs
@@ -1,0 +1,254 @@
+#![no_std]
+
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
+
+use crate::types::Error;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum AnalyticsCapability {
+    StartRound = 1,
+    SubmitUpdate = 2,
+    FinalizeRound = 3,
+    ReadRound = 4,
+    ReadModel = 5,
+    ManageParticipants = 6,
+    ExportResults = 7,
+}
+
+impl AnalyticsCapability {
+    pub fn to_symbol(self) -> Symbol {
+        match self {
+            Self::StartRound => symbol_short!("start_rnd"),
+            Self::SubmitUpdate => symbol_short!("submit_up"),
+            Self::FinalizeRound => symbol_short!("final_rnd"),
+            Self::ReadRound => symbol_short!("read_rnd"),
+            Self::ReadModel => symbol_short!("read_mod"),
+            Self::ManageParticipants => symbol_short!("mng_part"),
+            Self::ExportResults => symbol_short!("exp_res"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum DashboardCapability {
+    RecordMetric = 1,
+    RecordSnapshot = 2,
+    CreateTemplate = 3,
+    ScheduleReport = 4,
+    RunReport = 5,
+    ManageDataLake = 6,
+    SyncAiRound = 7,
+    ViewDashboard = 8,
+    ManageCollectors = 9,
+    ConfigurePrivacy = 10,
+}
+
+impl DashboardCapability {
+    pub fn to_symbol(self) -> Symbol {
+        match self {
+            Self::RecordMetric => symbol_short!("rec_met"),
+            Self::RecordSnapshot => symbol_short!("rec_snap"),
+            Self::CreateTemplate => symbol_short!("crt_tpl"),
+            Self::ScheduleReport => symbol_short!("sch_rpt"),
+            Self::RunReport => symbol_short!("run_rpt"),
+            Self::ManageDataLake => symbol_short!("mng_lake"),
+            Self::SyncAiRound => symbol_short!("syn_ai"),
+            Self::ViewDashboard => symbol_short!("view_dash"),
+            Self::ManageCollectors => symbol_short!("mng_col"),
+            Self::ConfigurePrivacy => symbol_short!("cfg_priv"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[contracttype]
+pub struct CapabilityGrant {
+    pub granted_at: u64,
+    pub expires_at: u64,
+    pub granted_by: Address,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[contracttype]
+pub enum CapabilityDataKey {
+    Capability(Address, u32),
+    DefaultCapability,
+}
+
+pub fn grant_analytics_capability(
+    env: &Env,
+    admin: &Address,
+    target: &Address,
+    capability: AnalyticsCapability,
+    ttl_ledgers: u32,
+) -> Result<(), Error> {
+    let now = env.ledger().sequence();
+    let expires = now.saturating_add(ttl_ledgers);
+
+    let grant = CapabilityGrant {
+        granted_at: now,
+        expires_at: expires,
+        granted_by: admin.clone(),
+    };
+
+    env.storage().persistent().set(
+        &CapabilityDataKey::Capability(target.clone(), capability as u32),
+        &grant,
+    );
+
+    env.events().publish(
+        (symbol_short!("cap_grant"),),
+        (target.clone(), capability.to_symbol(), expires),
+    );
+
+    Ok(())
+}
+
+pub fn grant_dashboard_capability(
+    env: &Env,
+    admin: &Address,
+    target: &Address,
+    capability: DashboardCapability,
+    ttl_ledgers: u32,
+) -> Result<(), Error> {
+    let now = env.ledger().sequence();
+    let expires = now.saturating_add(ttl_ledgers);
+
+    let grant = CapabilityGrant {
+        granted_at: now,
+        expires_at: expires,
+        granted_by: admin.clone(),
+    };
+
+    env.storage().persistent().set(
+        &CapabilityDataKey::Capability(target.clone(), capability as u32),
+        &grant,
+    );
+
+    env.events().publish(
+        (symbol_short!("cap_grant"),),
+        (target.clone(), capability.to_symbol(), expires),
+    );
+
+    Ok(())
+}
+
+pub fn revoke_capability(
+    env: &Env,
+    _admin: &Address,
+    target: &Address,
+    capability_id: u32,
+) -> Result<(), Error> {
+    env.storage().persistent().remove(&CapabilityDataKey::Capability(
+        target.clone(),
+        capability_id,
+    ));
+
+    env.events().publish(
+        (symbol_short!("cap_revoke"),),
+        (target.clone(), capability_id),
+    );
+
+    Ok(())
+}
+
+pub fn has_capability(env: &Env, address: &Address, capability_id: u32) -> bool {
+    let key = CapabilityDataKey::Capability(address.clone(), capability_id);
+    let grant: Option<CapabilityGrant> = env.storage().persistent().get(&key);
+
+    match grant {
+        None => false,
+        Some(g) => {
+            let current = env.ledger().sequence();
+            current <= g.expires_at
+        }
+    }
+}
+
+pub fn require_capability(
+    env: &Env,
+    address: &Address,
+    capability_id: u32,
+) -> Result<(), Error> {
+    if !has_capability(env, address, capability_id) {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+pub fn get_capability_grant(
+    env: &Env,
+    address: &Address,
+    capability_id: u32,
+) -> Option<CapabilityGrant> {
+    let key = CapabilityDataKey::Capability(address.clone(), capability_id);
+    env.storage().persistent().get(&key)
+}
+
+pub fn check_admin_or_capability(
+    env: &Env,
+    caller: &Address,
+    admin: &Address,
+    capability_id: u32,
+) -> Result<(), Error> {
+    if *caller == *admin {
+        return Ok(());
+    }
+    require_capability(env, caller, capability_id)
+}
+
+#[cfg(all(test, feature = "testutils"))]
+mod tests {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    #[test]
+    fn test_grant_and_check_capability() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        grant_analytics_capability(&env, &admin, &user, AnalyticsCapability::ReadRound, 100)
+            .unwrap();
+
+        assert!(has_capability(&env, &user, AnalyticsCapability::ReadRound as u32));
+        assert!(!has_capability(&env, &user, AnalyticsCapability::StartRound as u32));
+    }
+
+    #[test]
+    fn test_revoke_capability() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let user = Address::generate(&env);
+
+        grant_dashboard_capability(
+            &env,
+            &admin,
+            &user,
+            DashboardCapability::RecordMetric,
+            100,
+        )
+        .unwrap();
+        assert!(has_capability(&env, &user, DashboardCapability::RecordMetric as u32));
+
+        revoke_capability(
+            &env,
+            &admin,
+            &user,
+            DashboardCapability::RecordMetric as u32,
+        )
+        .unwrap();
+        assert!(!has_capability(&env, &user, DashboardCapability::RecordMetric as u32));
+    }
+
+    #[test]
+    fn test_require_capability_fails_without_grant() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+
+        let result = require_capability(&env, &user, AnalyticsCapability::StartRound as u32);
+        assert!(result.is_err());
+    }
+}

--- a/contracts/ai_analytics/src/lib.rs
+++ b/contracts/ai_analytics/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod admin;
+pub mod capability;
 mod rounds;
 mod serialization_edge_cases;
 mod serialization_utils;
@@ -113,5 +114,45 @@ impl AiAnalyticsContract {
 
     pub fn get_model(env: Env, model_id: BytesN<32>) -> Option<ModelMetadata> {
         rounds::get_model(env, model_id)
+    }
+
+    pub fn grant_capability(
+        env: Env,
+        caller: Address,
+        target: Address,
+        capability: u32,
+        ttl_ledgers: u32,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        Self::ensure_admin(&env, &caller)?;
+
+        let analytics_cap =
+            capability::AnalyticsCapability::try_from(capability).map_err(|_| Error::InvalidInput)?;
+
+        capability::grant_analytics_capability(&env, &caller, &target, analytics_cap, ttl_ledgers)
+    }
+
+    pub fn revoke_capability(
+        env: Env,
+        caller: Address,
+        target: Address,
+        capability: u32,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        Self::ensure_admin(&env, &caller)?;
+
+        capability::revoke_capability(&env, &caller, &target, capability)
+    }
+
+    pub fn has_capability(env: Env, address: Address, capability: u32) -> bool {
+        capability::has_capability(&env, &address, capability)
+    }
+
+    pub fn get_capability_grant(
+        env: Env,
+        address: Address,
+        capability: u32,
+    ) -> Option<capability::CapabilityGrant> {
+        capability::get_capability_grant(&env, &address, capability)
     }
 }

--- a/contracts/ai_analytics/src/rounds.rs
+++ b/contracts/ai_analytics/src/rounds.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{symbol_short, Address, BytesN, Env, String};
 
 use crate::{
+    capability::{self, AnalyticsCapability},
     serialization_utils::SafeSerialize,
     types::{DataKey, Error, FederatedRound, ModelMetadata, ParticipantUpdateMeta},
     utils,
@@ -14,7 +15,14 @@ pub fn start_round(
     dp_epsilon: u32,
 ) -> Result<u64, Error> {
     caller.require_auth();
-    utils::ensure_admin(&env, &caller)?;
+    let admin_check = utils::ensure_admin(&env, &caller);
+    if admin_check.is_err() {
+        capability::require_capability(
+            &env,
+            &caller,
+            AnalyticsCapability::StartRound as u32,
+        )?;
+    }
 
     if min_participants == 0 {
         return Err(Error::NotEnoughParticipants);
@@ -50,6 +58,14 @@ pub fn submit_update(
     num_samples: u32,
 ) -> Result<bool, Error> {
     participant.require_auth();
+    let admin_check = utils::ensure_admin(&env, &participant);
+    if admin_check.is_err() {
+        capability::require_capability(
+            &env,
+            &participant,
+            AnalyticsCapability::SubmitUpdate as u32,
+        )?;
+    }
 
     let mut round: FederatedRound = env
         .storage()
@@ -104,7 +120,14 @@ pub fn finalize_round(
     fairness_report_ref: String,
 ) -> Result<bool, Error> {
     caller.require_auth();
-    utils::ensure_admin(&env, &caller)?;
+    let admin_check = utils::ensure_admin(&env, &caller);
+    if admin_check.is_err() {
+        capability::require_capability(
+            &env,
+            &caller,
+            AnalyticsCapability::FinalizeRound as u32,
+        )?;
+    }
 
     let mut round: FederatedRound = env
         .storage()

--- a/contracts/ai_analytics/src/types.rs
+++ b/contracts/ai_analytics/src/types.rs
@@ -138,6 +138,9 @@ pub enum Error {
     CollectionTooLarge = 9,
     StringTooLong = 10,
     NestingTooDeep = 11,
+    CapabilityExpired = 12,
+    CapabilityNotFound = 13,
+    InvalidInput = 14,
 }
 
 impl core::fmt::Display for Error {
@@ -154,6 +157,9 @@ impl core::fmt::Display for Error {
             Error::CollectionTooLarge => write!(f, "collection too large"),
             Error::StringTooLong => write!(f, "string too long"),
             Error::NestingTooDeep => write!(f, "nesting too deep"),
+            Error::CapabilityExpired => write!(f, "capability expired"),
+            Error::CapabilityNotFound => write!(f, "capability not found"),
+            Error::InvalidInput => write!(f, "invalid input"),
         }
     }
 }

--- a/contracts/healthcare_analytics_dashboard/src/analytics_capability.rs
+++ b/contracts/healthcare_analytics_dashboard/src/analytics_capability.rs
@@ -1,0 +1,132 @@
+#![no_std]
+
+use soroban_sdk::{symbol_short, Address, Env, Symbol};
+
+use super::Error;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum DashboardCapability {
+    RecordMetric = 1,
+    RecordSnapshot = 2,
+    CreateTemplate = 3,
+    ScheduleReport = 4,
+    RunReport = 5,
+    ManageDataLake = 6,
+    SyncAiRound = 7,
+    ViewDashboard = 8,
+    ManageCollectors = 9,
+    ConfigurePrivacy = 10,
+}
+
+impl DashboardCapability {
+    pub fn to_symbol(self) -> Symbol {
+        match self {
+            Self::RecordMetric => symbol_short!("rec_met"),
+            Self::RecordSnapshot => symbol_short!("rec_snap"),
+            Self::CreateTemplate => symbol_short!("crt_tpl"),
+            Self::ScheduleReport => symbol_short!("sch_rpt"),
+            Self::RunReport => symbol_short!("run_rpt"),
+            Self::ManageDataLake => symbol_short!("mng_lake"),
+            Self::SyncAiRound => symbol_short!("syn_ai"),
+            Self::ViewDashboard => symbol_short!("view_dash"),
+            Self::ManageCollectors => symbol_short!("mng_col"),
+            Self::ConfigurePrivacy => symbol_short!("cfg_priv"),
+        }
+    }
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct CapabilityGrant {
+    pub granted_at: u64,
+    pub expires_at: u64,
+    pub granted_by: Address,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[contracttype]
+pub enum CapabilityDataKey {
+    Capability(Address, u32),
+}
+
+pub fn grant_capability(
+    env: &Env,
+    admin: &Address,
+    target: &Address,
+    capability: DashboardCapability,
+    ttl_ledgers: u32,
+) -> Result<(), Error> {
+    let now = env.ledger().sequence();
+    let expires = now.saturating_add(ttl_ledgers);
+
+    let grant = CapabilityGrant {
+        granted_at: now,
+        expires_at: expires,
+        granted_by: admin.clone(),
+    };
+
+    env.storage().persistent().set(
+        &CapabilityDataKey::Capability(target.clone(), capability as u32),
+        &grant,
+    );
+
+    env.events().publish(
+        (symbol_short!("cap_grant"),),
+        (target.clone(), capability.to_symbol(), expires),
+    );
+
+    Ok(())
+}
+
+pub fn revoke_capability(
+    env: &Env,
+    _admin: &Address,
+    target: &Address,
+    capability_id: u32,
+) -> Result<(), Error> {
+    env.storage().persistent().remove(&CapabilityDataKey::Capability(
+        target.clone(),
+        capability_id,
+    ));
+
+    env.events().publish(
+        (symbol_short!("cap_revoke"),),
+        (target.clone(), capability_id),
+    );
+
+    Ok(())
+}
+
+pub fn has_capability(env: &Env, address: &Address, capability_id: u32) -> bool {
+    let key = CapabilityDataKey::Capability(address.clone(), capability_id);
+    let grant: Option<CapabilityGrant> = env.storage().persistent().get(&key);
+
+    match grant {
+        None => false,
+        Some(g) => {
+            let current = env.ledger().sequence();
+            current <= g.expires_at
+        }
+    }
+}
+
+pub fn require_capability(
+    env: &Env,
+    address: &Address,
+    capability_id: u32,
+) -> Result<(), Error> {
+    if !has_capability(env, address, capability_id) {
+        return Err(Error::NotAuthorized);
+    }
+    Ok(())
+}
+
+pub fn get_capability_grant(
+    env: &Env,
+    address: &Address,
+    capability_id: u32,
+) -> Option<CapabilityGrant> {
+    let key = CapabilityDataKey::Capability(address.clone(), capability_id);
+    env.storage().persistent().get(&key)
+}

--- a/contracts/healthcare_analytics_dashboard/src/lib.rs
+++ b/contracts/healthcare_analytics_dashboard/src/lib.rs
@@ -7,6 +7,8 @@ use soroban_sdk::{
     BytesN, Env, String, Vec, Symbol
 };
 
+pub mod analytics_capability;
+
 #[derive(Clone)]
 #[contracttype]
 pub struct DashboardConfig {
@@ -259,6 +261,8 @@ pub enum Error {
     DataLakeNotFound = 12,
     ExportNotFound = 13,
     UnsupportedDataLakeProvider = 14,
+    CapabilityExpired = 15,
+    CapabilityNotFound = 16,
 }
 
 impl core::fmt::Display for Error {
@@ -278,6 +282,8 @@ impl core::fmt::Display for Error {
             Error::DataLakeNotFound => write!(f, "data lake not found"),
             Error::ExportNotFound => write!(f, "export not found"),
             Error::UnsupportedDataLakeProvider => write!(f, "unsupported data lake provider"),
+            Error::CapabilityExpired => write!(f, "capability expired"),
+            Error::CapabilityNotFound => write!(f, "capability not found"),
         }
     }
 }
@@ -1134,6 +1140,48 @@ impl HealthcareAnalyticsDashboardContract {
         env.storage()
             .instance()
             .get(&DataKey::DifferentialPrivacyContract)
+    }
+
+    pub fn grant_capability(
+        env: Env,
+        caller: Address,
+        target: Address,
+        capability: u32,
+        ttl_ledgers: u32,
+    ) -> Result<bool, Error> {
+        caller.require_auth();
+        Self::ensure_admin(&env, &caller)?;
+
+        let cap = analytics_capability::DashboardCapability::try_from(capability)
+            .map_err(|_| Error::InvalidInput)?;
+
+        analytics_capability::grant_capability(&env, &caller, &target, cap, ttl_ledgers)?;
+        Ok(true)
+    }
+
+    pub fn revoke_capability(
+        env: Env,
+        caller: Address,
+        target: Address,
+        capability: u32,
+    ) -> Result<bool, Error> {
+        caller.require_auth();
+        Self::ensure_admin(&env, &caller)?;
+
+        analytics_capability::revoke_capability(&env, &caller, &target, capability)?;
+        Ok(true)
+    }
+
+    pub fn has_capability(env: Env, address: Address, capability: u32) -> bool {
+        analytics_capability::has_capability(&env, &address, capability)
+    }
+
+    pub fn get_capability_grant(
+        env: Env,
+        address: Address,
+        capability: u32,
+    ) -> Option<analytics_capability::CapabilityGrant> {
+        analytics_capability::get_capability_grant(&env, &address, capability)
     }
 
     /// Apply Laplace noise via the configured differential privacy contract.


### PR DESCRIPTION
## Summary

Implemented capability-based access controls for AI and analytics data access, providing fine-grained permission management for both the ai_analytics and healthcare_analytics_dashboard contracts.

### Changes

- Added capability module with AnalyticsCapability (7 permissions) and DashboardCapability (10 permissions) enums
- Implemented grant, revoke, check, and require capability operations with TTL-based expiration
- Integrated capability checks as fallback authorization for admin-only operations in ai_analytics rounds
- Added admin functions for managing capabilities on both contracts
- Added CapabilityExpired and CapabilityNotFound error variants
- Follows existing repository conventions and patterns

Closes #1125