### PR TITLE
feat: add encrypted index and search metadata support for medical record search (Closes #1169)

### DIFF
--- a/contracts/medical_record_search/src/lib.rs
+++ b/contracts/medical_record_search/src/lib.rs
@@ -129,6 +129,26 @@ pub struct SearchAuditEntry {
     pub granted: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct EncryptedIndexEntry {
+    pub record_id: u64,
+    pub encrypted_hash: BytesN<32>,
+    pub patient: Address,
+    pub metadata_keys: Vec<BytesN<32>>,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct SearchMetadata {
+    pub patient_id: Address,
+    pub record_type: Symbol,
+    pub tags: Vec<BytesN<32>>,
+    pub created_at: u64,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
@@ -143,6 +163,8 @@ pub enum DataKey {
     CachePolicy,
     Ranking,
     Audit(u64),
+    EncryptedIndex(u64),
+    SearchMetadataKey(u64),
 }
 
 #[contracterror]
@@ -157,6 +179,10 @@ pub enum Error {
     RecordNotIndexed = 6,
     QueryTooLarge = 7,
     CacheMiss = 8,
+    IndexNotFound = 9,
+    IndexAlreadyExists = 10,
+    SearchFailed = 11,
+    InvalidEncryptedHash = 12,
 }
 
 impl core::fmt::Display for Error {
@@ -170,6 +196,10 @@ impl core::fmt::Display for Error {
             Error::RecordNotIndexed => write!(f, "record not indexed"),
             Error::QueryTooLarge => write!(f, "query too large"),
             Error::CacheMiss => write!(f, "cache miss"),
+            Error::IndexNotFound => write!(f, "encrypted index not found"),
+            Error::IndexAlreadyExists => write!(f, "encrypted index already exists"),
+            Error::SearchFailed => write!(f, "encrypted search failed"),
+            Error::InvalidEncryptedHash => write!(f, "invalid encrypted hash"),
         }
     }
 }
@@ -453,6 +483,155 @@ impl MedicalRecordSearchContract {
             .persistent()
             .get(&DataKey::Index(record_id))
             .ok_or(Error::RecordNotIndexed)
+    }
+
+    pub fn create_encrypted_index(
+        env: Env,
+        caller: Address,
+        record_id: u64,
+        encrypted_hash: BytesN<32>,
+        patient: Address,
+        metadata_keys: Vec<BytesN<32>>,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_role(&env, &caller, ROLE_INDEXER)?;
+        Self::require_not_paused(&env)?;
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::EncryptedIndex(record_id))
+        {
+            return Err(Error::IndexAlreadyExists);
+        }
+
+        let now = env.ledger().timestamp();
+        let entry = EncryptedIndexEntry {
+            record_id,
+            encrypted_hash,
+            patient,
+            metadata_keys,
+            created_at: now,
+            updated_at: now,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EncryptedIndex(record_id), &entry);
+
+        env.events().publish(
+            (symbol_short!("ENC_IDX_CR"),),
+            (record_id, caller),
+        );
+        Ok(())
+    }
+
+    pub fn search_by_encrypted_index(
+        env: Env,
+        caller: Address,
+        patient: Address,
+        metadata_key: BytesN<32>,
+    ) -> Result<Vec<EncryptedIndexEntry>, Error> {
+        caller.require_auth();
+        Self::require_role(&env, &caller, ROLE_SEARCHER)?;
+
+        let indexed_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::IndexedIds)
+            .unwrap_or(Vec::new(&env));
+
+        let mut results = Vec::new(&env);
+        for id in indexed_ids.iter() {
+            if let Some(entry) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, EncryptedIndexEntry>(&DataKey::EncryptedIndex(id))
+            {
+                if entry.patient == patient
+                    && entry
+                        .metadata_keys
+                        .iter()
+                        .any(|k| k == metadata_key)
+                {
+                    results.push_back(entry);
+                }
+            }
+        }
+
+        if results.is_empty() {
+            return Err(Error::SearchFailed);
+        }
+
+        Ok(results)
+    }
+
+    pub fn update_encrypted_index(
+        env: Env,
+        caller: Address,
+        record_id: u64,
+        encrypted_hash: BytesN<32>,
+        metadata_keys: Vec<BytesN<32>>,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_role(&env, &caller, ROLE_INDEXER)?;
+
+        let mut entry: EncryptedIndexEntry = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EncryptedIndex(record_id))
+            .ok_or(Error::IndexNotFound)?;
+
+        entry.encrypted_hash = encrypted_hash;
+        entry.metadata_keys = metadata_keys;
+        entry.updated_at = env.ledger().timestamp();
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EncryptedIndex(record_id), &entry);
+
+        env.events().publish(
+            (symbol_short!("ENC_IDX_UP"),),
+            (record_id, caller),
+        );
+        Ok(())
+    }
+
+    pub fn remove_encrypted_index(
+        env: Env,
+        caller: Address,
+        record_id: u64,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_role(&env, &caller, ROLE_INDEXER)?;
+
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::EncryptedIndex(record_id))
+        {
+            return Err(Error::IndexNotFound);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::EncryptedIndex(record_id));
+
+        env.events().publish(
+            (symbol_short!("ENC_IDX_RM"),),
+            (record_id, caller),
+        );
+        Ok(())
+    }
+
+    pub fn get_encrypted_index_entry(
+        env: Env,
+        record_id: u64,
+    ) -> Result<EncryptedIndexEntry, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EncryptedIndex(record_id))
+            .ok_or(Error::IndexNotFound)
     }
 }
 

--- a/contracts/medical_record_search/src/test.rs
+++ b/contracts/medical_record_search/src/test.rs
@@ -285,3 +285,118 @@ fn complex_filters_apply_network_and_attribute_constraints() {
     assert_eq!(results.len(), 1);
     assert_eq!(results.get(0).unwrap().record_id, 51);
 }
+
+#[test]
+fn test_create_encrypted_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let indexer = Address::generate(&env);
+    let patient = Address::generate(&env);
+    client.assign_role(&admin, &indexer, &ROLE_INDEXER);
+
+    let mut keys = Vec::new(&env);
+    keys.push_back(token(&env, 1));
+    keys.push_back(token(&env, 2));
+
+    client.create_encrypted_index(
+        &indexer,
+        &100,
+        &token(&env, 42),
+        &patient,
+        &keys,
+    );
+
+    let entry = client.get_encrypted_index_entry(&100);
+    assert_eq!(entry.record_id, 100);
+    assert_eq!(entry.patient, patient);
+    assert_eq!(entry.metadata_keys.len(), 2);
+}
+
+#[test]
+fn test_create_encrypted_index_duplicate_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let indexer = Address::generate(&env);
+    let patient = Address::generate(&env);
+    client.assign_role(&admin, &indexer, &ROLE_INDEXER);
+
+    let keys = Vec::new(&env);
+    client.create_encrypted_index(&indexer, &200, &token(&env, 1), &patient, &keys);
+
+    let result = client.try_create_encrypted_index(&indexer, &200, &token(&env, 2), &patient, &keys);
+    assert_eq!(result, Err(Ok(Error::IndexAlreadyExists)));
+}
+
+#[test]
+fn test_update_encrypted_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let indexer = Address::generate(&env);
+    let patient = Address::generate(&env);
+    client.assign_role(&admin, &indexer, &ROLE_INDEXER);
+
+    let keys = Vec::new(&env);
+    client.create_encrypted_index(&indexer, &300, &token(&env, 1), &patient, &keys);
+
+    let mut new_keys = Vec::new(&env);
+    new_keys.push_back(token(&env, 5));
+    client.update_encrypted_index(&indexer, &300, &token(&env, 99), &new_keys);
+
+    let entry = client.get_encrypted_index_entry(&300);
+    assert_eq!(entry.encrypted_hash, token(&env, 99));
+    assert_eq!(entry.metadata_keys.len(), 1);
+}
+
+#[test]
+fn test_remove_encrypted_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let indexer = Address::generate(&env);
+    let patient = Address::generate(&env);
+    client.assign_role(&admin, &indexer, &ROLE_INDEXER);
+
+    let keys = Vec::new(&env);
+    client.create_encrypted_index(&indexer, &400, &token(&env, 1), &patient, &keys);
+    client.remove_encrypted_index(&indexer, &400);
+
+    let result = client.try_get_encrypted_index_entry(&400);
+    assert_eq!(result, Err(Ok(Error::IndexNotFound)));
+}
+
+#[test]
+fn test_search_by_encrypted_index() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let indexer = Address::generate(&env);
+    let searcher = Address::generate(&env);
+    let patient = Address::generate(&env);
+    client.assign_role(&admin, &indexer, &ROLE_INDEXER);
+    client.assign_role(&admin, &searcher, &ROLE_SEARCHER);
+
+    let mut keys = Vec::new(&env);
+    keys.push_back(token(&env, 10));
+    keys.push_back(token(&env, 20));
+    client.create_encrypted_index(&indexer, &500, &token(&env, 1), &patient, &keys);
+
+    let results = client.search_by_encrypted_index(&searcher, &patient, &token(&env, 10));
+    assert_eq!(results.len(), 1);
+    assert_eq!(results.get(0).unwrap().record_id, 500);
+}
+
+#[test]
+fn test_search_encrypted_index_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let searcher = Address::generate(&env);
+    let patient = Address::generate(&env);
+    client.assign_role(&admin, &searcher, &ROLE_SEARCHER);
+
+    let result = client.try_search_by_encrypted_index(&searcher, &patient, &token(&env, 99));
+    assert_eq!(result, Err(Ok(Error::SearchFailed)));
+}


### PR DESCRIPTION
## Summary

Adds encrypted index and search metadata support to the medical_record_search contract, enabling privacy-preserving search over encrypted medical record data.

### Changes
- Added EncryptedIndexEntry type with encrypted_hash, patient, metadata_keys, timestamps
- Added SearchMetadata type with patient_id, record_type, tags
- Added create_encrypted_index() for indexing records with encrypted references
- Added search_by_encrypted_index() for patient-scoped encrypted search by metadata key
- Added update_encrypted_index() for updating encrypted hash and metadata
- Added emove_encrypted_index() for secure deletion
- Added get_encrypted_index_entry() for direct lookup
- Added error variants: IndexNotFound, IndexAlreadyExists, SearchFailed, InvalidEncryptedHash
- Added events: ENC_IDX_CR, ENC_IDX_UP, ENC_IDX_RM
- Added 6 comprehensive unit tests

Closes #1169