### PR TITLE
feat(medical_records,rbac): add compartmentalized data access with role-based tiers (Closes #1165)

### DIFF
--- a/contracts/medical_records/src/lib.rs
+++ b/contracts/medical_records/src/lib.rs
@@ -92,6 +92,60 @@ use soroban_sdk::{
 };
 use upgradeability::storage::{ADMIN as UPGRADE_ADMIN, VERSION};
 
+// ==================== Compartmentalized Data Access Types ====================
+
+/// Data tiers for role-based access control.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[contracttype]
+#[repr(u32)]
+pub enum DataAccessTier {
+    /// Basic demographic data - all roles
+    Basic = 0,
+    /// Clinical data - doctors, specialists, admins
+    Clinical = 1,
+    /// Sensitive data - patient consent required
+    Sensitive = 2,
+    /// Restricted data - admin and specialist only
+    Restricted = 3,
+    /// Research data - anonymized for research use
+    Research = 4,
+}
+
+/// A data compartment with associated metadata.
+#[derive(Clone)]
+#[contracttype]
+pub struct DataCompartment {
+    pub compartment_id: Symbol,
+    pub tier: DataAccessTier,
+    pub description: String,
+    pub required_role: Role,
+    pub requires_consent: bool,
+}
+
+/// Record of access grant to a compartment.
+#[derive(Clone)]
+#[contracttype]
+pub struct CompartmentAccess {
+    pub patient_id: Address,
+    pub compartment_id: Symbol,
+    pub granted_by: Address,
+    pub granted_at: u64,
+    pub expires_at: Option<u64>,
+}
+
+/// Role types in the system.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[contracttype]
+pub enum Role {
+    Admin,
+    Doctor,
+    Nurse,
+    Specialist,
+    Patient,
+    Researcher,
+    Auditor,
+}
+
 // ==================== Cross-Chain Types ====================
 
 #[derive(Clone, PartialEq, Eq)]
@@ -654,6 +708,11 @@ pub enum DataKey {
 
     // Redaction
     RedactionPolicy(u64),
+
+    // Compartmentalized Data Access
+    Compartment(Symbol),
+    CompartmentAccess(Address, Symbol),
+    UserRole(Address),
 }
 
 // ==================== Errors ====================
@@ -7276,5 +7335,155 @@ impl MedicalRecordsContract {
         }
 
         Ok(redacted)
+    }
+
+    // ─── Compartmentalized Data Access (Issue #1165) ─────────────────────────
+
+    /// Create a new data compartment for role-based tiered access.
+    pub fn create_data_compartment(
+        env: Env,
+        caller: Address,
+        compartment_id: Symbol,
+        tier: DataAccessTier,
+        description: String,
+        required_role: Role,
+        requires_consent: bool,
+    ) -> Result<(), Error> {
+        require_admin!(env, caller);
+
+        let compartment = DataCompartment {
+            compartment_id: compartment_id.clone(),
+            tier,
+            description,
+            required_role,
+            requires_consent,
+        };
+
+        env.storage().persistent().set(
+            &DataKey::Compartment(compartment_id.clone()),
+            &compartment,
+        );
+
+        env.events().publish(
+            (symbol_short!("COMP"), symbol_short!("CREATE")),
+            (compartment_id, tier as u32),
+        );
+
+        Ok(())
+    }
+
+    /// Get a data compartment by ID.
+    pub fn get_data_compartment(
+        env: Env,
+        compartment_id: Symbol,
+    ) -> Result<DataCompartment, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Compartment(compartment_id))
+            .ok_or(Error::NotFound)
+    }
+
+    /// Grant access to a patient's data compartment.
+    pub fn grant_compartment_access(
+        env: Env,
+        caller: Address,
+        patient_id: Address,
+        compartment_id: Symbol,
+        expires_at: Option<u64>,
+    ) -> Result<(), Error> {
+        require_admin!(env, caller);
+
+        let access = CompartmentAccess {
+            patient_id: patient_id.clone(),
+            compartment_id: compartment_id.clone(),
+            granted_by: caller.clone(),
+            granted_at: env.ledger().timestamp(),
+            expires_at,
+        };
+
+        env.storage().persistent().set(
+            &DataKey::CompartmentAccess(patient_id.clone(), compartment_id.clone()),
+            &access,
+        );
+
+        env.events().publish(
+            (symbol_short!("COMP"), symbol_short!("GRANT")),
+            (patient_id, compartment_id),
+        );
+
+        Ok(())
+    }
+
+    /// Check if a user has access to a patient's data compartment.
+    pub fn has_compartment_access(
+        env: Env,
+        user: Address,
+        patient_id: Address,
+        compartment_id: Symbol,
+    ) -> bool {
+        let access: CompartmentAccess = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::CompartmentAccess(
+                patient_id,
+                compartment_id,
+            )) {
+            Some(a) => a,
+            None => return false,
+        };
+
+        // Check expiry
+        if let Some(exp) = access.expires_at {
+            if env.ledger().timestamp() > exp {
+                return false;
+            }
+        }
+
+        // Check role
+        let role: Role = env
+            .storage()
+            .persistent()
+            .get(&DataKey::UserRole(user))
+            .unwrap_or(Role::Patient);
+
+        let compartment: DataCompartment = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Compartment(compartment_id))
+            .unwrap();
+
+        matches!(
+            (compartment.required_role, role),
+            (Role::Admin, Role::Admin)
+                | (Role::Doctor, Role::Doctor)
+                | (Role::Nurse, Role::Nurse)
+                | (Role::Specialist, Role::Specialist)
+                | (Role::Researcher, Role::Researcher)
+                | (Role::Auditor, Role::Auditor)
+                | (Role::Patient, Role::Patient)
+                | (Role::Admin, _)
+        )
+    }
+
+    /// Revoke access to a patient's data compartment.
+    pub fn revoke_compartment_access(
+        env: Env,
+        caller: Address,
+        patient_id: Address,
+        compartment_id: Symbol,
+    ) -> Result<(), Error> {
+        require_admin!(env, caller);
+
+        env.storage().persistent().remove(&DataKey::CompartmentAccess(
+            patient_id.clone(),
+            compartment_id.clone(),
+        ));
+
+        env.events().publish(
+            (symbol_short!("COMP"), symbol_short!("REVOKE")),
+            (patient_id, compartment_id),
+        );
+
+        Ok(())
     }
 }

--- a/contracts/medical_records/src/test.rs
+++ b/contracts/medical_records/src/test.rs
@@ -1865,3 +1865,144 @@ fn proptest_record_attributes_persistence() {
             "Timestamp must be set");
     });
 }
+
+// ==================== Compartmentalized Data Access Tests ====================
+
+#[test]
+fn test_create_data_compartment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = create_contract(&env);
+
+    let compartment_id = Symbol::new(&env, "CARDIOLOGY");
+    let description = String::from_str(&env, "Cardiology records compartment");
+
+    let result = client.create_data_compartment(
+        &admin,
+        &compartment_id,
+        &DataAccessTier::Clinical,
+        &description,
+        &Role::Doctor,
+        &false,
+    );
+
+    assert!(result.is_ok());
+
+    let compartment = client.get_data_compartment(&compartment_id);
+    assert!(compartment.is_ok());
+    let c = compartment.unwrap();
+    assert_eq!(c.tier, DataAccessTier::Clinical);
+    assert_eq!(c.required_role, Role::Doctor);
+}
+
+#[test]
+fn test_create_data_compartment_not_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = create_contract(&env);
+
+    let user = Address::generate(&env);
+    let compartment_id = Symbol::new(&env, "CARDIOLOGY");
+    let description = String::from_str(&env, "Cardiology records");
+
+    let result = client.create_data_compartment(
+        &user,
+        &compartment_id,
+        &DataAccessTier::Clinical,
+        &description,
+        &Role::Doctor,
+        &false,
+    );
+
+    assert_eq!(result, Err(Error::NotAuthorized));
+}
+
+#[test]
+fn test_grant_and_revoke_compartment_access() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = create_contract(&env);
+
+    let patient = Address::generate(&env);
+    let compartment_id = Symbol::new(&env, "GENERAL");
+    let description = String::from_str(&env, "General records");
+
+    // Create compartment first
+    client.create_data_compartment(
+        &admin,
+        &compartment_id,
+        &DataAccessTier::Basic,
+        &description,
+        &Role::Patient,
+        &false,
+    );
+
+    // Grant access
+    let result = client.grant_compartment_access(
+        &admin,
+        &patient,
+        &compartment_id,
+        &None,
+    );
+    assert!(result.is_ok());
+
+    // Check access
+    let user = Address::generate(&env);
+    client.manage_user(&admin, &user, &Role::Doctor);
+
+    assert!(client.has_compartment_access(
+        &user,
+        &patient,
+        &compartment_id,
+    ));
+
+    // Revoke access
+    let result = client.revoke_compartment_access(&admin, &patient, &compartment_id);
+    assert!(result.is_ok());
+
+    assert!(!client.has_compartment_access(
+        &user,
+        &patient,
+        &compartment_id,
+    ));
+}
+
+#[test]
+fn test_compartment_access_expiry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = create_contract(&env);
+
+    let patient = Address::generate(&env);
+    let compartment_id = Symbol::new(&env, "TEMP");
+    let description = String::from_str(&env, "Temporary access");
+
+    // Create compartment
+    client.create_data_compartment(
+        &admin,
+        &compartment_id,
+        &DataAccessTier::Sensitive,
+        &description,
+        &Role::Doctor,
+        &true,
+    );
+
+    // Grant with expiry in the past
+    let past_expiry = env.ledger().timestamp().saturating_sub(1000);
+    client.grant_compartment_access(
+        &admin,
+        &patient,
+        &compartment_id,
+        &Some(past_expiry),
+    );
+
+    let user = Address::generate(&env);
+    client.manage_user(&admin, &user, &Role::Doctor);
+
+    // Access should be denied (expired)
+    assert!(!client.has_compartment_access(
+        &user,
+        &patient,
+        &compartment_id,
+    ));
+}


### PR DESCRIPTION
## Summary

Implements compartmentalized data access with role-based tiers for medical records.

### Changes
- **medical_records:** Added DataAccessTier, DataCompartment, CompartmentAccess, Role types
- **medical_records:** Added create_data_compartment(), get_data_compartment(), grant_compartment_access(), has_compartment_access(), evoke_compartment_access() functions
- New DataKey variants for compartment storage
- Unit tests for all new functions

Closes #1165