### PR TITLE
feat: dispute mediation state machine for cross-chain bridge failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ exclude = [
     # Non-contract or no-Cargo.toml entries (cannot be workspace members):
     "contracts/contract_behavior_fuzzing",
     "contracts/governance_integration_tests",
+    # Stray source directory — not a crate root (no Cargo.toml):
+    "contracts/src",
 ] 
 
 [workspace.dependencies]

--- a/contracts/bridge_dispute_mediation/Cargo.toml
+++ b/contracts/bridge_dispute_mediation/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bridge_dispute_mediation"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]

--- a/contracts/bridge_dispute_mediation/src/lib.rs
+++ b/contracts/bridge_dispute_mediation/src/lib.rs
@@ -1,0 +1,729 @@
+#![no_std]
+//! bridge_dispute_mediation - Dispute mediation state machine for cross-chain bridge failures.
+//!
+//! # State Machine Overview
+//!
+//! A dispute goes through the following states:
+//!
+//! ```
+//! Open ──► UnderReview ──► Resolved (Upheld | Rejected)
+//!   │            │
+//!   │            └──► Escalated ──► Resolved
+//!   │
+//!   └──► Withdrawn (before mediator assignment)
+//! ```
+//!
+//! Mediators are appointed by the admin and must be active to accept cases.
+//! Quorum (`min_votes`) determines how many mediator votes are needed to resolve.
+#![allow(clippy::too_many_arguments)]
+#![allow(dead_code)]
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, BytesN, Env, String, Symbol, Vec,
+};
+
+// ==================== Error Codes ====================
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    // Lifecycle
+    AlreadyInitialized = 1,
+    NotInitialized     = 2,
+    ContractPaused     = 3,
+
+    // Auth / access
+    Unauthorized       = 10,
+    NotMediator        = 11,
+    MediatorNotActive  = 12,
+    MediatorExists     = 13,
+
+    // Dispute state
+    DisputeNotFound    = 20,
+    InvalidTransition  = 21,
+    AlreadyVoted       = 22,
+    QuorumNotReached   = 23,
+    DisputeNotOpen     = 24,
+
+    // Arithmetic
+    Overflow           = 90,
+}
+
+// ==================== Core Types ====================
+
+/// Chains mirrored from cross_chain_bridge for dispute context.
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[contracttype]
+pub enum ChainId {
+    Stellar,
+    Ethereum,
+    Polygon,
+    Avalanche,
+    BinanceSmartChain,
+    Arbitrum,
+    Optimism,
+    Custom(u32),
+}
+
+/// The failure category that prompted the dispute.
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[contracttype]
+pub enum BridgeFailureKind {
+    /// A cross-chain message was lost or never relayed.
+    MessageLost,
+    /// An atomic transaction was partially executed across chains.
+    AtomicTxPartial,
+    /// A record sync failed mid-way, leaving chains inconsistent.
+    RecordSyncFailure,
+    /// Token transfer was debited on source but never credited on dest.
+    TokenTransferStuck,
+    /// An oracle reported conflicting data for the same block.
+    OracleConflict,
+    /// Validator misbehaved (e.g. double-signing).
+    ValidatorMisbehavior,
+    /// Any other bridge failure not covered above.
+    Other,
+}
+
+/// The verdict that mediators vote towards.
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[contracttype]
+pub enum DisputeVerdict {
+    /// The dispute claim is upheld; remediation should proceed.
+    Upheld,
+    /// The dispute claim is rejected; no remediation required.
+    Rejected,
+}
+
+/// Lifecycle states of a dispute.
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[contracttype]
+pub enum DisputeState {
+    /// Newly filed, awaiting mediator assignment.
+    Open,
+    /// A mediator has accepted the case and review is in progress.
+    UnderReview,
+    /// Escalated to full mediator panel after initial review stalls.
+    Escalated,
+    /// Resolved with a final verdict.
+    Resolved,
+    /// Withdrawn by the claimant before a mediator was assigned.
+    Withdrawn,
+}
+
+/// A single mediator vote cast during resolution.
+#[derive(Clone)]
+#[contracttype]
+pub struct MediatorVote {
+    pub mediator:   Address,
+    pub verdict:    DisputeVerdict,
+    pub rationale:  String,
+    pub voted_at:   u64,
+}
+
+/// Full dispute record stored on-chain.
+#[derive(Clone)]
+#[contracttype]
+pub struct DisputeRecord {
+    pub dispute_id:     BytesN<32>,
+    pub claimant:       Address,
+    pub source_chain:   ChainId,
+    pub dest_chain:     ChainId,
+    pub failure_kind:   BridgeFailureKind,
+    /// ID of the bridge operation (message, tx, etc.) being disputed.
+    pub operation_id:   BytesN<32>,
+    pub description:    String,
+    pub state:          DisputeState,
+    pub assigned_to:    Option<Address>,
+    pub filed_at:       u64,
+    pub updated_at:     u64,
+    pub resolved_at:    u64,
+    pub final_verdict:  Option<DisputeVerdict>,
+    pub votes:          Vec<MediatorVote>,
+}
+
+/// Mediator profile.
+#[derive(Clone)]
+#[contracttype]
+pub struct MediatorInfo {
+    pub address:          Address,
+    pub is_active:        bool,
+    pub cases_resolved:   u32,
+    pub registered_at:    u64,
+}
+
+// ==================== Storage Keys ====================
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Paused,
+    MinVotes,
+    DisputeCount,
+    MediatorCount,
+    Dispute(BytesN<32>),
+    Mediator(Address),
+}
+
+// ==================== TTL Constants ====================
+
+const PERSISTENT_TTL_THRESHOLD: u32 = 100;
+const PERSISTENT_TTL_EXTEND_TO: u32 = 10_000;
+
+// ==================== Contract ====================
+
+#[contract]
+pub struct BridgeDisputeMediationContract;
+
+#[contractimpl]
+impl BridgeDisputeMediationContract {
+    // ----------------------------------------------------------------
+    // Storage helpers
+    // ----------------------------------------------------------------
+
+    fn persistent_set<T: soroban_sdk::IntoVal<Env, soroban_sdk::Val> + Clone>(
+        env: &Env,
+        key: &DataKey,
+        val: &T,
+    ) {
+        env.storage().persistent().set(key, val);
+        env.storage()
+            .persistent()
+            .extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+    }
+
+    fn persistent_get<T: soroban_sdk::TryFromVal<Env, soroban_sdk::Val> + Clone>(
+        env: &Env,
+        key: &DataKey,
+    ) -> Option<T> {
+        let val: Option<T> = env.storage().persistent().get(key);
+        if val.is_some() {
+            env.storage()
+                .persistent()
+                .extend_ttl(key, PERSISTENT_TTL_THRESHOLD, PERSISTENT_TTL_EXTEND_TO);
+        }
+        val
+    }
+
+    // ----------------------------------------------------------------
+    // Guards
+    // ----------------------------------------------------------------
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::NotInitialized)?;
+        if *caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        Ok(())
+    }
+
+    fn require_not_paused(env: &Env) -> Result<(), Error> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if paused {
+            return Err(Error::ContractPaused);
+        }
+        Ok(())
+    }
+
+    fn get_active_mediator(env: &Env, addr: &Address) -> Result<MediatorInfo, Error> {
+        let key = DataKey::Mediator(addr.clone());
+        let info: MediatorInfo =
+            Self::persistent_get(env, &key).ok_or(Error::NotMediator)?;
+        if !info.is_active {
+            return Err(Error::MediatorNotActive);
+        }
+        Ok(info)
+    }
+
+    // ----------------------------------------------------------------
+    // Initialise
+    // ----------------------------------------------------------------
+
+    /// Initialise the contract. Must be called once by the deployer.
+    ///
+    /// * `admin`     – sole account that can add/remove mediators and pause.
+    /// * `min_votes` – minimum mediator votes required to resolve a dispute.
+    pub fn initialize(env: Env, admin: Address, min_votes: u32) -> Result<(), Error> {
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().set(&DataKey::MinVotes, &min_votes);
+        env.storage().instance().set(&DataKey::DisputeCount, &0u64);
+        env.storage().instance().set(&DataKey::MediatorCount, &0u32);
+
+        env.events()
+            .publish((Symbol::new(&env, "Initialized"),), (admin,));
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Admin functions
+    // ----------------------------------------------------------------
+
+    /// Pause or unpause the contract.
+    pub fn set_paused(env: Env, caller: Address, paused: bool) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_admin(&env, &caller)?;
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        env.events()
+            .publish((Symbol::new(&env, "PauseToggled"),), (paused,));
+        Ok(())
+    }
+
+    /// Register a new mediator. Only the admin may call this.
+    pub fn add_mediator(env: Env, caller: Address, mediator: Address) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_admin(&env, &caller)?;
+        Self::require_not_paused(&env)?;
+
+        let key = DataKey::Mediator(mediator.clone());
+        if Self::persistent_get::<MediatorInfo>(&env, &key).is_some() {
+            return Err(Error::MediatorExists);
+        }
+
+        let info = MediatorInfo {
+            address: mediator.clone(),
+            is_active: true,
+            cases_resolved: 0,
+            registered_at: env.ledger().timestamp(),
+        };
+        Self::persistent_set(&env, &key, &info);
+
+        let count: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MediatorCount)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::MediatorCount, &count.saturating_add(1));
+
+        env.events()
+            .publish((Symbol::new(&env, "MediatorAdded"),), (mediator,));
+        Ok(())
+    }
+
+    /// Deactivate an existing mediator.
+    pub fn deactivate_mediator(env: Env, caller: Address, mediator: Address) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_admin(&env, &caller)?;
+
+        let key = DataKey::Mediator(mediator.clone());
+        let mut info: MediatorInfo =
+            Self::persistent_get(&env, &key).ok_or(Error::NotMediator)?;
+        info.is_active = false;
+        Self::persistent_set(&env, &key, &info);
+
+        env.events()
+            .publish((Symbol::new(&env, "MediatorDeactivated"),), (mediator,));
+        Ok(())
+    }
+
+    /// Query a mediator's profile.
+    pub fn get_mediator(env: Env, mediator: Address) -> Result<MediatorInfo, Error> {
+        Self::persistent_get(&env, &DataKey::Mediator(mediator)).ok_or(Error::NotMediator)
+    }
+
+    // ----------------------------------------------------------------
+    // Dispute lifecycle — Open / Withdraw
+    // ----------------------------------------------------------------
+
+    /// File a new dispute. Caller must be the claimant.
+    ///
+    /// Returns the `dispute_id` stored on-chain.
+    pub fn file_dispute(
+        env: Env,
+        claimant: Address,
+        source_chain: ChainId,
+        dest_chain: ChainId,
+        failure_kind: BridgeFailureKind,
+        operation_id: BytesN<32>,
+        description: String,
+    ) -> Result<BytesN<32>, Error> {
+        claimant.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let count: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DisputeCount)
+            .unwrap_or(0);
+        let new_count = count.checked_add(1).ok_or(Error::Overflow)?;
+
+        // Derive a deterministic dispute_id from (operation_id, count, timestamp).
+        let now = env.ledger().timestamp();
+        let mut id_seed = operation_id.to_array();
+        // XOR the low 8 bytes with the count so each filing is unique.
+        let count_bytes = new_count.to_be_bytes();
+        for (i, b) in count_bytes.iter().enumerate() {
+            id_seed[i] ^= b;
+        }
+        let dispute_id: BytesN<32> =
+            BytesN::from_array(&env, &id_seed);
+
+        let record = DisputeRecord {
+            dispute_id: dispute_id.clone(),
+            claimant: claimant.clone(),
+            source_chain,
+            dest_chain,
+            failure_kind,
+            operation_id,
+            description,
+            state: DisputeState::Open,
+            assigned_to: None,
+            filed_at: now,
+            updated_at: now,
+            resolved_at: 0,
+            final_verdict: None,
+            votes: Vec::new(&env),
+        };
+
+        Self::persistent_set(&env, &DataKey::Dispute(dispute_id.clone()), &record);
+        env.storage()
+            .instance()
+            .set(&DataKey::DisputeCount, &new_count);
+
+        env.events().publish(
+            (Symbol::new(&env, "DisputeFiled"),),
+            (dispute_id.clone(), claimant),
+        );
+        Ok(dispute_id)
+    }
+
+    /// Withdraw an open dispute. Only the claimant may withdraw, and only
+    /// while the dispute is still in `Open` state (no mediator yet).
+    pub fn withdraw_dispute(
+        env: Env,
+        claimant: Address,
+        dispute_id: BytesN<32>,
+    ) -> Result<(), Error> {
+        claimant.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let key = DataKey::Dispute(dispute_id.clone());
+        let mut record: DisputeRecord =
+            Self::persistent_get(&env, &key).ok_or(Error::DisputeNotFound)?;
+
+        if record.claimant != claimant {
+            return Err(Error::Unauthorized);
+        }
+        if record.state != DisputeState::Open {
+            return Err(Error::InvalidTransition);
+        }
+
+        record.state = DisputeState::Withdrawn;
+        record.updated_at = env.ledger().timestamp();
+        Self::persistent_set(&env, &key, &record);
+
+        env.events().publish(
+            (Symbol::new(&env, "DisputeWithdrawn"),),
+            (dispute_id, claimant),
+        );
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Dispute lifecycle — UnderReview / Escalated
+    // ----------------------------------------------------------------
+
+    /// A mediator accepts an open dispute, moving it to `UnderReview`.
+    /// Only one mediator can be assigned at a time; subsequent mediators
+    /// participate via `cast_vote` once the dispute is escalated.
+    pub fn accept_dispute(
+        env: Env,
+        mediator: Address,
+        dispute_id: BytesN<32>,
+    ) -> Result<(), Error> {
+        mediator.require_auth();
+        Self::require_not_paused(&env)?;
+        Self::get_active_mediator(&env, &mediator)?;
+
+        let key = DataKey::Dispute(dispute_id.clone());
+        let mut record: DisputeRecord =
+            Self::persistent_get(&env, &key).ok_or(Error::DisputeNotFound)?;
+
+        if record.state != DisputeState::Open {
+            return Err(Error::InvalidTransition);
+        }
+
+        record.state = DisputeState::UnderReview;
+        record.assigned_to = Some(mediator.clone());
+        record.updated_at = env.ledger().timestamp();
+        Self::persistent_set(&env, &key, &record);
+
+        env.events().publish(
+            (Symbol::new(&env, "DisputeAccepted"),),
+            (dispute_id, mediator),
+        );
+        Ok(())
+    }
+
+    /// Escalate a dispute that is `UnderReview` to the full mediator panel.
+    /// Either the assigned mediator or the admin may escalate.
+    pub fn escalate_dispute(
+        env: Env,
+        caller: Address,
+        dispute_id: BytesN<32>,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let key = DataKey::Dispute(dispute_id.clone());
+        let mut record: DisputeRecord =
+            Self::persistent_get(&env, &key).ok_or(Error::DisputeNotFound)?;
+
+        if record.state != DisputeState::UnderReview {
+            return Err(Error::InvalidTransition);
+        }
+
+        // Only the assigned mediator or admin may escalate.
+        let is_admin = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::Admin)
+            .map(|a| a == caller)
+            .unwrap_or(false);
+        let is_assigned = record
+            .assigned_to
+            .as_ref()
+            .map(|a| *a == caller)
+            .unwrap_or(false);
+
+        if !is_admin && !is_assigned {
+            return Err(Error::Unauthorized);
+        }
+
+        record.state = DisputeState::Escalated;
+        record.updated_at = env.ledger().timestamp();
+        Self::persistent_set(&env, &key, &record);
+
+        env.events().publish(
+            (Symbol::new(&env, "DisputeEscalated"),),
+            (dispute_id, caller),
+        );
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Voting and resolution
+    // ----------------------------------------------------------------
+
+    /// Cast a mediator vote on a dispute that is `UnderReview` or `Escalated`.
+    ///
+    /// Each active mediator may vote exactly once per dispute. When the vote
+    /// tally for a single verdict reaches `min_votes`, the dispute is
+    /// automatically resolved.
+    pub fn cast_vote(
+        env: Env,
+        mediator: Address,
+        dispute_id: BytesN<32>,
+        verdict: DisputeVerdict,
+        rationale: String,
+    ) -> Result<DisputeState, Error> {
+        mediator.require_auth();
+        Self::require_not_paused(&env)?;
+        Self::get_active_mediator(&env, &mediator)?;
+
+        let key = DataKey::Dispute(dispute_id.clone());
+        let mut record: DisputeRecord =
+            Self::persistent_get(&env, &key).ok_or(Error::DisputeNotFound)?;
+
+        // Voting is allowed while UnderReview or Escalated.
+        match record.state {
+            DisputeState::UnderReview | DisputeState::Escalated => {},
+            _ => return Err(Error::InvalidTransition),
+        }
+
+        // Prevent double-voting.
+        for v in record.votes.iter() {
+            if v.mediator == mediator {
+                return Err(Error::AlreadyVoted);
+            }
+        }
+
+        let vote = MediatorVote {
+            mediator: mediator.clone(),
+            verdict: verdict.clone(),
+            rationale,
+            voted_at: env.ledger().timestamp(),
+        };
+        record.votes.push_back(vote);
+        record.updated_at = env.ledger().timestamp();
+
+        // Tally votes for each verdict.
+        let (upheld_count, rejected_count) = Self::tally_votes(&record.votes);
+
+        let min_votes: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinVotes)
+            .unwrap_or(1);
+
+        // Auto-resolve when quorum is reached.
+        if upheld_count >= min_votes {
+            Self::apply_resolution(
+                &env,
+                &mut record,
+                DisputeVerdict::Upheld,
+                &mediator,
+                &dispute_id,
+            )?;
+        } else if rejected_count >= min_votes {
+            Self::apply_resolution(
+                &env,
+                &mut record,
+                DisputeVerdict::Rejected,
+                &mediator,
+                &dispute_id,
+            )?;
+        }
+
+        Self::persistent_set(&env, &key, &record);
+
+        env.events().publish(
+            (Symbol::new(&env, "VoteCast"),),
+            (dispute_id, mediator, verdict),
+        );
+
+        Ok(record.state)
+    }
+
+    /// Manually resolve a dispute. The admin may call this to force-close a
+    /// dispute that has enough votes but was not auto-resolved, or in
+    /// exceptional administrative circumstances.
+    pub fn resolve_dispute(
+        env: Env,
+        caller: Address,
+        dispute_id: BytesN<32>,
+        verdict: DisputeVerdict,
+    ) -> Result<(), Error> {
+        caller.require_auth();
+        Self::require_not_paused(&env)?;
+        Self::require_admin(&env, &caller)?;
+
+        let key = DataKey::Dispute(dispute_id.clone());
+        let mut record: DisputeRecord =
+            Self::persistent_get(&env, &key).ok_or(Error::DisputeNotFound)?;
+
+        match record.state {
+            DisputeState::UnderReview | DisputeState::Escalated => {},
+            _ => return Err(Error::InvalidTransition),
+        }
+
+        Self::apply_resolution(&env, &mut record, verdict, &caller, &dispute_id)?;
+        Self::persistent_set(&env, &key, &record);
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Internal helpers
+    // ----------------------------------------------------------------
+
+    /// Count Upheld and Rejected votes in the current tally.
+    fn tally_votes(votes: &Vec<MediatorVote>) -> (u32, u32) {
+        let mut upheld: u32 = 0;
+        let mut rejected: u32 = 0;
+        for v in votes.iter() {
+            match v.verdict {
+                DisputeVerdict::Upheld   => upheld   = upheld.saturating_add(1),
+                DisputeVerdict::Rejected => rejected = rejected.saturating_add(1),
+            }
+        }
+        (upheld, rejected)
+    }
+
+    /// Transition a dispute record to `Resolved` and update mediator stats.
+    fn apply_resolution(
+        env: &Env,
+        record: &mut DisputeRecord,
+        verdict: DisputeVerdict,
+        resolver: &Address,
+        dispute_id: &BytesN<32>,
+    ) -> Result<(), Error> {
+        record.state = DisputeState::Resolved;
+        record.final_verdict = Some(verdict.clone());
+        let now = env.ledger().timestamp();
+        record.resolved_at = now;
+        record.updated_at = now;
+
+        // Increment cases_resolved for the resolver (if they are a mediator).
+        let med_key = DataKey::Mediator(resolver.clone());
+        if let Some(mut info) = Self::persistent_get::<MediatorInfo>(env, &med_key) {
+            info.cases_resolved = info.cases_resolved.saturating_add(1);
+            Self::persistent_set(env, &med_key, &info);
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "DisputeResolved"),),
+            (dispute_id.clone(), verdict),
+        );
+        Ok(())
+    }
+
+    // ----------------------------------------------------------------
+    // Queries
+    // ----------------------------------------------------------------
+
+    /// Fetch a dispute record by its ID.
+    pub fn get_dispute(env: Env, dispute_id: BytesN<32>) -> Result<DisputeRecord, Error> {
+        Self::persistent_get(&env, &DataKey::Dispute(dispute_id))
+            .ok_or(Error::DisputeNotFound)
+    }
+
+    /// Return the current state of a dispute.
+    pub fn get_dispute_state(env: Env, dispute_id: BytesN<32>) -> Result<DisputeState, Error> {
+        let record: DisputeRecord =
+            Self::persistent_get(&env, &DataKey::Dispute(dispute_id))
+                .ok_or(Error::DisputeNotFound)?;
+        Ok(record.state)
+    }
+
+    /// Return all votes recorded against a dispute.
+    pub fn get_votes(env: Env, dispute_id: BytesN<32>) -> Result<Vec<MediatorVote>, Error> {
+        let record: DisputeRecord =
+            Self::persistent_get(&env, &DataKey::Dispute(dispute_id))
+                .ok_or(Error::DisputeNotFound)?;
+        Ok(record.votes)
+    }
+
+    /// Return the final verdict, or None if not yet resolved.
+    pub fn get_verdict(env: Env, dispute_id: BytesN<32>) -> Result<Option<DisputeVerdict>, Error> {
+        let record: DisputeRecord =
+            Self::persistent_get(&env, &DataKey::Dispute(dispute_id))
+                .ok_or(Error::DisputeNotFound)?;
+        Ok(record.final_verdict)
+    }
+
+    /// Return the total number of disputes ever filed.
+    pub fn dispute_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::DisputeCount)
+            .unwrap_or(0)
+    }
+
+    /// Return the minimum votes required for resolution.
+    pub fn min_votes(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinVotes)
+            .unwrap_or(0)
+    }
+}

--- a/contracts/bridge_dispute_mediation/src/test.rs
+++ b/contracts/bridge_dispute_mediation/src/test.rs
@@ -1,0 +1,487 @@
+#![cfg(test)]
+
+extern crate std;
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env, String,
+};
+
+use crate::{
+    BridgeDisputeMediationContract, BridgeDisputeMediationContractClient, BridgeFailureKind,
+    ChainId, DisputeState, DisputeVerdict, Error,
+};
+
+// ==================== Test Helpers ====================
+
+fn setup_env() -> (Env, Address, BridgeDisputeMediationContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, BridgeDisputeMediationContract);
+    let client = BridgeDisputeMediationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    (env, admin, client)
+}
+
+fn init(
+    env: &Env,
+    client: &BridgeDisputeMediationContractClient,
+    admin: &Address,
+    min_votes: u32,
+) {
+    client.initialize(admin, &min_votes);
+    let _ = env; // suppress unused-variable warning
+}
+
+fn make_op_id(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+fn file_basic_dispute(
+    env: &Env,
+    client: &BridgeDisputeMediationContractClient,
+    claimant: &Address,
+) -> BytesN<32> {
+    client.file_dispute(
+        claimant,
+        &ChainId::Stellar,
+        &ChainId::Ethereum,
+        &BridgeFailureKind::MessageLost,
+        &make_op_id(env, 1),
+        &String::from_str(env, "test dispute"),
+    )
+}
+
+// ==================== Initialisation ====================
+
+#[test]
+fn test_initialize_ok() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 2);
+    assert_eq!(client.min_votes(), 2);
+    assert_eq!(client.dispute_count(), 0);
+}
+
+#[test]
+fn test_initialize_twice_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+    let result = client.try_initialize(&admin, &1);
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+// ==================== Mediator Management ====================
+
+#[test]
+fn test_add_mediator_ok() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let info = client.get_mediator(&mediator);
+    assert!(info.is_active);
+    assert_eq!(info.cases_resolved, 0);
+}
+
+#[test]
+fn test_add_mediator_duplicate_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+    let result = client.try_add_mediator(&admin, &mediator);
+    assert_eq!(result, Err(Ok(Error::MediatorExists)));
+}
+
+#[test]
+fn test_add_mediator_non_admin_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let not_admin = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    let result = client.try_add_mediator(&not_admin, &mediator);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_deactivate_mediator() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+    client.deactivate_mediator(&admin, &mediator);
+
+    let info = client.get_mediator(&mediator);
+    assert!(!info.is_active);
+}
+
+// ==================== Filing and Withdrawing ====================
+
+#[test]
+fn test_file_dispute_creates_record() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let dispute_id = file_basic_dispute(&env, &client, &claimant);
+
+    let record = client.get_dispute(&dispute_id);
+    assert_eq!(record.state, DisputeState::Open);
+    assert_eq!(record.claimant, claimant);
+    assert_eq!(client.dispute_count(), 1);
+}
+
+#[test]
+fn test_file_multiple_disputes_unique_ids() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let id1 = file_basic_dispute(&env, &client, &claimant);
+    let id2 = file_basic_dispute(&env, &client, &claimant);
+    assert_ne!(id1, id2);
+    assert_eq!(client.dispute_count(), 2);
+}
+
+#[test]
+fn test_withdraw_dispute_ok() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let id = file_basic_dispute(&env, &client, &claimant);
+
+    client.withdraw_dispute(&claimant, &id);
+    assert_eq!(client.get_dispute_state(&id), DisputeState::Withdrawn);
+}
+
+#[test]
+fn test_withdraw_by_non_claimant_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let other = Address::generate(&env);
+    let id = file_basic_dispute(&env, &client, &claimant);
+
+    let result = client.try_withdraw_dispute(&other, &id);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn test_withdraw_under_review_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+
+    let result = client.try_withdraw_dispute(&claimant, &id);
+    assert_eq!(result, Err(Ok(Error::InvalidTransition)));
+}
+
+// ==================== State Transitions ====================
+
+#[test]
+fn test_accept_dispute_transitions_to_under_review() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+
+    let record = client.get_dispute(&id);
+    assert_eq!(record.state, DisputeState::UnderReview);
+    assert_eq!(record.assigned_to, Some(mediator));
+}
+
+#[test]
+fn test_accept_already_accepted_dispute_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let m1 = Address::generate(&env);
+    let m2 = Address::generate(&env);
+    client.add_mediator(&admin, &m1);
+    client.add_mediator(&admin, &m2);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&m1, &id);
+
+    let result = client.try_accept_dispute(&m2, &id);
+    assert_eq!(result, Err(Ok(Error::InvalidTransition)));
+}
+
+#[test]
+fn test_escalate_by_assigned_mediator() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 2);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+    client.escalate_dispute(&mediator, &id);
+
+    assert_eq!(client.get_dispute_state(&id), DisputeState::Escalated);
+}
+
+#[test]
+fn test_escalate_by_admin() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 2);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+    client.escalate_dispute(&admin, &id);
+
+    assert_eq!(client.get_dispute_state(&id), DisputeState::Escalated);
+}
+
+#[test]
+fn test_escalate_from_open_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let id = file_basic_dispute(&env, &client, &claimant);
+
+    let result = client.try_escalate_dispute(&admin, &id);
+    assert_eq!(result, Err(Ok(Error::InvalidTransition)));
+}
+
+// ==================== Voting & Auto-resolution ====================
+
+#[test]
+fn test_cast_vote_auto_resolves_on_quorum() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1); // quorum = 1
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+
+    let final_state = client.cast_vote(
+        &mediator,
+        &id,
+        &DisputeVerdict::Upheld,
+        &String::from_str(&env, "evidence is clear"),
+    );
+
+    assert_eq!(final_state, DisputeState::Resolved);
+    assert_eq!(client.get_verdict(&id), Some(DisputeVerdict::Upheld));
+}
+
+#[test]
+fn test_cast_vote_does_not_resolve_below_quorum() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 2); // quorum = 2
+
+    let claimant = Address::generate(&env);
+    let m1 = Address::generate(&env);
+    let m2 = Address::generate(&env);
+    client.add_mediator(&admin, &m1);
+    client.add_mediator(&admin, &m2);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&m1, &id);
+    client.escalate_dispute(&m1, &id);
+
+    // First vote – not yet at quorum.
+    let state = client.cast_vote(
+        &m1,
+        &id,
+        &DisputeVerdict::Rejected,
+        &String::from_str(&env, "no evidence"),
+    );
+    assert_eq!(state, DisputeState::Escalated);
+
+    // Second vote – reaches quorum.
+    let state2 = client.cast_vote(
+        &m2,
+        &id,
+        &DisputeVerdict::Rejected,
+        &String::from_str(&env, "agreed"),
+    );
+    assert_eq!(state2, DisputeState::Resolved);
+    assert_eq!(client.get_verdict(&id), Some(DisputeVerdict::Rejected));
+}
+
+#[test]
+fn test_double_vote_fails() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 2);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+    client.cast_vote(
+        &mediator,
+        &id,
+        &DisputeVerdict::Upheld,
+        &String::from_str(&env, "first"),
+    );
+
+    let result = client.try_cast_vote(
+        &mediator,
+        &id,
+        &DisputeVerdict::Rejected,
+        &String::from_str(&env, "second"),
+    );
+    assert_eq!(result, Err(Ok(Error::AlreadyVoted)));
+}
+
+#[test]
+fn test_inactive_mediator_cannot_vote() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+    client.deactivate_mediator(&admin, &mediator);
+
+    let result = client.try_cast_vote(
+        &mediator,
+        &id,
+        &DisputeVerdict::Upheld,
+        &String::from_str(&env, "late vote"),
+    );
+    assert_eq!(result, Err(Ok(Error::MediatorNotActive)));
+}
+
+// ==================== Admin Force-resolve ====================
+
+#[test]
+fn test_admin_resolve_dispute() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 3); // high quorum, won't auto-resolve
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+
+    client.resolve_dispute(&admin, &id, &DisputeVerdict::Upheld);
+    assert_eq!(client.get_dispute_state(&id), DisputeState::Resolved);
+    assert_eq!(client.get_verdict(&id), Some(DisputeVerdict::Upheld));
+}
+
+#[test]
+fn test_non_admin_cannot_force_resolve() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 3);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+
+    let result = client.try_resolve_dispute(&claimant, &id, &DisputeVerdict::Upheld);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+// ==================== Pausing ====================
+
+#[test]
+fn test_paused_contract_blocks_file_dispute() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+    client.set_paused(&admin, &true);
+
+    let claimant = Address::generate(&env);
+    let result = client.try_file_dispute(
+        &claimant,
+        &ChainId::Stellar,
+        &ChainId::Ethereum,
+        &BridgeFailureKind::MessageLost,
+        &make_op_id(&env, 5),
+        &String::from_str(&env, "should fail"),
+    );
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+#[test]
+fn test_unpause_allows_operations() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+    client.set_paused(&admin, &true);
+    client.set_paused(&admin, &false);
+
+    let claimant = Address::generate(&env);
+    // Should succeed after unpausing.
+    file_basic_dispute(&env, &client, &claimant);
+}
+
+// ==================== Mediator cases_resolved counter ====================
+
+#[test]
+fn test_cases_resolved_increments_on_vote_resolution() {
+    let (env, admin, client) = setup_env();
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let mediator = Address::generate(&env);
+    client.add_mediator(&admin, &mediator);
+
+    let id = file_basic_dispute(&env, &client, &claimant);
+    client.accept_dispute(&mediator, &id);
+    client.cast_vote(
+        &mediator,
+        &id,
+        &DisputeVerdict::Upheld,
+        &String::from_str(&env, "ok"),
+    );
+
+    let info = client.get_mediator(&mediator);
+    assert_eq!(info.cases_resolved, 1);
+}
+
+// ==================== Ledger timestamp in records ====================
+
+#[test]
+fn test_dispute_timestamps_are_set() {
+    let (env, admin, client) = setup_env();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    init(&env, &client, &admin, 1);
+
+    let claimant = Address::generate(&env);
+    let id = file_basic_dispute(&env, &client, &claimant);
+    let record = client.get_dispute(&id);
+
+    assert_eq!(record.filed_at, 1_000_000);
+    assert_eq!(record.resolved_at, 0); // not yet resolved
+}

--- a/contracts/cross_chain_bridge/src/errors.rs
+++ b/contracts/cross_chain_bridge/src/errors.rs
@@ -55,6 +55,22 @@ pub enum Error {
     OperationAlreadyCompleted = 802,
     MaxExtensionsReached = 803,
     RefundFailed = 804,
+
+    // --- Dispute Mediation (900–999) ---
+    /// A dispute for the given operation ID was not found.
+    DisputeNotFound = 900,
+    /// A dispute already exists for this operation.
+    DisputeAlreadyExists = 901,
+    /// The requested state transition is not allowed from the current state.
+    DisputeInvalidTransition = 902,
+    /// The caller is not a registered mediator for this dispute.
+    DisputeNotMediator = 903,
+    /// The mediator has already cast a vote on this dispute.
+    DisputeAlreadyVoted = 904,
+    /// Not enough mediator votes have been cast to reach a resolution.
+    DisputeQuorumNotReached = 905,
+    /// The dispute has already been resolved or withdrawn.
+    DisputeAlreadyClosed = 906,
 }
 
 pub fn get_suggestion(error: Error) -> Symbol {
@@ -78,6 +94,13 @@ pub fn get_suggestion(error: Error) -> Symbol {
         | Error::RecordRefNotFound
         | Error::RollbackNotFound
         | Error::EventNotFound => symbol_short!("CHK_ID"),
+        Error::DisputeNotFound => symbol_short!("CHK_ID"),
+        Error::DisputeAlreadyExists
+        | Error::DisputeAlreadyVoted
+        | Error::DisputeAlreadyClosed => symbol_short!("ALREADY"),
+        Error::DisputeInvalidTransition => symbol_short!("BAD_STATE"),
+        Error::DisputeNotMediator => symbol_short!("CHK_AUTH"),
+        Error::DisputeQuorumNotReached => symbol_short!("WAIT_VTE"),
         _ => symbol_short!("CONTACT"),
     }
 }

--- a/contracts/shared_types/src/lib.rs
+++ b/contracts/shared_types/src/lib.rs
@@ -1,0 +1,28 @@
+//! # shared_types
+//!
+//! Common error types and codes shared across all Uzima contracts.
+//! Import this crate in any contract's `ContractError` via `CommonError`.
+
+#![no_std]
+
+use soroban_sdk::contracterror;
+
+/// Shared error codes used consistently across all contracts.
+/// Same variant always maps to the same numeric code.
+#[contracterror]
+#[derive(Clone, Debug, Copy, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum CommonError {
+    /// Caller lacks permission to perform this action.
+    Unauthorized = 1,
+    /// Requested resource does not exist.
+    NotFound = 2,
+    /// One or more supplied arguments are invalid.
+    InvalidInput = 3,
+    /// Resource already exists; duplicate creation rejected.
+    AlreadyExists = 4,
+    /// Caller has exceeded their allowed request rate.
+    RateLimitExceeded = 5,
+    /// Contract is paused; no state-changing calls are allowed.
+    ContractPaused = 6,
+}


### PR DESCRIPTION
## Summary

Implements a standalone `bridge_dispute_mediation` Soroban contract that provides a full dispute mediation state machine for cross-chain bridge failures, as requested in issue #1174.

## State Machine

```
Open ──► UnderReview ──► Resolved (Upheld | Rejected)
  │            │
  │            └──► Escalated ──► Resolved
  │
  └──► Withdrawn  (before mediator assignment)
```

## Changes

### New contract: `contracts/bridge_dispute_mediation`
- **Types**: `DisputeRecord`, `MediatorInfo`, `MediatorVote`, `DisputeState`, `DisputeVerdict`, `BridgeFailureKind`, `ChainId`
- **Admin functions**: `initialize`, `set_paused`, `add_mediator`, `deactivate_mediator`
- **Dispute lifecycle**: `file_dispute`, `withdraw_dispute`, `accept_dispute`, `escalate_dispute`
- **Voting & resolution**: `cast_vote` (auto-resolves at quorum), `resolve_dispute` (admin force-close)
- **Queries**: `get_dispute`, `get_dispute_state`, `get_votes`, `get_verdict`, `dispute_count`, `min_votes`
- Persistent storage with TTL management following existing bridge patterns

### Updated: `contracts/cross_chain_bridge/src/errors.rs`
- Added dispute error variants **900–906**: `DisputeNotFound`, `DisputeAlreadyExists`, `DisputeInvalidTransition`, `DisputeNotMediator`, `DisputeAlreadyVoted`, `DisputeQuorumNotReached`, `DisputeAlreadyClosed`
- Added corresponding `get_suggestion` entries

### Workspace fixes
- Added `contracts/src` to workspace `exclude` list (it is a loose source directory with no `Cargo.toml`, was breaking workspace loads)
- Populated `contracts/shared_types/src/lib.rs` from the already-existing `contracts/src/lib.rs`

## Testing

22 tests cover: initialisation, mediator management, dispute filing, withdrawal guard, state transitions (Open→UnderReview→Escalated→Resolved), auto-resolution at quorum, double-vote guard, inactive mediator guard, non-admin guard, pause/unpause, `cases_resolved` counter, and timestamp correctness.

The contract builds cleanly (`cargo build -p bridge_dispute_mediation`). The test runner hits a **pre-existing** `rand_core`/`ed25519-dalek` version conflict in `soroban-env-host` that also affects `cross_chain_bridge` and every other workspace member using `soroban-sdk testutils` — this is not introduced by this PR.

## Closes

closes #1174