### PR TITLE
feat: enforce no_std, template compat checker, dead-code scan

### DIFF
--- a/contracts/contract_behavior_fuzzing/src/lib.rs
+++ b/contracts/contract_behavior_fuzzing/src/lib.rs
@@ -1,4 +1,6 @@
 //! contract_behavior_fuzzing - Healthcare smart contract on Stellar blockchain.
+// no_std-exempt: this crate is a native test/fuzz harness, not a WASM contract.
+// It uses std::panic and std::vec intentionally and does not target wasm32.
 use core::fmt::Debug;
 use std::panic::{self, AssertUnwindSafe};
 use std::vec::Vec;

--- a/contracts/contract_template/README.md
+++ b/contracts/contract_template/README.md
@@ -1,0 +1,56 @@
+# contract_template
+
+Canonical scaffold for all Uzima Soroban smart contracts.
+
+## Purpose
+
+This template defines the minimum required structure for every new contract:
+`#![no_std]`, `#[contract]` + `#[contractimpl]`, an `initialize` function,
+`require_auth()` usage, a `#[contracterror]` enum, and event emission.
+
+## Generating a New Contract
+
+```bash
+# Simple copy-based scaffold:
+./scripts/scaffold-contract.sh <your_contract_name>
+
+# Category-aware scaffold:
+./scripts/generate_contract.sh <your_contract_name> <category>
+
+# Verify the scaffold:
+./scripts/smoke-test-scaffold.sh <your_contract_name>
+```
+
+## Checking Template Compatibility
+
+```bash
+# Check all workspace contracts:
+./scripts/check_template_compat.sh
+
+# Check a specific contract:
+./scripts/check_template_compat.sh <contract_name>
+
+# List every check performed:
+./scripts/check_template_compat.sh --list-checks
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib.rs` | Main contract: `#[contract]` struct, `#[contractimpl]` block |
+| `src/errors.rs` | `#[contracterror]` enum following Uzima conventions |
+| `src/events.rs` | Event-emission helpers |
+| `src/types.rs` | Shared `#[contracttype]` structs |
+| `src/test.rs` | Unit tests using `soroban-sdk/testutils` |
+| `Cargo.toml` | Workspace-inherited metadata, `cdylib` crate type |
+
+## Entry Points
+
+| Function | Auth | Description |
+|----------|------|-------------|
+| `initialize(env, admin)` | None (deployer becomes admin) | One-time init |
+| `transfer_admin(env, new_admin)` | Current admin | Transfer admin rights |
+| `update_data(env, caller, data)` | Admin | Update stored data |
+| `get_admin(env)` | None | Return current admin |
+| `get_data(env)` | None | Return stored data |

--- a/docs/NO_STD_COMPLIANCE.md
+++ b/docs/NO_STD_COMPLIANCE.md
@@ -168,3 +168,59 @@ The following contracts are excluded from the workspace because they require `st
 - `health_check`
 
 These contracts should be migrated to `no_std` before workspace inclusion.
+
+## Enforcement Script
+
+The `scripts/enforce_no_std.sh` script checks all `contracts/*/src/lib.rs`
+and `libs/*/src/lib.rs` files for the `#![no_std]` attribute and reports any
+violations.
+
+```bash
+# Check compliance (exit 1 if any violations):
+./scripts/enforce_no_std.sh
+
+# Show all results including passing files:
+./scripts/enforce_no_std.sh --verbose
+
+# Auto-add #![no_std] to files that only use core/soroban-sdk (no std::):
+./scripts/enforce_no_std.sh --fix
+```
+
+This script is intended to be run in CI on every pull request to prevent
+regressions.  Add a step like the following to your CI workflow:
+
+```yaml
+- name: Enforce no_std compliance
+  run: ./scripts/enforce_no_std.sh
+```
+
+### Opting Out (Native / Fuzz Harnesses)
+
+Crates that intentionally use `std` (e.g. native test harnesses, fuzz
+runners) can opt out by placing the following comment anywhere in their
+`lib.rs`:
+
+```rust
+// no_std-exempt: <reason explaining why std is needed>
+```
+
+The enforcement script will skip these files and count them as exempt rather
+than failing.
+
+## Template Compatibility Checker
+
+The `scripts/check_template_compat.sh` script verifies that contracts follow
+the conventions defined in `contracts/contract_template`.  It checks for
+`#![no_std]`, required macros, event emission, Cargo.toml structure, and
+more.
+
+```bash
+# Check all workspace contracts:
+./scripts/check_template_compat.sh
+
+# List every check performed:
+./scripts/check_template_compat.sh --list-checks
+
+# Check specific contracts:
+./scripts/check_template_compat.sh medical_records identity_registry
+```

--- a/libs/auth_events/src/lib.rs
+++ b/libs/auth_events/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 use soroban_sdk::{contracttype, contracterror, Address, Env, symbol_short};
 
 #[contracterror]

--- a/scripts/check_template_compat.sh
+++ b/scripts/check_template_compat.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# check_template_compat.sh — Verify that scaffolded contracts are compatible
+# with the canonical contracts/contract_template structure.
+#
+# Usage:
+#   ./scripts/check_template_compat.sh [--verbose] [--skip-exclude] [CONTRACT ...]
+#
+# Options:
+#   --verbose       Show PASS results in addition to failures.
+#   --skip-exclude  Also check contracts in the workspace exclude list.
+#   --list-checks   Print the check catalogue and exit.
+#
+# If CONTRACT names are given only those are checked; otherwise all
+# contracts/ subdirectories are scanned.
+#
+# Checks performed:
+#   C1  src/lib.rs exists
+#   C2  Cargo.toml exists
+#   C3  #![no_std] declared (or no_std-exempt comment present)
+#   C4  #[contract] struct present
+#   C5  #[contractimpl] block present
+#   C6  initialize function exists
+#   C7  require_auth() called
+#   C8  Error type (contracterror) defined
+#   C9  Event emission (events module or env.events())
+#   C10 Cargo.toml uses workspace version/edition
+#   C11 soroban-sdk dependency declared
+#   C12 crate-type includes "cdylib"
+#   C13 No 'use std::' imports in lib.rs
+#   C14 No format! macro in lib.rs (requires alloc)
+#   C15 README.md exists
+#
+# Exit codes:
+#   0  All checks passed.
+#   1  One or more failures.
+#   2  Template directory not found.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_DIR="$PROJECT_ROOT/contracts/contract_template"
+CONTRACTS_DIR="$PROJECT_ROOT/contracts"
+WORKSPACE_TOML="$PROJECT_ROOT/Cargo.toml"
+
+VERBOSE=false
+SKIP_EXCLUDE=false
+TARGET_CONTRACTS=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --verbose)      VERBOSE=true ;;
+    --skip-exclude) SKIP_EXCLUDE=true ;;
+    --list-checks)
+      grep -E "^#   C[0-9]" "$0" | sed 's/^# //'
+      exit 0 ;;
+    --*)
+      echo "Unknown option: $arg"
+      echo "Usage: $0 [--verbose] [--skip-exclude] [CONTRACT ...]"
+      exit 1 ;;
+    *)
+      TARGET_CONTRACTS+=("$arg") ;;
+  esac
+done
+
+if [[ ! -d "$TEMPLATE_DIR/src" ]]; then
+  echo "ERROR: Template directory not found: $TEMPLATE_DIR"
+  exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Build excluded-contract set from workspace Cargo.toml
+# ---------------------------------------------------------------------------
+declare -A EXCLUDED
+if [[ -f "$WORKSPACE_TOML" ]] && ! $SKIP_EXCLUDE; then
+  in_block=false
+  while IFS= read -r line; do
+    if echo "$line" | grep -q "^exclude\s*=\s*\["; then
+      in_block=true
+    fi
+    if $in_block; then
+      while IFS= read -r entry; do
+        name="${entry##contracts/}"
+        EXCLUDED["$name"]=1
+      done < <(echo "$line" | grep -oP '"contracts/[^"]*"' | tr -d '"' | sed 's|contracts/||')
+      if echo "$line" | grep -q "\]"; then
+        in_block=false
+      fi
+    fi
+  done < "$WORKSPACE_TOML"
+fi
+
+# ---------------------------------------------------------------------------
+# Collect contracts to check
+# ---------------------------------------------------------------------------
+if [[ ${#TARGET_CONTRACTS[@]} -gt 0 ]]; then
+  CONTRACTS=("${TARGET_CONTRACTS[@]}")
+else
+  mapfile -t CONTRACTS < <(
+    find "$CONTRACTS_DIR" -maxdepth 1 -mindepth 1 -type d \
+      | xargs -I{} basename {} | sort
+  )
+fi
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+run_check() {
+  local id="$1" desc="$2" result="$3" detail="${4:-}"
+  if [[ "$result" == "pass" ]]; then
+    pass_count=$((pass_count + 1))
+    if [[ "$VERBOSE" == "true" ]]; then
+      echo "    [PASS] $id $desc"
+    fi
+  else
+    fail_count=$((fail_count + 1))
+    echo "    [FAIL] $id $desc${detail:+ — $detail}"
+  fi
+}
+
+check_contract() {
+  local name="$1"
+  local dir="$CONTRACTS_DIR/$name"
+
+  # Skip non-Rust entries
+  if [[ ! -d "$dir/src" && ! -f "$dir/Cargo.toml" ]]; then
+    skip_count=$((skip_count + 1))
+    if [[ "$VERBOSE" == "true" ]]; then
+      echo "  [SKIP] $name  (no src/ or Cargo.toml)"
+    fi
+    return
+  fi
+
+  # Skip workspace-excluded contracts (unless --skip-exclude)
+  if [[ -v "EXCLUDED[$name]" ]]; then
+    skip_count=$((skip_count + 1))
+    if [[ "$VERBOSE" == "true" ]]; then
+      echo "  [SKIP] $name  (workspace exclude list)"
+    fi
+    return
+  fi
+
+  echo ""
+  echo "Checking: $name"
+
+  local lib_rs="$dir/src/lib.rs"
+  local cargo_toml="$dir/Cargo.toml"
+  local errors_rs="$dir/src/errors.rs"
+  local events_rs="$dir/src/events.rs"
+  local readme="$dir/README.md"
+
+  # C1 — src/lib.rs exists
+  if [[ -f "$lib_rs" ]]; then
+    run_check "C1" "src/lib.rs exists" "pass"
+  else
+    run_check "C1" "src/lib.rs exists" "fail" "file not found"
+    return
+  fi
+
+  # C2 — Cargo.toml exists
+  if [[ -f "$cargo_toml" ]]; then
+    run_check "C2" "Cargo.toml exists" "pass"
+  else
+    run_check "C2" "Cargo.toml exists" "fail" "file not found"
+  fi
+
+  # C3 — #![no_std]
+  if grep -q "#!\[no_std\]" "$lib_rs" || grep -q "no_std-exempt" "$lib_rs"; then
+    run_check "C3" "#![no_std] declared" "pass"
+  else
+    run_check "C3" "#![no_std] declared" "fail" "missing #![no_std]"
+  fi
+
+  # C4 — #[contract]
+  if grep -q "#\[contract\]" "$lib_rs"; then
+    run_check "C4" "#[contract] struct present" "pass"
+  else
+    run_check "C4" "#[contract] struct present" "fail" "no #[contract] attribute found"
+  fi
+
+  # C5 — #[contractimpl]
+  if grep -q "#\[contractimpl\]" "$lib_rs"; then
+    run_check "C5" "#[contractimpl] block present" "pass"
+  else
+    run_check "C5" "#[contractimpl] block present" "fail" "no #[contractimpl] attribute found"
+  fi
+
+  # C6 — initialize fn
+  if grep -q "fn initialize" "$lib_rs"; then
+    run_check "C6" "initialize function exists" "pass"
+  else
+    run_check "C6" "initialize function exists" "fail" "no 'fn initialize' found"
+  fi
+
+  # C7 — require_auth
+  if grep -q "require_auth" "$lib_rs"; then
+    run_check "C7" "require_auth() used" "pass"
+  else
+    run_check "C7" "require_auth() used" "fail" "no require_auth() — auth may be missing"
+  fi
+
+  # C8 — error type
+  if [[ -f "$errors_rs" ]] || grep -qr "contracterror" "$dir/src/" 2>/dev/null; then
+    run_check "C8" "error type (contracterror) defined" "pass"
+  else
+    run_check "C8" "error type (contracterror) defined" "fail" \
+      "no errors.rs and no #[contracterror] in src/"
+  fi
+
+  # C9 — event emission
+  if [[ -f "$events_rs" ]] || grep -qr "env\.events()" "$dir/src/" 2>/dev/null; then
+    run_check "C9" "event emission present" "pass"
+  else
+    run_check "C9" "event emission present" "fail" \
+      "no events.rs and no env.events() call found"
+  fi
+
+  if [[ -f "$cargo_toml" ]]; then
+    # C10 — workspace version/edition
+    if grep -q "version\.workspace\s*=\s*true" "$cargo_toml" \
+       && grep -q "edition\.workspace\s*=\s*true" "$cargo_toml"; then
+      run_check "C10" "Cargo.toml uses workspace version/edition" "pass"
+    else
+      run_check "C10" "Cargo.toml uses workspace version/edition" "fail" \
+        "use 'version.workspace = true' and 'edition.workspace = true'"
+    fi
+
+    # C11 — soroban-sdk
+    if grep -q "soroban-sdk" "$cargo_toml"; then
+      run_check "C11" "soroban-sdk dependency declared" "pass"
+    else
+      run_check "C11" "soroban-sdk dependency declared" "fail" \
+        "soroban-sdk missing from [dependencies]"
+    fi
+
+    # C12 — cdylib present in crate-type (may also include rlib)
+    if grep -q 'crate-type\s*=\s*\[.*"cdylib".*\]' "$cargo_toml"; then
+      run_check "C12" 'crate-type includes "cdylib"' "pass"
+    else
+      run_check "C12" 'crate-type includes "cdylib"' "fail" \
+        "cdylib missing from crate-type — contract won't build to WASM"
+    fi
+  fi
+
+  # C13 — no use std::
+  if grep -q "use std::" "$lib_rs"; then
+    run_check "C13" "no 'use std::' imports" "fail" \
+      "found 'use std::' — use core:: or soroban-sdk equivalents"
+  else
+    run_check "C13" "no 'use std::' imports" "pass"
+  fi
+
+  # C14 — no format!
+  if grep -q "format!" "$lib_rs"; then
+    run_check "C14" "no format! macro" "fail" \
+      "format! requires alloc — use soroban_sdk::String::from_str()"
+  else
+    run_check "C14" "no format! macro" "pass"
+  fi
+
+  # C15 — README.md
+  if [[ -f "$readme" ]]; then
+    run_check "C15" "README.md exists" "pass"
+  else
+    run_check "C15" "README.md exists" "fail" "no README.md found"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo "================================================================"
+echo "  Contract Template Compatibility Checker"
+echo "  Template : $TEMPLATE_DIR"
+echo "================================================================"
+
+for contract in "${CONTRACTS[@]}"; do
+  check_contract "$contract"
+done
+
+echo ""
+echo "================================================================"
+echo "  Summary"
+echo "================================================================"
+echo "  Skipped  : $skip_count"
+echo "  Passes   : $pass_count"
+echo "  Failures : $fail_count"
+echo ""
+
+if [[ $fail_count -gt 0 ]]; then
+  echo "  ✗ $fail_count check(s) failed."
+  echo ""
+  echo "  Guidance:"
+  echo "    • Use './scripts/scaffold-contract.sh <name>' for new contracts."
+  echo "    • See docs/NO_STD_COMPLIANCE.md for no_std migration help."
+  echo "    • Run './scripts/enforce_no_std.sh --fix' to auto-add #![no_std]."
+  echo ""
+  exit 1
+fi
+
+echo "  ✓ All checks passed — contracts are template-compatible."
+echo ""
+exit 0

--- a/scripts/dead_code_scan.sh
+++ b/scripts/dead_code_scan.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# dead_code_scan.sh — Repository-wide dead-code and unused-dependency scan
+# for Rust and JavaScript packages.
+#
+# Usage:
+#   ./scripts/dead_code_scan.sh [--rust] [--js] [--verbose] [--report FILE]
+#
+# Options:
+#   --rust      Run Rust-only scans (default: both).
+#   --js        Run JS-only scans (default: both).
+#   --verbose   Show extra output from underlying tools.
+#   --report F  Write a plain-text summary report to file F.
+#
+# Rust checks:
+#   1. cargo check with -D dead_code  (dead code lint as error)
+#   2. cargo +nightly udeps            (unused dependencies, nightly required)
+#      Falls back gracefully if nightly / cargo-udeps is not installed.
+#
+# JS / Node checks:
+#   1. knip  (dead exports, unused files, unused deps — preferred)
+#      Falls back to depcheck when knip is not installed.
+#   2. depcheck  (unused/missing npm dependencies)
+#      Falls back gracefully when neither tool is installed.
+#
+# Exit codes:
+#   0  No dead code or unused dependencies found.
+#   1  Issues found, or a scan tool reported an error.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+RUN_RUST=true
+RUN_JS=true
+VERBOSE=false
+REPORT_FILE=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --rust)    RUN_JS=false ;;
+    --js)      RUN_RUST=false ;;
+    --verbose) VERBOSE=true ;;
+    --report)  ;;  # handled below via shift
+    *)
+      # handle --report FILE
+      if [[ "$arg" == --report=* ]]; then
+        REPORT_FILE="${arg#--report=}"
+      fi ;;
+  esac
+done
+
+# Re-parse to pick up --report FILE (two-token form)
+args=("$@")
+for (( i=0; i<${#args[@]}; i++ )); do
+  if [[ "${args[$i]}" == "--report" && $((i+1)) -lt ${#args[@]} ]]; then
+    REPORT_FILE="${args[$((i+1))]}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+section()  { echo ""; echo "══════════════════════════════════════════════"; echo "  $1"; echo "══════════════════════════════════════════════"; }
+info()     { echo "  ℹ  $1"; }
+ok()       { echo "  ✓  $1"; }
+warn()     { echo "  ⚠  $1"; }
+fail_msg() { echo "  ✗  $1"; }
+
+RUST_ISSUES=0
+JS_ISSUES=0
+
+# Capture output for optional report file
+REPORT_LINES=()
+rline() { REPORT_LINES+=("$1"); }
+
+# ---------------------------------------------------------------------------
+# RUST SCANS
+# ---------------------------------------------------------------------------
+if $RUN_RUST; then
+  section "Rust Dead-Code & Unused-Dependency Scan"
+  cd "$PROJECT_ROOT"
+
+  # ── 1. cargo check with dead_code lint ──────────────────────────────────
+  info "Running: cargo check --workspace (dead_code lint)"
+  rline "[RUST] cargo check --workspace (dead_code)"
+
+  # Build a RUSTFLAGS that promotes the dead_code lint to deny
+  DEAD_CODE_FLAGS="-D dead_code"
+
+  set +e
+  if $VERBOSE; then
+    RUSTFLAGS="$DEAD_CODE_FLAGS" cargo check --workspace --message-format short 2>&1
+    rust_dc_exit=$?
+  else
+    rust_dc_out=$(RUSTFLAGS="$DEAD_CODE_FLAGS" cargo check --workspace --message-format short 2>&1)
+    rust_dc_exit=$?
+  fi
+  set -e
+
+  if [[ $rust_dc_exit -eq 0 ]]; then
+    ok "No dead_code violations found in workspace crates."
+    rline "  PASS: no dead_code violations"
+  else
+    if ! $VERBOSE; then
+      # Show only lines mentioning dead_code / unused
+      echo "$rust_dc_out" | grep -E "(dead_code|unused|warning\[|error\[)" | head -60 || true
+    fi
+    warn "dead_code lint found issues (exit $rust_dc_exit)."
+    warn "Run 'RUSTFLAGS=\"-D dead_code\" cargo check --workspace' for full output."
+    rline "  WARN: dead_code lint reported issues (exit $rust_dc_exit)"
+    RUST_ISSUES=$((RUST_ISSUES + 1))
+  fi
+
+  # ── 2. cargo-udeps (unused Cargo dependencies) ──────────────────────────
+  info "Checking for unused Cargo dependencies (cargo-udeps)"
+  rline "[RUST] cargo udeps"
+
+  if ! command -v cargo-udeps &>/dev/null; then
+    # Try installing it if cargo is available and we have nightly
+    if rustup toolchain list 2>/dev/null | grep -q "nightly"; then
+      info "cargo-udeps not found; attempting install..."
+      if cargo install cargo-udeps --locked --quiet 2>/dev/null; then
+        UDEPS_AVAILABLE=true
+      else
+        UDEPS_AVAILABLE=false
+        warn "Could not install cargo-udeps — skipping unused-dep check."
+        warn "Install manually: cargo install cargo-udeps --locked"
+        rline "  SKIP: cargo-udeps not available"
+      fi
+    else
+      UDEPS_AVAILABLE=false
+      warn "cargo-udeps requires nightly toolchain — skipping."
+      warn "Install: rustup toolchain add nightly && cargo install cargo-udeps --locked"
+      rline "  SKIP: nightly toolchain not available for cargo-udeps"
+    fi
+  else
+    UDEPS_AVAILABLE=true
+  fi
+
+  if ${UDEPS_AVAILABLE:-false}; then
+    set +e
+    if $VERBOSE; then
+      cargo +nightly udeps --workspace 2>&1
+      udeps_exit=$?
+    else
+      udeps_out=$(cargo +nightly udeps --workspace 2>&1)
+      udeps_exit=$?
+    fi
+    set -e
+
+    if [[ $udeps_exit -eq 0 ]]; then
+      ok "No unused Cargo dependencies found."
+      rline "  PASS: no unused Cargo dependencies"
+    else
+      if ! $VERBOSE; then
+        echo "$udeps_out" | grep -v "^$" | tail -40 || true
+      fi
+      fail_msg "cargo-udeps found unused dependencies (exit $udeps_exit)."
+      fail_msg "Remove unused [dependencies] entries from the relevant Cargo.toml files."
+      rline "  FAIL: cargo-udeps found unused dependencies"
+      RUST_ISSUES=$((RUST_ISSUES + 1))
+    fi
+  fi
+
+  # ── 3. Pattern-based scan: pub items never referenced ───────────────────
+  info "Scanning for unused pub items (heuristic grep)"
+  rline "[RUST] heuristic unused-pub scan"
+
+  # Look for pub fn / pub struct / pub enum defined in contracts/
+  # that are never referenced outside their own file.
+  UNUSED_PUB=()
+  while IFS= read -r lib_rs; do
+    rel="${lib_rs#"$PROJECT_ROOT/"}"
+    # Skip test files
+    [[ "$lib_rs" == *"/test"* ]] && continue
+    # Collect pub function names from this file
+    while IFS= read -r sym; do
+      [[ -z "$sym" ]] && continue
+      # Count references across the entire repo source
+      ref_count=$(grep -rn --include="*.rs" "\b${sym}\b" "$PROJECT_ROOT/contracts" \
+                    "$PROJECT_ROOT/libs" "$PROJECT_ROOT/tests" 2>/dev/null | wc -l)
+      # Defined once; if total references == 1 it is only the definition
+      if [[ "$ref_count" -le 1 ]]; then
+        UNUSED_PUB+=("$rel: $sym")
+      fi
+    done < <(grep -oP '(?<=pub fn )\w+' "$lib_rs" 2>/dev/null || true)
+  done < <(find "$PROJECT_ROOT/contracts" "$PROJECT_ROOT/libs" \
+             -name "lib.rs" -path "*/src/lib.rs" 2>/dev/null)
+
+  if [[ ${#UNUSED_PUB[@]} -eq 0 ]]; then
+    ok "Heuristic scan found no obviously unused public functions."
+    rline "  PASS: heuristic unused-pub scan clean"
+  else
+    warn "${#UNUSED_PUB[@]} potentially unused public function(s) found:"
+    for item in "${UNUSED_PUB[@]}"; do
+      echo "    - $item"
+      rline "    - $item"
+    done
+    warn "Review the above — they may be contract entry points (expected) or dead code."
+    rline "  WARN: ${#UNUSED_PUB[@]} potentially unused public functions"
+    # This is a warning only; contract entry points will appear here.
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# JS / NODE SCANS
+# ---------------------------------------------------------------------------
+if $RUN_JS; then
+  section "JavaScript / Node Unused-Dependency Scan"
+  cd "$PROJECT_ROOT"
+
+  PKG_JSON="$PROJECT_ROOT/package.json"
+  if [[ ! -f "$PKG_JSON" ]]; then
+    warn "No package.json found at project root — skipping JS scan."
+  else
+    # ── 1. Try knip (preferred — finds dead exports + unused deps) ──────────
+    info "Looking for knip..."
+    rline "[JS] knip / depcheck scan"
+
+    if command -v knip &>/dev/null || npx --yes knip --version &>/dev/null 2>&1; then
+      info "Running knip..."
+      set +e
+      if $VERBOSE; then
+        npx knip 2>&1
+        knip_exit=$?
+      else
+        knip_out=$(npx knip 2>&1)
+        knip_exit=$?
+      fi
+      set -e
+
+      if [[ $knip_exit -eq 0 ]]; then
+        ok "knip: no unused files, exports, or dependencies found."
+        rline "  PASS: knip found no issues"
+      else
+        if ! $VERBOSE; then echo "$knip_out" | head -60; fi
+        fail_msg "knip found unused JS/TS code or dependencies (exit $knip_exit)."
+        rline "  FAIL: knip found issues (exit $knip_exit)"
+        JS_ISSUES=$((JS_ISSUES + 1))
+      fi
+    # ── 2. Fall back to depcheck ────────────────────────────────────────────
+    elif command -v depcheck &>/dev/null || npm list -g depcheck &>/dev/null 2>&1; then
+      info "knip not found — using depcheck as fallback..."
+      set +e
+      if $VERBOSE; then
+        depcheck --skip-missing 2>&1
+        dc_exit=$?
+      else
+        dc_out=$(depcheck --skip-missing 2>&1)
+        dc_exit=$?
+      fi
+      set -e
+
+      if [[ $dc_exit -eq 0 ]]; then
+        ok "depcheck: no unused dependencies found."
+        rline "  PASS: depcheck clean"
+      else
+        if ! $VERBOSE; then echo "$dc_out"; fi
+        fail_msg "depcheck found unused dependencies (exit $dc_exit)."
+        fail_msg "Remove or justify unused entries in package.json."
+        rline "  FAIL: depcheck found unused deps"
+        JS_ISSUES=$((JS_ISSUES + 1))
+      fi
+    else
+      warn "Neither knip nor depcheck is installed — skipping JS unused-dep check."
+      warn "Install: npm install -g knip   or   npm install -g depcheck"
+      rline "  SKIP: no JS analysis tool installed"
+    fi
+
+    # ── 3. Check for obviously unused scripts (defined but never called) ───
+    info "Checking for unreferenced npm scripts..."
+    SCRIPT_NAMES=$(node -e "
+      const p = require('./package.json');
+      const s = p.scripts || {};
+      console.log(Object.keys(s).join('\n'));
+    " 2>/dev/null || true)
+
+    if [[ -n "$SCRIPT_NAMES" ]]; then
+      UNREFERENCED=()
+      while IFS= read -r script; do
+        [[ -z "$script" ]] && continue
+        # Skip lifecycle scripts that npm calls automatically
+        case "$script" in
+          prepare|prepublish|postinstall|preinstall|test|start|build) continue ;;
+        esac
+        # Check if the script name is referenced in any workflow, Makefile, or doc
+        ref=$(grep -rn "\"$script\"\|npm run $script\|yarn $script" \
+              "$PROJECT_ROOT/.github" "$PROJECT_ROOT/makefile" \
+              "$PROJECT_ROOT/README.md" 2>/dev/null | wc -l || echo 0)
+        if [[ "$ref" -eq 0 ]]; then
+          UNREFERENCED+=("$script")
+        fi
+      done <<< "$SCRIPT_NAMES"
+
+      if [[ ${#UNREFERENCED[@]} -gt 0 ]]; then
+        warn "${#UNREFERENCED[@]} npm script(s) appear unreferenced in CI/Makefile/README:"
+        for s in "${UNREFERENCED[@]}"; do
+          echo "    - $s"
+          rline "    - $s"
+        done
+        warn "Consider documenting or removing them."
+        rline "  WARN: ${#UNREFERENCED[@]} unreferenced npm scripts"
+      else
+        ok "All npm scripts appear referenced."
+        rline "  PASS: npm scripts referenced"
+      fi
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Write optional report file
+# ---------------------------------------------------------------------------
+if [[ -n "$REPORT_FILE" ]]; then
+  {
+    echo "Dead-Code & Unused-Dependency Scan Report"
+    echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    echo "Project  : $PROJECT_ROOT"
+    echo ""
+    for line in "${REPORT_LINES[@]}"; do
+      echo "$line"
+    done
+  } > "$REPORT_FILE"
+  echo ""
+  info "Report written to: $REPORT_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# Final summary
+# ---------------------------------------------------------------------------
+section "Final Summary"
+TOTAL_ISSUES=$((RUST_ISSUES + JS_ISSUES))
+
+if $RUN_RUST; then echo "  Rust issues : $RUST_ISSUES"; fi
+if $RUN_JS;   then echo "  JS issues   : $JS_ISSUES";   fi
+echo ""
+
+if [[ $TOTAL_ISSUES -gt 0 ]]; then
+  fail_msg "$TOTAL_ISSUES scan(s) reported issues."
+  echo ""
+  echo "  Remediation tips:"
+  echo "    Rust dead code  : Remove or annotate with #[allow(dead_code)]"
+  echo "    Rust unused deps: Remove from Cargo.toml or add a justification comment"
+  echo "    JS unused deps  : Remove from package.json or add to peerDependencies"
+  echo ""
+  exit 1
+fi
+
+ok "All scans passed — no dead code or unused dependencies detected."
+echo ""
+exit 0

--- a/scripts/enforce_no_std.sh
+++ b/scripts/enforce_no_std.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# enforce_no_std.sh — Verify that all Soroban contract crates declare
+# #![no_std] and do not import the Rust standard library.
+#
+# Usage:
+#   ./scripts/enforce_no_std.sh [--fix] [--verbose]
+#
+# Options:
+#   --fix      Auto-prepend #![no_std] to any lib.rs missing it,
+#              provided the file does not contain 'use std::' imports.
+#   --verbose  Print PASS results in addition to failures.
+#
+# Opt-out: If a file intentionally uses std (e.g. a fuzz harness), add
+# the following comment anywhere in the file:
+#   // no_std-exempt: <reason>
+#
+# Exit codes:
+#   0  All contracts are compliant.
+#   1  One or more violations found.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FIX=false
+VERBOSE=false
+for arg in "$@"; do
+  case "$arg" in
+    --fix)     FIX=true ;;
+    --verbose) VERBOSE=true ;;
+    *)
+      echo "Unknown option: $arg"
+      echo "Usage: $0 [--fix] [--verbose]"
+      exit 1 ;;
+  esac
+done
+
+PASS=0; FAIL=0; EXEMPT=0; FIXED=0
+FAILURES=()
+
+echo "=== no_std Compliance Check ==="
+mapfile -t LIB_FILES < <(
+  find "$PROJECT_ROOT/contracts" "$PROJECT_ROOT/libs" \
+    -name "lib.rs" -path "*/src/lib.rs" | sort
+)
+echo "Checking ${#LIB_FILES[@]} lib.rs files under contracts/ and libs/"
+echo ""
+
+for lib_rs in "${LIB_FILES[@]}"; do
+  rel="${lib_rs#"$PROJECT_ROOT/"}"
+
+  if grep -q "no_std-exempt" "$lib_rs" 2>/dev/null; then
+    EXEMPT=$((EXEMPT + 1))
+    $VERBOSE && echo "  [EXEMPT] $rel"
+    continue
+  fi
+
+  if grep -q "#!\[no_std\]" "$lib_rs"; then
+    PASS=$((PASS + 1))
+    $VERBOSE && echo "  [PASS]   $rel"
+    continue
+  fi
+
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$rel")
+
+  if $FIX; then
+    if grep -q "use std::" "$lib_rs"; then
+      echo "  [FAIL]   $rel  (cannot auto-fix: contains 'use std::' imports)"
+    else
+      TMP=$(mktemp)
+      awk '!found && !/^[[:space:]]*$/ && !/^\/\/!/ {
+        print "#![no_std]"; print ""; found=1
+      } { print }' "$lib_rs" > "$TMP"
+      mv "$TMP" "$lib_rs"
+      FIXED=$((FIXED + 1))
+      echo "  [FIXED]  $rel"
+    fi
+  else
+    echo "  [FAIL]   $rel  (missing #![no_std])"
+  fi
+done
+
+echo ""
+echo "=== Summary ==="
+echo "  Checked   : ${#LIB_FILES[@]}"
+echo "  Compliant : $PASS"
+echo "  Exempt    : $EXEMPT"
+$FIX && echo "  Fixed     : $FIXED"
+echo "  Failures  : $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo ""
+  echo "Violating files:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  echo ""
+  echo "Fix: Add '#![no_std]' as the first non-comment line in each file."
+  echo "     Or run: ./scripts/enforce_no_std.sh --fix"
+  echo "     To exempt a file: add '// no_std-exempt: <reason>' anywhere in it."
+  exit 1
+fi
+
+echo ""
+echo "All checked files are no_std compliant. ✓"
+exit 0


### PR DESCRIPTION
## Summary

This PR resolves three assigned issues with focused, non-breaking tooling additions that improve code quality, developer experience, and long-term contract maintainability.

---

## Changes

### closes #1195 — Enforce no_std and no-alloc constraints

- **`scripts/enforce_no_std.sh`** — New CI-ready script that scans every `contracts/*/src/lib.rs` and `libs/*/src/lib.rs` for `#![no_std]`. Supports `--fix` (auto-prepend when safe) and `--verbose` flags. Files that legitimately use `std` (e.g. fuzz harnesses) can opt out with a `// no_std-exempt: <reason>` comment.
- **`libs/auth_events/src/lib.rs`** — Added missing `#![no_std]` attribute. All 117 checked files now pass; 1 is marked exempt.
- **`contracts/contract_behavior_fuzzing/src/lib.rs`** — Added `// no_std-exempt` comment (this crate is a native fuzz harness, not a WASM contract).
- **`docs/NO_STD_COMPLIANCE.md`** — Documented the enforcement script, the opt-out mechanism, and added a reference to the template compat checker.

### closes #1194 — Contract template compatibility checker

- **`scripts/check_template_compat.sh`** — 15-check validator that verifies every scaffolded contract follows `contracts/contract_template` conventions:
  - C1–C2: `src/lib.rs` and `Cargo.toml` exist
  - C3: `#![no_std]` declared (or `no_std-exempt` present)
  - C4–C5: `#[contract]` struct and `#[contractimpl]` block present
  - C6: `initialize` function exists
  - C7: `require_auth()` called
  - C8: `#[contracterror]` error type defined
  - C9: Event emission (`env.events()` or `events` module)
  - C10–C12: Cargo.toml workspace inheritance and `cdylib` crate type
  - C13–C14: No `use std::` or `format!` (no_alloc concern)
  - C15: `README.md` exists
- **`contracts/contract_template/README.md`** — Added documentation so the canonical template passes its own C15 check.

### closes #1193 — Repository-wide dead-code and unused-dependency scan

- **`scripts/dead_code_scan.sh`** — Unified scanner for both Rust and JS:
  - **Rust**: runs `cargo check --workspace` with `-D dead_code` lint; runs `cargo +nightly udeps` for unused Cargo dependencies (graceful fallback if nightly/udeps not installed); heuristic grep scan for unreferenced public functions.
  - **JS/Node**: runs `knip` (preferred) or `depcheck` (fallback) for unused npm dependencies and dead exports; checks for unreferenced npm scripts.
  - Supports `--rust`, `--js`, `--verbose`, and `--report FILE` flags.

---

## Verification

```bash
# Issue #1195 — passes 117/118, 1 exempt
./scripts/enforce_no_std.sh

# Issue #1194 — all 15 checks pass on template + identity_registry
./scripts/check_template_compat.sh --verbose contract_template identity_registry

# Issue #1193 — JS scan correctly detected pre-existing package.json syntax error
./scripts/dead_code_scan.sh --js
```

---

## Files Changed

| File | Change |
|------|--------|
| `scripts/enforce_no_std.sh` | New — #1195 enforcement script |
| `scripts/check_template_compat.sh` | New — #1194 compatibility checker |
| `scripts/dead_code_scan.sh` | New — #1193 dead-code scanner |
| `libs/auth_events/src/lib.rs` | Fix: add `#![no_std]` |
| `contracts/contract_behavior_fuzzing/src/lib.rs` | Fix: add `no_std-exempt` comment |
| `contracts/contract_template/README.md` | New — template documentation |
| `docs/NO_STD_COMPLIANCE.md` | Updated: enforcement docs and opt-out guide |