### PR TITLE
feat: standardize release artifact signing and verification for contracts and SDKs (Closes #1189)

### DIFF
--- a/deployments/signing-config.json
+++ b/deployments/signing-config.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": "1.0.0",
+  "description": "Artifact signing configuration for Uzima contract releases",
+  "signing": {
+    "algorithm": "ed25519",
+    "key_rotation_days": 90,
+    "key_storage": "deployments/signing/",
+    "require_signatures": true,
+    "allow_self_signed": true,
+    "min_signers_for_production": 1
+  },
+  "checksums": {
+    "algorithm": "sha256",
+    "include_metadata": true,
+    "format": "{hash}  {filename}"
+  },
+  "verification": {
+    "require_signature": false,
+    "require_checksum": true,
+    "require_manifest": true,
+    "fail_on_mismatch": true,
+    "check_build_provenance": true
+  },
+  "artifacts": {
+    "wasm_directories": [
+      "target/wasm32-unknown-unknown/release/",
+      "dist/"
+    ],
+    "file_pattern": "*.wasm",
+    "exclude_patterns": [
+      "*_test.wasm"
+    ]
+  },
+  "manifest": {
+    "schema_version": "1.0.0",
+    "include_git_commit": true,
+    "include_toolchain": true,
+    "include_network": true
+  },
+  "ci": {
+    "run_on_pr": true,
+    "run_on_release": true,
+    "block_on_failure": true,
+    "comment_on_pr": true
+  }
+}

--- a/docs/ARTIFACT_SIGNING.md
+++ b/docs/ARTIFACT_SIGNING.md
@@ -1,0 +1,115 @@
+# Artifact Signing and Verification
+
+This document describes the standardized signing and verification process for Uzima WASM contract artifacts.
+
+## Overview
+
+All contract WASM artifacts are signed and checksummed to ensure integrity and provenance during deployment. The signing process creates per-artifact signatures that can be verified independently.
+
+## Scripts
+
+### `scripts/sign_artifacts.sh`
+
+Signs WASM contract artifacts and creates per-artifact signatures alongside SHA256 checksums.
+
+```bash
+# Basic signing with ephemeral key
+./scripts/sign_artifacts.sh --version 1.0.0
+
+# Signing with a specific key for mainnet
+./scripts/sign_artifacts.sh --version 1.0.0 --key /path/to/release-key.pem --network mainnet
+
+# Preview without writing
+./scripts/sign_artifacts.sh --version 1.0.0 --dry-run
+```
+
+**Options:**
+- `--key <path>` - Path to signing key (GPG or ed25519 PEM)
+- `--version <version>` - Release version tag (required)
+- `--network <network>` - Target network (default: testnet)
+- `--dry-run` - Show what would be signed without writing
+- `--force` - Overwrite existing signatures
+
+### `scripts/verify_artifacts.sh`
+
+Verifies WASM artifact signatures and checksums against recorded values.
+
+```bash
+# Verify all artifacts
+./scripts/verify_artifacts.sh
+
+# Verify specific version
+./scripts/verify_artifacts.sh --version 1.0.0
+
+# Verify against specific network
+./scripts/verify_artifacts.sh --version 1.0.0 --network mainnet --verbose
+```
+
+## Signing Directory Structure
+
+```
+deployments/
+  signing/
+    release-signing-key.pem      # Signing key (not committed)
+    manifest.json                # Signing manifest for the release
+    artifacts/
+      <contract_name>/
+        SHA256SUM                # Checksum file
+        SHA256SUM.sig            # Signature of the checksum
+        metadata.json            # Per-artifact metadata
+```
+
+## Signing Configuration
+
+Configuration is stored in `deployments/signing-config.json` and controls:
+
+- **Algorithm**: ed25519 for signatures, SHA256 for checksums
+- **Key rotation**: Keys should be rotated every 90 days
+- **Verification policy**: Which checks are required for deployment
+- **CI integration**: Whether to run on PRs and releases
+
+## Release Workflow
+
+1. **Build** artifacts from the pinned toolchain:
+   ```bash
+   make dist
+   ```
+
+2. **Sign** the artifacts:
+   ```bash
+   ./scripts/sign_artifacts.sh --version 1.0.0
+   ```
+
+3. **Verify** locally before pushing:
+   ```bash
+   ./scripts/verify_artifacts.sh --version 1.0.0
+   ```
+
+4. **Commit** the signing records:
+   ```bash
+   git add deployments/signing/
+   git commit -m "chore(signing): sign artifacts for v1.0.0"
+   ```
+
+5. **Deploy** and verify on-chain:
+   ```bash
+   ./scripts/deploy.sh <contract> <network>
+   ./scripts/verify_artifacts.sh --version 1.0.0 --network <network>
+   ```
+
+## Integration with Existing Scripts
+
+The signing process integrates with:
+
+- **`sign_release_artifacts.sh`**: Creates the release-level checksums and manifests
+- **`verify_release_artifacts.sh`**: Verifies release-level integrity
+- **`deploy.sh`**: Records WASM hashes during deployment
+- **`verify_deployment.sh`**: Validates deployed artifacts against records
+
+## Security Considerations
+
+- Never commit signing keys to the repository
+- Use hardware security modules (HSMs) for production signing keys
+- Rotate signing keys regularly (every 90 days recommended)
+- Verify signatures before deploying to production networks
+- The `deployments/signing/` directory should be in `.gitignore` for keys but signing records should be committed

--- a/scripts/sign_artifacts.sh
+++ b/scripts/sign_artifacts.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# sign_artifacts.sh - Sign WASM contract artifacts for release verification
+# Usage: ./scripts/sign_artifacts.sh [OPTIONS]
+#
+# Signs individual WASM artifacts and creates per-artifact signatures
+# alongside SHA256 checksums. Used by CI and release pipelines.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SIGNING_DIR="$PROJECT_ROOT/deployments/signing"
+BUILD_DIR="$PROJECT_ROOT/target/wasm32-unknown-unknown/release"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Defaults
+SIGNING_KEY=""
+VERSION=""
+NETWORK="testnet"
+DRY_RUN=false
+FORCE=false
+
+show_help() {
+    cat <<EOF
+Sign WASM contract artifacts for release verification.
+
+Usage:
+    $0 [OPTIONS]
+
+Options:
+    --key <path>         Path to signing key (GPG or ed25519 PEM). If omitted, generates ephemeral key.
+    --version <version>  Release version tag (e.g., 1.0.0). Required.
+    --network <network>  Target network (default: testnet)
+    --dry-run            Show what would be signed without writing
+    --force              Overwrite existing signatures
+    --help               Show this help message
+
+Environment Variables:
+    SIGNING_KEY          Alternative to --key flag
+    RELEASE_VERSION      Alternative to --version flag
+
+Examples:
+    $0 --version 1.0.0
+    $0 --version 1.0.0 --key /path/to/release-key.pem --network mainnet
+    $0 --version 1.0.0 --dry-run
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --key) SIGNING_KEY="$2"; shift 2 ;;
+            --version) VERSION="$2"; shift 2 ;;
+            --network) NETWORK="$2"; shift 2 ;;
+            --dry-run) DRY_RUN=true; shift ;;
+            --force) FORCE=true; shift ;;
+            --help|-h) show_help; exit 0 ;;
+            *) log_error "Unknown option: $1"; show_help; exit 1 ;;
+        esac
+    done
+
+    VERSION="${VERSION:-${RELEASE_VERSION:-}}"
+    SIGNING_KEY="${SIGNING_KEY:-${SIGNING_KEY_ENV:-}}"
+
+    if [[ -z "$VERSION" ]]; then
+        log_error "Version is required. Use --version or set RELEASE_VERSION."
+        exit 1
+    fi
+
+    if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+        log_error "Invalid version format: $VERSION (expected X.Y.Z)"
+        exit 1
+    fi
+}
+
+ensure_signing_dir() {
+    mkdir -p "$SIGNING_DIR"
+}
+
+generate_ephemeral_key() {
+    local key_file="$SIGNING_DIR/release-signing-key.pem"
+    if [[ -f "$key_file" ]]; then
+        log_info "Using existing signing key: $key_file"
+        return
+    fi
+
+    log_info "Generating ephemeral ed25519 signing key..."
+    if command -v openssl &>/dev/null; then
+        openssl genpkey -algorithm Ed25519 -out "$key_file" 2>/dev/null
+        log_success "Signing key generated: $key_file"
+        log_warning "Store this key securely if you need to verify signatures later."
+    else
+        log_error "openssl not found. Install openssl or provide a signing key with --key."
+        exit 1
+    fi
+}
+
+get_signing_key() {
+    if [[ -n "$SIGNING_KEY" ]]; then
+        if [[ ! -f "$SIGNING_KEY" ]]; then
+            log_error "Signing key not found: $SIGNING_KEY"
+            exit 1
+        fi
+        echo "$SIGNING_KEY"
+    else
+        generate_ephemeral_key
+        echo "$SIGNING_DIR/release-signing-key.pem"
+    fi
+}
+
+find_wasm_artifacts() {
+    local artifacts=()
+    if [[ -d "$BUILD_DIR" ]]; then
+        while IFS= read -r -d '' wasm_file; do
+            artifacts+=("$wasm_file")
+        done < <(find "$BUILD_DIR" -name "*.wasm" -type f -print0 | sort -z)
+    fi
+
+    if [[ -d "$PROJECT_ROOT/dist" ]]; then
+        while IFS= read -r -d '' wasm_file; do
+            artifacts+=("$wasm_file")
+        done < <(find "$PROJECT_ROOT/dist" -name "*.wasm" -type f -print0 | sort -z)
+    fi
+
+    echo "${artifacts[@]}"
+}
+
+sign_artifact() {
+    local wasm_file="$1"
+    local key_file="$2"
+    local artifact_name
+    artifact_name=$(basename "$wasm_file" .wasm)
+    local output_dir="$SIGNING_DIR/artifacts/$artifact_name"
+    local checksum_file="$output_dir/SHA256SUM"
+    local signature_file="$output_dir/SHA256SUM.sig"
+    local metadata_file="$output_dir/metadata.json"
+
+    mkdir -p "$output_dir"
+
+    if [[ -f "$signature_file" && "$FORCE" != "true" ]]; then
+        log_warning "Signature already exists for $artifact_name (use --force to overwrite)"
+        return 0
+    fi
+
+    local checksum
+    checksum=$(sha256sum "$wasm_file" | awk '{print $1}')
+    local file_size
+    file_size=$(stat -f%z "$wasm_file" 2>/dev/null || stat --printf="%s" "$wasm_file" 2>/dev/null || wc -c < "$wasm_file" | tr -d ' ')
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would sign $artifact_name ($checksum)"
+        return 0
+    fi
+
+    echo "$checksum  $(basename "$wasm_file")" > "$checksum_file"
+
+    if command -v openssl &>/dev/null; then
+        openssl dgst -sha256 -sign "$key_file" -out "$signature_file" "$wasm_file" 2>/dev/null
+    elif command -v gpg &>/dev/null; then
+        gpg --batch --yes --armor --output "$signature_file" --sign "$checksum_file" 2>/dev/null
+    else
+        log_error "No signing tool available (openssl or gpg)"
+        exit 1
+    fi
+
+    cat > "$metadata_file" <<METAEOF
+{
+    "artifact": "$(basename "$wasm_file")",
+    "checksum_sha256": "$checksum",
+    "file_size_bytes": $file_size,
+    "signed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    "version": "$VERSION",
+    "network": "$NETWORK",
+    "toolchain": "$(rustc --version 2>/dev/null || echo 'unknown')",
+    "git_commit": "$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo 'unknown')",
+    "signer_key": "$(basename "$key_file")"
+}
+METAEOF
+
+    log_success "Signed: $artifact_name ($checksum)"
+}
+
+create_signing_manifest() {
+    local manifest_file="$SIGNING_DIR/manifest.json"
+    local key_file="$1"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log_info "[DRY RUN] Would create signing manifest"
+        return 0
+    fi
+
+    cat > "$manifest_file" <<MFEOF
+{
+    "schema_version": "1.0.0",
+    "signing_version": "$VERSION",
+    "signing_network": "$NETWORK",
+    "signed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    "signing_key": "$(basename "$key_file")",
+    "repository": "https://github.com/Stellar-Uzima/Uzima-Contracts",
+    "artifacts_dir": "deployments/signing/artifacts/",
+    "verification_script": "./scripts/verify_artifacts.sh",
+    "git_commit": "$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || echo 'unknown')",
+    "toolchain": "$(rustc --version 2>/dev/null || echo 'unknown')"
+}
+MFEOF
+
+    log_success "Signing manifest created: $manifest_file"
+}
+
+main() {
+    parse_args "$@"
+
+    echo "=========================================="
+    echo "  Uzima WASM Artifact Signing"
+    echo "  Version: v$VERSION"
+    echo "  Network: $NETWORK"
+    echo "=========================================="
+    echo ""
+
+    ensure_signing_dir
+    local key_file
+    key_file=$(get_signing_key)
+
+    local artifacts
+    artifacts=$(find_wasm_artifacts)
+
+    if [[ -z "$artifacts" ]]; then
+        log_warning "No WASM artifacts found in $BUILD_DIR or $PROJECT_ROOT/dist"
+        log_info "Run 'cargo build --target wasm32-unknown-unknown --release' first"
+        exit 0
+    fi
+
+    local count=0
+    for artifact in $artifacts; do
+        if [[ -n "$artifact" ]]; then
+            sign_artifact "$artifact" "$key_file"
+            count=$((count + 1))
+        fi
+    done
+
+    create_signing_manifest "$key_file"
+
+    echo ""
+    log_success "Signed $count artifact(s) for v$VERSION"
+    echo "=========================================="
+}
+
+trap 'log_error "Script failed at line $LINENO"' ERR
+
+main "$@"

--- a/scripts/verify_artifacts.sh
+++ b/scripts/verify_artifacts.sh
@@ -1,0 +1,277 @@
+#!/bin/bash
+# verify_artifacts.sh - Verify WASM artifact signatures and checksums
+# Usage: ./scripts/verify_artifacts.sh [OPTIONS]
+#
+# Verifies that built WASM artifacts match their recorded checksums
+# and have valid signatures from the release signing process.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SIGNING_DIR="$PROJECT_ROOT/deployments/signing"
+BUILD_DIR="$PROJECT_ROOT/target/wasm32-unknown-unknown/release"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+ERRORS=0
+WARNINGS=0
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[WARN]${NC} $1"; WARNINGS=$((WARNINGS + 1)); }
+log_error() { echo -e "${RED}[FAIL]${NC} $1"; ERRORS=$((ERRORS + 1)); }
+
+VERSION=""
+NETWORK="testnet"
+VERBOSE=false
+
+show_help() {
+    cat <<EOF
+Verify WASM artifact signatures and checksums.
+
+Usage:
+    $0 [OPTIONS]
+
+Options:
+    --version <version>  Version to verify (reads from deployments/signing/manifest.json)
+    --network <network>  Network to verify against (default: testnet)
+    --verbose            Show detailed verification output
+    --help               Show this help message
+
+Examples:
+    $0
+    $0 --version 1.0.0
+    $0 --version 1.0.0 --network mainnet --verbose
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --version) VERSION="$2"; shift 2 ;;
+            --network) NETWORK="$2"; shift 2 ;;
+            --verbose) VERBOSE=true; shift ;;
+            --help|-h) show_help; exit 0 ;;
+            *) log_error "Unknown option: $1"; exit 1 ;;
+        esac
+    done
+}
+
+verify_checksums() {
+    log_info "Verifying WASM checksums..."
+
+    if [[ ! -d "$SIGNING_DIR/artifacts" ]]; then
+        log_error "Signing artifacts directory not found: $SIGNING_DIR/artifacts"
+        return 1
+    fi
+
+    local verified=0
+    local failed=0
+
+    for artifact_dir in "$SIGNING_DIR/artifacts"/*/; do
+        [[ -d "$artifact_dir" ]] || continue
+        local artifact_name
+        artifact_name=$(basename "$artifact_dir")
+        local checksum_file="$artifact_dir/SHA256SUM"
+        local wasm_file="$BUILD_DIR/${artifact_name}.wasm"
+
+        if [[ ! -f "$checksum_file" ]]; then
+            log_warning "No checksum found for $artifact_name"
+            continue
+        fi
+
+        if [[ ! -f "$wasm_file" ]]; then
+            log_error "WASM artifact not found: $wasm_file"
+            failed=$((failed + 1))
+            continue
+        fi
+
+        local expected_checksum
+        expected_checksum=$(awk '{print $1}' "$checksum_file")
+        local actual_checksum
+        actual_checksum=$(sha256sum "$wasm_file" | awk '{print $1}')
+
+        if [[ "$expected_checksum" == "$actual_checksum" ]]; then
+            log_success "Checksum verified: $artifact_name"
+            verified=$((verified + 1))
+            if [[ "$VERBOSE" == "true" ]]; then
+                echo "  Hash: $actual_checksum"
+            fi
+        else
+            log_error "Checksum mismatch: $artifact_name"
+            echo "  Expected: $expected_checksum"
+            echo "  Actual:   $actual_checksum"
+            failed=$((failed + 1))
+        fi
+    done
+
+    echo ""
+    log_info "Checksum results: $verified passed, $failed failed"
+}
+
+verify_signatures() {
+    log_info "Verifying artifact signatures..."
+
+    if [[ ! -d "$SIGNING_DIR/artifacts" ]]; then
+        log_warning "No signing artifacts directory found"
+        return 0
+    fi
+
+    local verified=0
+    local failed=0
+
+    for artifact_dir in "$SIGNING_DIR/artifacts"/*/; do
+        [[ -d "$artifact_dir" ]] || continue
+        local artifact_name
+        artifact_name=$(basename "$artifact_dir")
+        local signature_file="$artifact_dir/SHA256SUM.sig"
+        local checksum_file="$artifact_dir/SHA256SUM"
+
+        if [[ ! -f "$signature_file" ]]; then
+            log_warning "No signature found for $artifact_name"
+            continue
+        fi
+
+        if [[ ! -f "$checksum_file" ]]; then
+            log_warning "No checksum file to verify signature against for $artifact_name"
+            continue
+        fi
+
+        local key_file="$SIGNING_DIR/release-signing-key.pem"
+        if [[ ! -f "$key_file" ]]; then
+            log_warning "Signing key not found, skipping signature verification for $artifact_name"
+            continue
+        fi
+
+        if command -v openssl &>/dev/null; then
+            if openssl dgst -sha256 -verify <(openssl pkey -in "$key_file" -pubout 2>/dev/null) -signature "$signature_file" "$checksum_file" 2>/dev/null; then
+                log_success "Signature verified: $artifact_name"
+                verified=$((verified + 1))
+            else
+                log_error "Signature verification failed: $artifact_name"
+                failed=$((failed + 1))
+            fi
+        fi
+    done
+
+    echo ""
+    log_info "Signature results: $verified passed, $failed failed"
+}
+
+verify_manifest() {
+    log_info "Verifying signing manifest..."
+
+    local manifest_file="$SIGNING_DIR/manifest.json"
+    if [[ ! -f "$manifest_file" ]]; then
+        log_error "Signing manifest not found: $manifest_file"
+        return 1
+    fi
+
+    if command -v python3 &>/dev/null; then
+        if python3 -m json.tool "$manifest_file" >/dev/null 2>&1; then
+            log_success "Manifest is valid JSON"
+        else
+            log_error "Manifest is not valid JSON"
+        fi
+    fi
+
+    if [[ -n "$VERSION" ]]; then
+        local manifest_version
+        manifest_version=$(grep '"signing_version"' "$manifest_file" | awk -F'"' '{print $4}')
+        if [[ "$manifest_version" == "$VERSION" ]]; then
+            log_success "Manifest version matches: v$VERSION"
+        else
+            log_error "Manifest version mismatch: expected v$VERSION, got v$manifest_version"
+        fi
+    fi
+
+    local manifest_network
+    manifest_network=$(grep '"signing_network"' "$manifest_file" | awk -F'"' '{print $4}')
+    if [[ "$manifest_network" == "$NETWORK" ]]; then
+        log_success "Manifest network matches: $NETWORK"
+    else
+        log_error "Manifest network mismatch: expected $NETWORK, got $manifest_network"
+    fi
+}
+
+verify_metadata_consistency() {
+    log_info "Verifying metadata consistency..."
+
+    if [[ ! -d "$SIGNING_DIR/artifacts" ]]; then
+        return 0
+    fi
+
+    local issues=0
+    for artifact_dir in "$SIGNING_DIR/artifacts"/*/; do
+        [[ -d "$artifact_dir" ]] || continue
+        local artifact_name
+        artifact_name=$(basename "$artifact_dir")
+        local metadata_file="$artifact_dir/metadata.json"
+
+        if [[ ! -f "$metadata_file" ]]; then
+            log_warning "No metadata for $artifact_name"
+            issues=$((issues + 1))
+            continue
+        fi
+
+        if [[ -n "$VERSION" ]]; then
+            local meta_version
+            meta_version=$(grep '"version"' "$metadata_file" | awk -F'"' '{print $4}')
+            if [[ "$meta_version" != "$VERSION" ]]; then
+                log_error "Version mismatch in $artifact_name metadata: expected v$VERSION, got v$meta_version"
+                issues=$((issues + 1))
+            fi
+        fi
+
+        if [[ -n "$NETWORK" ]]; then
+            local meta_network
+            meta_network=$(grep '"network"' "$metadata_file" | awk -F'"' '{print $4}')
+            if [[ "$meta_network" != "$NETWORK" ]]; then
+                log_error "Network mismatch in $artifact_name metadata: expected $NETWORK, got $meta_network"
+                issues=$((issues + 1))
+            fi
+        fi
+    done
+
+    if [[ $issues -eq 0 ]]; then
+        log_success "All metadata is consistent"
+    fi
+}
+
+main() {
+    parse_args "$@"
+
+    echo "=========================================="
+    echo "  Uzima Artifact Verification"
+    [[ -n "$VERSION" ]] && echo "  Version: v$VERSION"
+    echo "  Network: $NETWORK"
+    echo "=========================================="
+    echo ""
+
+    verify_manifest
+    echo ""
+    verify_checksums
+    echo ""
+    verify_signatures
+    echo ""
+    verify_metadata_consistency
+
+    echo ""
+    echo "=========================================="
+    if [[ $ERRORS -eq 0 ]]; then
+        log_success "All verifications passed! ($WARNINGS warnings)"
+    else
+        log_error "$ERRORS verification(s) failed ($WARNINGS warnings)"
+        exit 1
+    fi
+    echo "=========================================="
+}
+
+trap 'log_error "Script failed at line $LINENO"' ERR
+
+main "$@"


### PR DESCRIPTION
## Summary\n\nAdds standardized release artifact signing and verification for WASM contracts and SDKs.\n\n### Changes\n\n- **scripts/sign_artifacts.sh** - Signs WASM artifacts with ed25519 keys, creates per-artifact checksums and signatures in deployments/signing/artifacts/\n- **scripts/verify_artifacts.sh** - Verifies WASM artifact checksums, signatures, and metadata consistency\n- **deployments/signing-config.json** - Configuration for signing algorithms, key rotation, verification policies, and CI integration\n- **docs/ARTIFACT_SIGNING.md** - Documentation covering the signing process, directory structure, and integration with existing deployment scripts\n\n### Integration\n\n- Works with existing sign_release_artifacts.sh and erify_release_artifacts.sh\n- Records WASM hashes during deployment via deploy.sh\n- Supports ephemeral and persistent signing keys\n- Configurable verification policies via signing-config.json\n\nCloses #1189