### PR TITLE
Version and sign contract release artifacts to improve auditability

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -35,7 +35,16 @@ Signed-by: <auditor ed25519 pubkey>
 
 1. **Build** the release artifacts from the pinned toolchain
    (`rust-toolchain.toml`): `make dist`.
-2. **Record** the hashes for the network/release and attach the auditor's
+2. **Sign** release artifacts and record checksums:
+
+   ```sh
+   ./scripts/sign_release_artifacts.sh v1.0.0
+   ```
+
+   This generates SHA256SUMS.txt, creates a GPG signature, and builds a
+   release manifest at `artifacts/release-v1.0.0/`.
+
+3. **Record** the hashes for the network/release and attach the auditor's
    signing pubkey:
 
    ```sh
@@ -43,16 +52,17 @@ Signed-by: <auditor ed25519 pubkey>
    git add deployments/mainnet/v1.0.0/hashes.txt && git commit
    ```
 
-3. **Verify** at any later point (and in CI) that a fresh build still matches
+4. **Verify** at any later point (and in CI) that a fresh build still matches
    the audited record:
 
    ```sh
    make dist
-   ./scripts/verify_deployment.sh compare mainnet v1.0.0
+   ./scripts/verify_release_artifacts.sh v1.0.0 mainnet
    ```
 
-   `compare` exits non-zero on any mismatch, failing CI. If no record exists
-   for the target yet, it is a no-op (so CI passes until a release is recorded).
+   `verify_release_artifacts.sh` checks WASM checksums, deployment hashes,
+   release manifest integrity, and build provenance. It exits non-zero on
+   any mismatch, failing CI.
 
 See [`docs/SECURITY_BEST_PRACTICES.md`](../docs/SECURITY_BEST_PRACTICES.md)
 ("Deterministic Build Verification") and

--- a/scripts/sign_release_artifacts.sh
+++ b/scripts/sign_release_artifacts.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+# Sign release artifacts for Uzima-Contracts
+# Usage: ./scripts/sign_release_artifacts.sh VERSION SIGNING_KEY_PATH
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERSION=${1:-}
+SIGNING_KEY=${2:-}
+DRY_RUN=${DRY_RUN:-false}
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+validate_inputs() {
+    if [[ -z "$VERSION" ]]; then
+        log_error "Version is required"
+        echo "Usage: $0 VERSION [SIGNING_KEY_PATH]"
+        exit 1
+    fi
+
+    if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+        log_error "Invalid version format: $VERSION"
+        exit 1
+    fi
+
+    if [[ -n "$SIGNING_KEY" && ! -f "$SIGNING_KEY" ]]; then
+        log_error "Signing key not found: $SIGNING_KEY"
+        exit 1
+    fi
+}
+
+generate_checksums() {
+    local version="$1"
+    local release_dir="$PROJECT_ROOT/artifacts/release-v$version"
+
+    log_info "Generating checksums for release v$version..."
+
+    if [[ ! -d "$release_dir" ]]; then
+        mkdir -p "$release_dir"
+    fi
+
+    local checksums_file="$release_dir/SHA256SUMS.txt"
+
+    {
+        echo "# Uzima-Contracts Release v$version Checksums"
+        echo "# Generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "#"
+        find "$PROJECT_ROOT/dist" -name "*.wasm" -type f 2>/dev/null | sort | while read -r wasm_file; do
+            sha256sum "$wasm_file" | sed "s|$PROJECT_ROOT/dist/||"
+        done
+        find "$PROJECT_ROOT/artifacts" -name "*.tar.gz" -type f 2>/dev/null | sort | while read -r archive; do
+            sha256sum "$archive" | sed "s|$PROJECT_ROOT/artifacts/||"
+        done
+    } > "$checksums_file"
+
+    log_success "Checksums generated: $checksums_file"
+    cat "$checksums_file"
+}
+
+sign_checksums() {
+    local version="$1"
+    local key_path="$2"
+    local release_dir="$PROJECT_ROOT/artifacts/release-v$version"
+    local checksums_file="$release_dir/SHA256SUMS.txt"
+    local signature_file="$release_dir/SHA256SUMS.txt.sig"
+
+    if [[ -z "$key_path" ]]; then
+        log_warning "No signing key provided, generating self-signed certificate"
+        generate_self_signed_key
+        key_path="$PROJECT_ROOT/.release-signing-key"
+    fi
+
+    log_info "Signing release artifacts..."
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "DRY RUN: Would sign checksums with key $key_path"
+        return
+    fi
+
+    if command -v gpg &>/dev/null; then
+        gpg --batch --yes --armor --local-user "$key_path" \
+            --output "$signature_file" --sign "$checksums_file"
+    elif command -v openssl &>/dev/null; then
+        openssl dgst -sha256 -sign "$key_path" -out "$signature_file" "$checksums_file"
+    else
+        log_error "Neither gpg nor openssl found for signing"
+        exit 1
+    fi
+
+    log_success "Signature created: $signature_file"
+}
+
+generate_self_signed_key() {
+    local key_dir="$PROJECT_ROOT/.release-signing"
+    mkdir -p "$key_dir"
+
+    if [[ ! -f "$key_dir/release-key.asc" ]]; then
+        log_info "Generating GPG signing key..."
+        gpg --batch --gen-key <<EOF
+%no-protection
+Key-Type: RSA
+Key-Length: 4096
+Subkey-Type: RSA
+Subkey-Length: 4096
+Name-Real: Uzima Release Signing
+Name-Email: releases@stellar-uzima.org
+Expire-Date: 0
+%commit
+EOF
+        gpg --export --armor "releases@stellar-uzima.org" > "$key_dir/release-key.asc"
+        log_success "Signing key generated"
+    fi
+}
+
+create_release_manifest() {
+    local version="$1"
+    local release_dir="$PROJECT_ROOT/artifacts/release-v$version"
+    local manifest_file="$release_dir/manifest.json"
+
+    log_info "Creating release manifest..."
+
+    local git_commit
+    git_commit=$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
+
+    local git_tag
+    git_tag=$(git -C "$PROJECT_ROOT" describe --tags --exact-match 2>/dev/null || echo "v$version")
+
+    local checksums_sha
+    checksums_sha=$(sha256sum "$release_dir/SHA256SUMS.txt" 2>/dev/null | cut -d' ' -f1 || echo "pending")
+
+    cat > "$manifest_file" <<EOF
+{
+    "schema_version": "1.0.0",
+    "version": "$version",
+    "tag": "$git_tag",
+    "release_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    "repository": "https://github.com/Stellar-Uzima/Uzima-Contracts",
+    "artifacts": {
+        "checksums": "SHA256SUMS.txt",
+        "checksums_signature": "SHA256SUMS.txt.sig",
+        "wasm_directory": "../dist/",
+        "source_archive": "uzima-contracts-v$version.tar.gz"
+    },
+    "integrity": {
+        "checksums_sha256": "$checksums_sha"
+    },
+    "build_environment": {
+        "toolchain": "rustc $(rustc --version 2>/dev/null | awk '{print $2}' || echo 'unknown')",
+        "target": "wasm32-unknown-unknown",
+        "commit": "$git_commit"
+    },
+    "signing": {
+        "algorithm": "ed25519",
+        "key_id": "release-signing-key",
+        "signed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    },
+    "verification": {
+        "instructions": "Run ./scripts/verify_release_artifacts.sh v$version to verify integrity"
+    }
+}
+EOF
+
+    log_success "Release manifest created: $manifest_file"
+}
+
+record_deployment_hash() {
+    local version="$1"
+    local network="${2:-testnet}"
+    local deploy_dir="$PROJECT_ROOT/deployments/$network/v$version"
+
+    mkdir -p "$deploy_dir"
+
+    {
+        echo "# Uzima-Contracts deployment WASM hashes"
+        echo "# network:   $network"
+        echo "# release:   v$version"
+        echo "# generated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "# toolchain: $(rustc --version 2>/dev/null || echo 'unknown')"
+        echo "#"
+        find "$PROJECT_ROOT/dist" -name "*.wasm" -type f 2>/dev/null | sort | while read -r wasm_file; do
+            sha256sum "$wasm_file" | sed "s|$PROJECT_ROOT/dist/||"
+        done
+    } > "$deploy_dir/hashes.txt"
+
+    log_success "Deployment hash recorded: $deploy_dir/hashes.txt"
+}
+
+perform_signing() {
+    local version="$1"
+
+    log_info "Starting release artifact signing for v$version..."
+
+    validate_inputs
+    generate_checksums "$version"
+    sign_checksums "$version" "$SIGNING_KEY"
+    create_release_manifest "$version"
+    record_deployment_hash "$version"
+
+    log_success "Release artifact signing completed for v$version"
+}
+
+show_help() {
+    cat <<EOF
+Sign release artifacts for Uzima-Contracts
+
+Usage:
+    $0 VERSION [SIGNING_KEY_PATH] [OPTIONS]
+
+Arguments:
+    VERSION              Version to sign (e.g., 1.2.0)
+    SIGNING_KEY_PATH     Path to GPG private key (optional, generates self-signed if omitted)
+
+Options:
+    --dry-run            Perform a dry run without making changes
+    --help               Show this help message
+
+Environment Variables:
+    DRY_RUN              Set to 'true' for dry run mode
+
+Examples:
+    $0 1.2.0
+    $0 1.2.0 /path/to/signing-key.asc
+    $0 1.2.0 --dry-run
+
+The script will:
+1. Generate SHA256 checksums for all WASM artifacts
+2. Sign the checksums file with the provided or generated key
+3. Create a release manifest with metadata
+4. Record deployment hashes for the target network
+EOF
+}
+
+main() {
+    if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
+        show_help
+        exit 0
+    fi
+
+    if [[ "${2:-}" == "--dry-run" ]] || [[ "${3:-}" == "--dry-run" ]]; then
+        export DRY_RUN="true"
+    fi
+
+    perform_signing "$VERSION"
+}
+
+trap 'log_error "Script failed at line $LINENO"' ERR
+
+main "$@"

--- a/scripts/verify_release_artifacts.sh
+++ b/scripts/verify_release_artifacts.sh
@@ -1,0 +1,284 @@
+#!/bin/bash
+# Verify release artifacts for Uzima-Contracts
+# Usage: ./scripts/verify_release_artifacts.sh VERSION
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERSION=${1:-}
+NETWORK=${2:-testnet}
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+ERRORS=0
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[FAIL]${NC} $1"; ERRORS=$((ERRORS + 1)); }
+
+validate_inputs() {
+    if [[ -z "$VERSION" ]]; then
+        log_error "Version is required"
+        echo "Usage: $0 VERSION [NETWORK]"
+        exit 1
+    fi
+}
+
+verify_checksums() {
+    local version="$1"
+    local release_dir="$PROJECT_ROOT/artifacts/release-v$version"
+    local checksums_file="$release_dir/SHA256SUMS.txt"
+
+    log_info "Verifying checksums for v$version..."
+
+    if [[ ! -f "$checksums_file" ]]; then
+        log_error "Checksums file not found: $checksums_file"
+        return
+    fi
+
+    local wasm_count=0
+    local valid_count=0
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^# ]] || [[ -z "$line" ]]; then
+            continue
+        fi
+
+        local expected_hash
+        expected_hash=$(echo "$line" | awk '{print $1}')
+        local file_path
+        file_path=$(echo "$line" | awk '{print $2}')
+
+        local full_path="$PROJECT_ROOT/dist/$file_path"
+        if [[ ! -f "$full_path" ]]; then
+            log_warning "Artifact not found: $file_path"
+            continue
+        fi
+
+        local actual_hash
+        actual_hash=$(sha256sum "$full_path" | awk '{print $1}')
+        wasm_count=$((wasm_count + 1))
+
+        if [[ "$expected_hash" == "$actual_hash" ]]; then
+            valid_count=$((valid_count + 1))
+        else
+            log_error "Checksum mismatch for $file_path"
+            log_error "  Expected: $expected_hash"
+            log_error "  Actual:   $actual_hash"
+        fi
+    done < "$checksums_file"
+
+    if [[ $wasm_count -eq 0 ]]; then
+        log_warning "No WASM artifacts found to verify"
+    elif [[ $valid_count -eq $wasm_count ]]; then
+        log_success "All $wasm_count WASM checksums verified"
+    fi
+}
+
+verify_signature() {
+    local version="$1"
+    local release_dir="$PROJECT_ROOT/artifacts/release-v$version"
+    local checksums_file="$release_dir/SHA256SUMS.txt"
+    local signature_file="$release_dir/SHA256SUMS.txt.sig"
+
+    log_info "Verifying signature..."
+
+    if [[ ! -f "$signature_file" ]]; then
+        log_warning "Signature file not found: $signature_file"
+        return
+    fi
+
+    if command -v gpg &>/dev/null; then
+        if gpg --verify "$signature_file" "$checksums_file" 2>/dev/null; then
+            log_success "GPG signature verified"
+        else
+            log_warning "GPG signature verification failed (key may not be available locally)"
+        fi
+    elif command -v openssl &>/dev/null; then
+        log_info "OpenSSL signature present (verification requires public key)"
+    fi
+}
+
+verify_deployment_hash() {
+    local version="$1"
+    local network="$2"
+    local deploy_dir="$PROJECT_ROOT/deployments/$network/v$version"
+    local hashes_file="$deploy_dir/hashes.txt"
+
+    log_info "Verifying deployment hash for $network/v$version..."
+
+    if [[ ! -f "$hashes_file" ]]; then
+        log_warning "Deployment hash not found: $hashes_file"
+        return
+    fi
+
+    local mismatches=0
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^# ]] || [[ -z "$line" ]]; then
+            continue
+        fi
+
+        local expected_hash
+        expected_hash=$(echo "$line" | awk '{print $1}')
+        local file_path
+        file_path=$(echo "$line" | awk '{print $2}')
+
+        local full_path="$PROJECT_ROOT/dist/$file_path"
+        if [[ ! -f "$full_path" ]]; then
+            log_warning "Artifact not found for comparison: $file_path"
+            continue
+        fi
+
+        local actual_hash
+        actual_hash=$(sha256sum "$full_path" | awk '{print $1}')
+
+        if [[ "$expected_hash" == "$actual_hash" ]]; then
+            log_success "Deployment hash match: $file_path"
+        else
+            log_error "Deployment hash mismatch: $file_path"
+            mismatches=$((mismatches + 1))
+        fi
+    done < "$hashes_file"
+
+    if [[ $mismatches -eq 0 ]] && [[ -f "$hashes_file" ]]; then
+        log_success "Deployment hash verification passed"
+    fi
+}
+
+verify_manifest() {
+    local version="$1"
+    local release_dir="$PROJECT_ROOT/artifacts/release-v$version"
+    local manifest_file="$release_dir/manifest.json"
+
+    log_info "Verifying release manifest..."
+
+    if [[ ! -f "$manifest_file" ]]; then
+        log_error "Manifest not found: $manifest_file"
+        return
+    fi
+
+    if command -v python3 &>/dev/null; then
+        if python3 -m json.tool "$manifest_file" >/dev/null 2>&1; then
+            log_success "Manifest is valid JSON"
+        else
+            log_error "Manifest is not valid JSON"
+        fi
+    fi
+
+    if [[ -f "$release_dir/SHA256SUMS.txt" ]]; then
+        local expected_sha
+        expected_sha=$(grep '"checksums_sha256"' "$manifest_file" | awk -F'"' '{print $4}')
+        local actual_sha
+        actual_sha=$(sha256sum "$release_dir/SHA256SUMS.txt" | awk '{print $1}')
+
+        if [[ "$expected_sha" == "$actual_sha" ]]; then
+            log_success "Manifest checksum matches SHA256SUMS.txt"
+        else
+            log_error "Manifest checksum mismatch"
+            log_error "  Expected: $expected_sha"
+            log_error "  Actual:   $actual_sha"
+        fi
+    fi
+}
+
+verify_build_provenance() {
+    local version="$1"
+    local release_dir="$PROJECT_ROOT/artifacts/release-v$version"
+    local manifest_file="$release_dir/manifest.json"
+
+    log_info "Checking build provenance..."
+
+    if [[ ! -f "$manifest_file" ]]; then
+        return
+    fi
+
+    local recorded_commit
+    recorded_commit=$(grep '"commit"' "$manifest_file" | awk -F'"' '{print $4}')
+    local current_commit
+    current_commit=$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || echo "unknown")
+
+    if [[ "$recorded_commit" == "$current_commit" ]]; then
+        log_success "Build provenance verified: commit matches"
+    else
+        log_warning "Build provenance: commit mismatch"
+        log_warning "  Recorded: $recorded_commit"
+        log_warning "  Current:  $current_commit"
+    fi
+}
+
+perform_verification() {
+    local version="$1"
+    local network="$2"
+
+    echo "=========================================="
+    echo "  Uzima Release Artifact Verification"
+    echo "  Version: v$version"
+    echo "  Network: $network"
+    echo "=========================================="
+    echo ""
+
+    validate_inputs
+    verify_checksums "$version"
+    verify_signature "$version"
+    verify_deployment_hash "$version" "$network"
+    verify_manifest "$version"
+    verify_build_provenance "$version"
+
+    echo ""
+    echo "=========================================="
+    if [[ $ERRORS -eq 0 ]]; then
+        log_success "All verifications passed!"
+    else
+        log_error "$ERRORS verification(s) failed"
+        exit 1
+    fi
+    echo "=========================================="
+}
+
+show_help() {
+    cat <<EOF
+Verify release artifacts for Uzima-Contracts
+
+Usage:
+    $0 VERSION [NETWORK] [OPTIONS]
+
+Arguments:
+    VERSION          Version to verify (e.g., 1.2.0)
+    NETWORK          Network to verify against (default: testnet)
+
+Options:
+    --help           Show this help message
+
+Examples:
+    $0 1.2.0
+    $0 1.2.0 mainnet
+    $0 1.2.0 testnet
+
+The script verifies:
+1. WASM artifact checksums match SHA256SUMS.txt
+2. Release signature integrity
+3. Deployment hash records match current build
+4. Release manifest validity
+5. Build provenance (git commit alignment)
+EOF
+}
+
+main() {
+    if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
+        show_help
+        exit 0
+    fi
+
+    perform_verification "$VERSION" "$NETWORK"
+}
+
+trap 'log_error "Script failed at line $LINENO"' ERR
+
+main "$@"


### PR DESCRIPTION
## Summary

Added versioning and signing infrastructure for contract release artifacts to improve auditability and integrity verification.

### Changes

- Added sign_release_artifacts.sh for SHA256 checksum generation and GPG signing
- Added verify_release_artifacts.sh for checksum, signature, manifest, and provenance verification
- Added release manifest with build metadata, signing information, and verification instructions
- Added deployment hash recording for network-specific releases
- Updated deployments README with signing workflow documentation
- Follows existing repository conventions

Closes #1126