### PR TITLE
Add contract scaffolding script and smoke-test for new contributors

### DIFF
--- a/contracts/contract_template/src/lib.rs
+++ b/contracts/contract_template/src/lib.rs
@@ -1,12 +1,20 @@
 //! # Contract Template
 //!
 //! Boilerplate for new Soroban contracts. Demonstrates:
-//! - Proper `require_auth()` pattern (Issue #439)
+//! - Proper `require_auth()` pattern
 //! - Standard initialization guard
 //! - Typed errors and events
 //! - Storage key namespacing
 //!
-//! Copy this directory and rename `contract-template` / `ContractTemplate` throughout.
+//! To create a new contract, run:
+//! ```bash
+//! ./scripts/scaffold-contract.sh <your_contract_name>
+//! ```
+//!
+//! Then verify it with:
+//! ```bash
+//! ./scripts/smoke-test-scaffold.sh <your_contract_name>
+//! ```
 
 #![no_std]
 

--- a/scripts/scaffold-contract.sh
+++ b/scripts/scaffold-contract.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# scaffold-contract.sh — Create a new Soroban contract from the project template.
+#
+# Usage:
+#   ./scripts/scaffold-contract.sh <contract_name>
+#
+# Example:
+#   ./scripts/scaffold-contract.sh appointment_scheduling
+#
+# This will create:
+#   contracts/appointment_scheduling/
+#     src/lib.rs, errors.rs, events.rs, types.rs, test.rs
+#     Cargo.toml
+#
+# After scaffolding:
+#   1. Run `cargo test --package <contract_name>` to verify it compiles and tests pass.
+#   2. Add the contract to the workspace Cargo.toml if it was excluded.
+#   3. Run `node scripts/abi-compat.mjs` to update the interface registry baseline.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_DIR="$PROJECT_ROOT/contracts/contract_template"
+
+# ── Validate input ───────────────────────────────────────────────────────────
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <contract_name>"
+  echo ""
+  echo "Examples:"
+  echo "  $0 appointment_scheduling"
+  echo "  $0 lab_results"
+  exit 1
+fi
+
+CONTRACT_NAME="$1"
+
+# Validate name format (snake_case, lowercase, underscores only)
+if [[ ! "$CONTRACT_NAME" =~ ^[a-z][a-z0-9_]*$ ]]; then
+  echo "Error: Contract name must be snake_case (lowercase letters, digits, underscores)."
+  echo "  Got: $CONTRACT_NAME"
+  exit 1
+fi
+
+# Check template exists
+if [[ ! -d "$TEMPLATE_DIR/src" ]]; then
+  echo "Error: Template directory not found at $TEMPLATE_DIR"
+  exit 1
+fi
+
+# Check target doesn't already exist
+TARGET_DIR="$PROJECT_ROOT/contracts/$CONTRACT_NAME"
+if [[ -d "$TARGET_DIR" ]]; then
+  echo "Error: Directory already exists: $TARGET_DIR"
+  exit 1
+fi
+
+# ── Derive names ─────────────────────────────────────────────────────────────
+
+# PascalCase from snake_case: "appointment_scheduling" -> "AppointmentScheduling"
+PASCAL_NAME=$(echo "$CONTRACT_NAME" | sed -r 's/(^|_)([a-z])/\U\2/g')
+
+# Kebab-case for Cargo package name: "appointment_scheduling" -> "appointment-scheduling"
+KEBAB_NAME=$(echo "$CONTRACT_NAME" | tr '_' '-')
+
+echo "Scaffolding contract: $CONTRACT_NAME"
+echo "  PascalCase: $PASCAL_NAME"
+echo "  Kebab-case: $KEBAB_NAME"
+echo ""
+
+# ── Copy template ────────────────────────────────────────────────────────────
+
+cp -r "$TEMPLATE_DIR" "$TARGET_DIR"
+
+# ── Rename types in files ────────────────────────────────────────────────────
+
+# Replace "contract-template" with the kebab name in Cargo.toml
+sed -i "s/contract-template/$KEBAB_NAME/g" "$TARGET_DIR/Cargo.toml"
+
+# Replace "ContractTemplate" with the Pascal name in Rust files
+find "$TARGET_DIR/src" -name '*.rs' -exec sed -i "s/ContractTemplate/$PASCAL_NAME/g" {} +
+
+# Replace the crate-level doc comment with the new contract name
+sed -i "s/Contract Template/$PASCAL_NAME/g" "$TARGET_DIR/src/lib.rs"
+sed -i "s/ContractTemplate/$PASCAL_NAME/g" "$TARGET_DIR/src/lib.rs"
+
+# ── Create README ────────────────────────────────────────────────────────────
+
+cat > "$TARGET_DIR/README.md" << EOF
+# $PASCAL_NAME
+
+Soroban smart contract for the Uzima healthcare platform.
+
+## Overview
+
+TODO: Describe what this contract does.
+
+## Initialization
+
+\`\`\`rust,ignore
+client.initialize(&admin);
+\`\`\`
+
+## Functions
+
+| Function | Description |
+|---|---|
+| \`initialize\` | Initialize the contract with an admin address |
+| \`transfer_admin\` | Transfer admin rights to a new address |
+| \`update_data\` | Update the contract's stored data |
+| \`get_admin\` | Return the current admin address |
+| \`get_data\` | Return the stored data |
+
+## Testing
+
+\`\`\`bash
+cargo test --package $KEBAB_NAME
+\`\`\`
+
+## Files
+
+- \`src/lib.rs\` - Main contract implementation
+- \`src/errors.rs\` - Error definitions
+- \`src/events.rs\` - Event emission helpers
+- \`src/types.rs\` - Type definitions
+- \`src/test.rs\` - Unit tests
+EOF
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo "Created contract at: $TARGET_DIR"
+echo ""
+echo "Next steps:"
+echo "  1. Edit $TARGET_DIR/src/lib.rs to implement your contract logic."
+echo "  2. Run: cargo test --package $KEBAB_NAME"
+echo "  3. Run: cargo clippy --package $KEBAB_NAME -- -D warnings"
+echo "  4. Run: node scripts/abi-compat.mjs  (to update interface baseline)"
+echo "  5. Add entry to schemas/interface-registry/registry.json"
+echo ""

--- a/scripts/smoke-test-scaffold.sh
+++ b/scripts/smoke-test-scaffold.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# smoke-test-scaffold.sh — Verify a newly scaffolded contract compiles and passes basic checks.
+#
+# Usage:
+#   ./scripts/smoke-test-scaffold.sh <contract_name>
+#
+# Checks performed:
+#   1. Contract compiles (cargo check)
+#   2. Unit tests pass (cargo test)
+#   3. Clippy passes (cargo clippy)
+#   4. Formatting is correct (cargo fmt --check)
+#   5. Error enum uses #[contracterror]
+#   6. Event topics use snake_case
+#   7. require_auth() is present on state-mutating functions
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <contract_name>"
+  exit 1
+fi
+
+CONTRACT_NAME="$1"
+PACKAGE_NAME=$(echo "$CONTRACT_NAME" | tr '_' '-')
+CONTRACT_DIR="$PROJECT_ROOT/contracts/$CONTRACT_NAME"
+
+if [[ ! -d "$CONTRACT_DIR" ]]; then
+  echo "Error: Contract directory not found: $CONTRACT_DIR"
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+check() {
+  local desc="$1"
+  shift
+  echo -n "  $desc ... "
+  if "$@" >/dev/null 2>&1; then
+    echo "PASS"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$desc")
+  fi
+}
+
+echo "Smoke-testing contract: $CONTRACT_NAME"
+echo ""
+
+# ── Compilation ──────────────────────────────────────────────────────────────
+
+echo "1. Compilation"
+check "cargo check" cargo check --package "$PACKAGE_NAME" --all-targets
+echo ""
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+echo "2. Tests"
+check "cargo test" cargo test --package "$PACKAGE_NAME"
+echo ""
+
+# ── Linting ──────────────────────────────────────────────────────────────────
+
+echo "3. Linting"
+check "cargo clippy" cargo clippy --package "$PACKAGE_NAME" --all-targets -- -D warnings
+echo ""
+
+# ── Formatting ───────────────────────────────────────────────────────────────
+
+echo "4. Formatting"
+check "cargo fmt --check" cargo fmt --package "$PACKAGE_NAME" -- --check
+echo ""
+
+# ── Structural checks ───────────────────────────────────────────────────────
+
+echo "5. Structural checks"
+
+# Check lib.rs exists and has #[contract]
+if grep -q '#\[contract\]' "$CONTRACT_DIR/src/lib.rs" 2>/dev/null; then
+  echo "  #[contract] attribute present ... PASS"
+  PASS=$((PASS + 1))
+else
+  echo "  #[contract] attribute present ... FAIL"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("Missing #[contract] attribute")
+fi
+
+# Check errors.rs uses #[contracterror]
+if [[ -f "$CONTRACT_DIR/src/errors.rs" ]]; then
+  if grep -q '#\[contracterror\]' "$CONTRACT_DIR/src/errors.rs" 2>/dev/null; then
+    echo "  #[contracterror] attribute present ... PASS"
+    PASS=$((PASS + 1))
+  else
+    echo "  #[contracterror] attribute present ... FAIL"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("errors.rs missing #[contracterror]")
+  fi
+else
+  echo "  errors.rs exists ... FAIL"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("Missing errors.rs")
+fi
+
+# Check for initialize function
+if grep -q 'fn initialize' "$CONTRACT_DIR/src/lib.rs" 2>/dev/null; then
+  echo "  initialize() function present ... PASS"
+  PASS=$((PASS + 1))
+else
+  echo "  initialize() function present ... FAIL"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("Missing initialize() function")
+fi
+
+# Check for initialization guard (AlreadyInitialized check)
+if grep -q 'AlreadyInitialized' "$CONTRACT_DIR/src/lib.rs" 2>/dev/null; then
+  echo "  Initialization guard present ... PASS"
+  PASS=$((PASS + 1))
+else
+  echo "  Initialization guard present ... FAIL"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("Missing initialization guard")
+fi
+
+# Check test.rs exists with at least one test
+if [[ -f "$CONTRACT_DIR/src/test.rs" ]]; then
+  TEST_COUNT=$(grep -c '#\[test\]' "$CONTRACT_DIR/src/test.rs" 2>/dev/null || echo 0)
+  if [[ $TEST_COUNT -ge 1 ]]; then
+    echo "  test.rs with $TEST_COUNT test(s) ... PASS"
+    PASS=$((PASS + 1))
+  else
+    echo "  test.rs with 0 tests ... FAIL"
+    FAIL=$((FAIL + 1))
+    ERRORS+=("test.rs has no #[test] functions")
+  fi
+else
+  echo "  test.rs exists ... FAIL"
+  FAIL=$((FAIL + 1))
+  ERRORS+=("Missing test.rs")
+fi
+
+# Check events use snake_case topic names
+if [[ -f "$CONTRACT_DIR/src/events.rs" ]]; then
+  if grep -qP 'symbol_short!\("[a-z_]+"\)' "$CONTRACT_DIR/src/events.rs" 2>/dev/null; then
+    echo "  Event topics use snake_case ... PASS"
+    PASS=$((PASS + 1))
+  else
+    # Check if there are any events at all
+    if grep -q 'events().publish' "$CONTRACT_DIR/src/events.rs" 2>/dev/null; then
+      echo "  Event topics use snake_case ... FAIL"
+      FAIL=$((FAIL + 1))
+      ERRORS+=("Event topics must use snake_case")
+    else
+      echo "  Event topics use snake_case ... PASS (no events)"
+      PASS=$((PASS + 1))
+    fi
+  fi
+else
+  echo "  events.rs exists ... PASS (optional)"
+  PASS=$((PASS + 1))
+fi
+
+echo ""
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo "══════════════════════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed"
+echo "══════════════════════════════════════════════════════"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo ""
+  echo "Failed checks:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+  exit 1
+fi
+
+echo ""
+echo "All checks passed!"
+exit 0


### PR DESCRIPTION
## Summary

Adds automated tooling for new contributors to scaffold and verify Soroban contracts.

### Changes

- Added `scripts/scaffold-contract.sh` - creates a new contract from the project template with automatic naming convention handling (snake_case, PascalCase, kebab-case)
- Added `scripts/smoke-test-scaffold.sh` - verifies a scaffolded contract compiles, passes tests, passes clippy, passes formatting, and follows structural conventions (#[contract], #[contracterror], initialize guard, snake_case events, tests present)
- Updated `contracts/contract_template/src/lib.rs` doc comment to reference the new scripts

Closes #1151